### PR TITLE
Close the city view when city overview panel being closed due to selection change

### DIFF
--- a/UI/Panels/CityPanel.lua
+++ b/UI/Panels/CityPanel.lua
@@ -552,6 +552,7 @@ function OnCitySelectionChanged( ownerPlayerID:number, cityID:number, i:number, 
 			Refresh();
 		else
 			Close();
+			UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
 			-- Tell the CityPanelOverview a city was deselected
 			LuaEvents.CityPanel_LiveCityDataChanged( nil, false ); 
 		end


### PR DESCRIPTION
When the selection changes (i.e. buying building with gold or starting a new building in a district), the city overview panel closes in order to show some on-map animation. However, the production panel remains open and the view remains zoomed in. This commit fixes the issue (tracked by bug #10).