### PR TITLE
Fix escape key not working properly in city view

### DIFF
--- a/UI/Panels/CityPanelOverview.lua
+++ b/UI/Panels/CityPanelOverview.lua
@@ -787,6 +787,7 @@ function KeyHandler( key:number )
 		if ( m_isShowingPanel ) then
 			LuaEvents.CityPanelOverview_CloseButton();
 			Close();
+			UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
 			return true;
 		else
 			return false;

--- a/UI/Panels/CityPanelOverview.lua
+++ b/UI/Panels/CityPanelOverview.lua
@@ -785,8 +785,6 @@ end
 function KeyHandler( key:number )
     if key == Keys.VK_ESCAPE then
 		if ( m_isShowingPanel ) then
-			LuaEvents.CityPanelOverview_CloseButton();
-			Close();
 			UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
 			return true;
 		else


### PR DESCRIPTION
Escape key should now close the city view and return to unit selection