### PR TITLE
Automatically refresh production panel

### DIFF
--- a/UI/Panels/ProductionPanel.lua
+++ b/UI/Panels/ProductionPanel.lua
@@ -2228,7 +2228,7 @@ function Initialize()
 	LuaEvents.StrageticView_MapPlacement_ProductionOpen.Add( OnStrategicViewMapPlacementProductionOpen );
 	LuaEvents.Tutorial_ProductionOpen.Add( OnTutorialProductionOpen );	
 
-	--Events.CityProductionChanged.Add( OnCityProductionChanged );
+	Events.CityProductionChanged.Add( OnCityProductionChanged );
 	Events.CityProductionCompleted.Add(OnCityProductionCompleted);
 
 	LuaEvents.QUI_Option_ToggleCowboy.Add( OnToggleCowboy );


### PR DESCRIPTION
Right now, when changing the production in a city, the production panel becomes out
of date (i.e. the last selected item is not available for selection).
Enabling this event handler causes the production panel to be refreshed
whenever the production changes.