### PR TITLE
Enhancement: Emphasizing resources that need improvement

### DIFF
--- a/UI/WorldViewIconsManager.lua
+++ b/UI/WorldViewIconsManager.lua
@@ -183,6 +183,17 @@ function SetResourceIcon( pInstance:table, pPlot, type, state)
 			end
 			table.insert(toolTipItems, resourceString)
 			pInstance.ResourceIcon:SetToolTipString(table.concat(toolTipItems, "[NEWLINE]"));
+			
+			local plotWasImproved;
+		      	local ICON_LOW_OPACITY	:number = 0x77ffffff;
+		      	if (pPlot:GetImprovementType() == -1) then
+				plotWasImproved = false;
+		      	else
+				plotWasImproved = true;
+		      	end
+		      	if plotWasImproved then
+				pInstance.ResourceIcon:SetColor(ICON_LOW_OPACITY);
+		      	end
 		end
 	end
 end
@@ -659,6 +670,7 @@ function Initialize()
 	Events.ResourceVisibilityChanged.Add(OnResourceVisibilityChanged);
 	Events.ResourceAddedToMap.Add(OnResourceChanged);
 	Events.ResourceRemovedFromMap.Add(OnResourceRemovedFromMap);
+	Events.ImprovementAddedToMap.Add( OnResourceChanged );
 	Events.PlotVisibilityChanged.Add(OnPlotVisibilityChanged);
 	Events.PlotMarkerChanged.Add(OnPlotMarkersChanged);
 	Events.UnitSelectionChanged.Add( OnUnitSelectionChanged );

--- a/UI/WorldViewIconsManager.lua
+++ b/UI/WorldViewIconsManager.lua
@@ -184,15 +184,16 @@ function SetResourceIcon( pInstance:table, pPlot, type, state)
 			table.insert(toolTipItems, resourceString)
 			pInstance.ResourceIcon:SetToolTipString(table.concat(toolTipItems, "[NEWLINE]"));
 			
-			local plotWasImproved;
-		      	local ICON_LOW_OPACITY	:number = 0x77ffffff;
+			--CQUI: Resource icon becomes transparent after being improved
+			local CQUI_plotWasImproved;
+		      	local CQUI_ICON_LOW_OPACITY	:number = 0x77ffffff;
 		      	if (pPlot:GetImprovementType() == -1) then
-				plotWasImproved = false;
+				CQUI_plotWasImproved = false;
 		      	else
-				plotWasImproved = true;
+				CQUI_plotWasImproved = true;
 		      	end
-		      	if plotWasImproved then
-				pInstance.ResourceIcon:SetColor(ICON_LOW_OPACITY);
+		      	if CQUI_plotWasImproved then
+				pInstance.ResourceIcon:SetColor(CQUI_ICON_LOW_OPACITY);
 		      	end
 		end
 	end


### PR DESCRIPTION
This little change in SetResourceIcon would render already improved tiles with opacity so that the non improved tiles would be more emphasized.

For me personally, in mid-late game I like to keep tile resources on at all times and I wanted an easier way to tell if a tile was improved or not without zooming in and looking at the art of the improved tile.

Here's a preview, hope it's clear enough:
![480_screenshots_20161107133659_1](https://cloud.githubusercontent.com/assets/1408457/20058652/52d05f76-a4f2-11e6-8ab5-a401a2c20fe7.jpg)

