### PR TITLE
50% and 100% Tech/Civic Notifications

### DIFF
--- a/UI/Panels/NotificationPanel.lua
+++ b/UI/Panels/NotificationPanel.lua
@@ -1528,6 +1528,12 @@ function OnUnitKilledInCombat( targetUnit )
 	end
 end
 
+function CQUI_AddNotification(description:string, summary:string)
+    local handler = GetHandler( NotificationTypes.DEFAULT );	
+	table.insert(m_kDebugNotification);
+	handler.Add( summary, table.count(m_kDebugNotificaiton));	
+end
+
 -- ===========================================================================
 --	Setup
 -- ===========================================================================
@@ -1556,5 +1562,8 @@ function Initialize()
 	Events.LoadGameViewStateDone.Add( OnLoadGameViewStateDone );
 
 	LuaEvents.ActionPanel_ActivateNotification.Add( OnLuaActivateNotification );
+
+    -- CQUI
+    LuaEvents.CQUI_AddNotification.Add( CQUI_AddNotification );
 end
 Initialize();

--- a/UI/Panels/StatusMessagePanel.lua
+++ b/UI/Panels/StatusMessagePanel.lua
@@ -9,6 +9,14 @@ include( "InstanceManager" );
 -- =========================================================================== 
 local DEFAULT_TIME_TO_DISPLAY	:number = 10;	-- Seconds to display the message
 
+-- CQUI CONSTANTS Trying to make the different messages have unique colors
+local STATUS_MESSAGE_CIVIC      :number = 3;    -- Number to distinguish civic messages
+local STATUS_MESSAGE_TECHS      :number = 4;    -- Number to distinguish tech messages
+
+-- Figure out eventually what colors are used by the actual civic and tech trees
+local CIVIC_COLOR                       = "COLOR_RESEARCH_STORED"; 
+local TECHS_COLOR                       = "COLOR_CULTURE_STORED";   
+
 
 -- =========================================================================== 
 --	VARIABLES
@@ -20,6 +28,8 @@ local m_gossipIM				:table = InstanceManager:new( "GossipMessageInstance", "Root
 local PlayerConnectedChatStr	:string = Locale.Lookup( "LOC_MP_PLAYER_CONNECTED_CHAT" );
 local PlayerDisconnectedChatStr :string	= Locale.Lookup( "LOC_MP_PLAYER_DISCONNECTED_CHAT" );
 local PlayerKickedChatStr		:string	= Locale.Lookup( "LOC_MP_PLAYER_KICKED_CHAT" );
+
+local cqui_messageType          :number = 0;
 
 local m_kMessages :table = {};
 
@@ -55,6 +65,16 @@ function OnStatusMessage( str:string, fDisplayTime:number, type:number )
 		table.insert( kTypeEntry.MessageInstances, pInstance );
 
 		local timeToDisplay:number = (fDisplayTime > 0) and fDisplayTime or DEFAULT_TIME_TO_DISPLAY;
+
+        -- CQUI Figuring out how to change the color of the status message
+        if cqui_messageType == STATUS_MESSAGE_CIVIC then
+            --pInstance.Container:SetColorByName(CIVIC_COLOR);
+            --ContextPtr:SetColorByName(CIVIC_COLOR);
+        elseif cqui_messageType == STATUS_MESSAGE_TECHS then
+            --pInstance.Container:SetColorByName(TECHS_COLOR);
+            --ContextPtr:SetColorByName(TECHS_COLOR);
+        end
+
 		pInstance.StatusLabel:SetText( str );		
 		pInstance.Anim:SetEndPauseTime( timeToDisplay );
 		pInstance.Anim:RegisterEndCallback( function() OnEndAnim(kTypeEntry,pInstance) end );
@@ -116,11 +136,28 @@ function Test()
 		end, true);
 end
 
+function CQUI_OnStatusMessage(str:string, fDisplayTime:number, thisType:number)
+
+    if thisType == STATUS_MESSAGE_CIVIC then
+        cqui_messageType = STATUS_MESSAGE_CIVIC;
+    elseif thisType == STATUS_MESSAGE_TECHS then
+        cqui_messageType = STATUS_MESSAGE_TECHS;
+    else
+        cqui_messageType = 0;
+    end
+    
+    OnStatusMessage(str, fDisplayTime, ReportingStatusTypes.DEFAULT);
+
+end
+
 -- ===========================================================================
 function Initialize()
 	Events.StatusMessage.Add( OnStatusMessage );
 	Events.MultiplayerPlayerConnected.Add( OnMultplayerPlayerConnected );
 	Events.MultiplayerPrePlayerDisconnected.Add( OnMultiplayerPrePlayerDisconnected );
+
+    -- CQUI
+    LuaEvents.CQUI_AddStatusMessage.Add( CQUI_OnStatusMessage );
 	--Test();
 end
 Initialize();

--- a/UI/Screens/CivicsTree.lua
+++ b/UI/Screens/CivicsTree.lua
@@ -104,6 +104,9 @@ local VERTICAL_CENTER				:number = (SIZE_NODE_Y) / 2;
 local MAX_BEFORE_TRUNC_GOV_TITLE	:number = 165;
 local MAX_BEFORE_TRUNC_TO_BOOST		:number = 385;
 
+-- CQUI CONSTANTS
+local STATUS_MESSAGE_CIVIC          :number = 3;    -- Number to distinguish civic messages
+
 STATUS_ART[ITEM_STATUS.BLOCKED]		= { Name="BLOCKED",		TextColor0=0xff202726, TextColor1=0x00000000, FillTexture="CivicsTree_GearButtonTile_Disabled.dds",BGU=0,BGV=(SIZE_NODE_Y*3),	HideIcon=true,  IsButton=false,	BoltOn=false,	IconBacking=PIC_METER_BACK };
 STATUS_ART[ITEM_STATUS.READY]		= { Name="READY",		TextColor0=0xaaffffff, TextColor1=0x88000000, FillTexture=nil,									BGU=0,BGV=0,					HideIcon=true,  IsButton=true,	BoltOn=false,	IconBacking=PIC_METER_BACK  };
 STATUS_ART[ITEM_STATUS.CURRENT]		= { Name="CURRENT",		TextColor0=0xaaffffff, TextColor1=0x88000000, FillTexture=nil,									BGU=0,BGV=(SIZE_NODE_Y*4),		HideIcon=false,  IsButton=false,	BoltOn=true,	IconBacking=PIC_METER_BACK };
@@ -154,6 +157,9 @@ local m_kGovernments		:table = {};
 local m_kPolicyCatalogData	:table;
 
 local m_shiftDown			:boolean = false;
+
+-- CQUI variables
+local cqui_halfwayNotified  :table = {};
 
 
 -- ===========================================================================
@@ -1110,7 +1116,43 @@ function OnLocalPlayerTurnBegin()
 		    m_ePlayer = ePlayer;
 		    m_kCurrentData = GetLivePlayerData( ePlayer, -1 );
 	    end
+
+        --------------------------------------------------------------------------
+        -- CQUI Check for Civic Progress
+
+        -- Get the current tech
+        local kPlayer		    :table	= Players[ePlayer];
+	    local playerCivics	    :table	= kPlayer:GetCulture();
+	    local currentCivicID	:number = playerCivics:GetProgressingCivic();
+        local isCurrentBoosted  :boolean = playerCivics:HasBoostBeenTriggered(currentCivicsID);
+
+        -- Make sure there is a civic selected before continuing with checks
+        if currentCivicID ~= -1 then
+            local civicName = GameInfo.Civics[currentCivicID].Name;
+
+            local currentCost	        = playerCivics:GetCultureCost(currentCivicID);
+	        local currentProgress	    = playerCivics:GetCulturalProgress(currentCivicID);
+            local currentYield          = playerCivics:GetCultureYield();
+            local percentageToBeDone    = (currentProgress + currentYield) / currentCost;
+        
+            -- Is the current civic completed?
+            -- Else is it greater than 50% and has yet to be displayed?
+            if percentageToBeDone >= 1 then
+                LuaEvents.CQUI_AddStatusMessage("The Civic, " .. Locale.ToUpper( civicName ) .. ", is completed.", 10, STATUS_MESSAGE_CIVIC);
+            elseif percentageToBeDone >= .50 and isCurrentBoosted == false and cqui_halfwayNotified[currentCivicID] ~= true then
+                LuaEvents.CQUI_AddStatusMessage("The current Civic, " .. Locale.ToUpper( civicName ) .. ", is at least 50% completed: " .. tostring(round(percentageToBeDone*100,2)) .. "%", 10, STATUS_MESSAGE_CIVIC);
+                cqui_halfwayNotified[currentCivicID] = true;
+            end
+        end
+
+        --------------------------------------------------------------------------
+
     end
+end
+
+function round(num, idp)
+  local mult = 10^(idp or 0)
+  return math.floor(num * mult + 0.5) / mult
 end
 
 -- ===========================================================================

--- a/UI/Screens/CivicsTree.lua
+++ b/UI/Screens/CivicsTree.lua
@@ -1134,13 +1134,14 @@ function OnLocalPlayerTurnBegin()
 	        local currentProgress	    = playerCivics:GetCulturalProgress(currentCivicID);
             local currentYield          = playerCivics:GetCultureYield();
             local percentageToBeDone    = (currentProgress + currentYield) / currentCost;
+            local percentageNextTurn    = (currentProgress + currentYield*2) / currentCost;
         
-            -- Is the current civic completed?
+            -- Is the current civic completed? -> Could be moved to the "OnCivicComplete" function
             -- Else is it greater than 50% and has yet to be displayed?
             if percentageToBeDone >= 1 then
                 LuaEvents.CQUI_AddStatusMessage("The Civic, " .. Locale.ToUpper( civicName ) .. ", is completed.", 10, STATUS_MESSAGE_CIVIC);
-            elseif percentageToBeDone >= .50 and isCurrentBoosted == false and cqui_halfwayNotified[currentCivicID] ~= true then
-                LuaEvents.CQUI_AddStatusMessage("The current Civic, " .. Locale.ToUpper( civicName ) .. ", is at least 50% completed: " .. tostring(round(percentageToBeDone*100,2)) .. "%", 10, STATUS_MESSAGE_CIVIC);
+            elseif percentageNextTurn >= .50 and isCurrentBoosted == false and cqui_halfwayNotified[currentCivicID] ~= true then
+                LuaEvents.CQUI_AddStatusMessage("The current Civic, " .. Locale.ToUpper( civicName ) .. ", is one turn from 50%.", 10, STATUS_MESSAGE_CIVIC);
                 cqui_halfwayNotified[currentCivicID] = true;
             end
         end
@@ -1148,11 +1149,6 @@ function OnLocalPlayerTurnBegin()
         --------------------------------------------------------------------------
 
     end
-end
-
-function round(num, idp)
-  local mult = 10^(idp or 0)
-  return math.floor(num * mult + 0.5) / mult
 end
 
 -- ===========================================================================
@@ -1864,6 +1860,7 @@ function OnBuildingChanged( plotX:number, plotY:number, buildingIndex:number, pl
 	end
 end
 
+
 -- ===========================================================================
 --	Load all static information as well as display information for the
 --	current local player.
@@ -1919,5 +1916,6 @@ function Initialize()
 	Events.LocalPlayerTurnEnd.Add( OnLocalPlayerTurnEnd );
 	Events.LocalPlayerChanged.Add(AllocateUI);
 	Events.SystemUpdateUI.Add( OnUpdateUI );
+
 end
 Initialize();

--- a/UI/Screens/TechTree.lua
+++ b/UI/Screens/TechTree.lua
@@ -107,6 +107,9 @@ local VERTICAL_CENTER				:number = (SIZE_NODE_Y) / 2;
 local MAX_BEFORE_TRUNC_TO_BOOST		:number = 310;
 local MAX_BEFORE_TRUNC_KEY_LABEL:number = 100;
 
+-- CQUI CONSTANTS
+local STATUS_MESSAGE_TECHS          :number = 4;    -- Number to distinguish tech messages
+
 
 STATUS_ART[ITEM_STATUS.BLOCKED]		= { Name="BLOCKED",		TextColor0=0xff202726, TextColor1=0x00000000, FillTexture="TechTree_GearButtonTile_Disabled.dds",BGU=0,BGV=(SIZE_NODE_Y*3),	IsButton=false,	BoltOn=false,	IconBacking=PIC_METER_BACK };
 STATUS_ART[ITEM_STATUS.READY]		= { Name="READY",		TextColor0=0xaaffffff, TextColor1=0x88000000, FillTexture=nil,									BGU=0,BGV=0,				IsButton=true,	BoltOn=false,	IconBacking=PIC_METER_BACK  };
@@ -145,6 +148,9 @@ local m_kFilters			:table = {};
 
 local m_shiftDown			:boolean = false;
 local m_ToggleTechTreeId;
+
+-- CQUI variables
+local cqui_halfwayNotified  :table = {};
 
 -- ===========================================================================
 -- Return string respresenation of a prereq table
@@ -1016,7 +1022,49 @@ function OnLocalPlayerTurnBegin()
 		    m_ePlayer = ePlayer;
 		    m_kCurrentData = GetLivePlayerData( ePlayer );		    
 	    end
+
+        --------------------------------------------------------------------------
+        -- CQUI Check for Tech Progress
+
+        -- Get the current tech
+        local kPlayer		:table	= Players[ePlayer];
+	    local playerTechs	:table	= kPlayer:GetTechs();
+	    local currentTechID	:number = playerTechs:GetResearchingTech();
+        local isCurrentBoosted :boolean = playerTechs:HasBoostBeenTriggered(currentTechID);
+        
+        -- Make sure there is a technology selected before continuing with checks
+        if currentTechID ~= -1 then
+            local techName = GameInfo.Technologies[currentTechID].Name;
+
+            local currentCost	        = playerTechs:GetResearchCost(currentTechID);
+	        local currentProgress	    = playerTechs:GetResearchProgress(currentTechID);
+            local currentYield          = playerTechs:GetScienceYield();
+            local percentageToBeDone    = (currentProgress + currentYield) / currentCost;
+
+        
+            -- Is the current tech completed?
+            -- Else is it greater than 50% and has yet to be displayed?
+            if percentageToBeDone >= 1 then
+                LuaEvents.CQUI_AddStatusMessage("The Technology, " .. Locale.ToUpper( techName ) .. ", is completed.", 10, STATUS_MESSAGE_TECHS);
+            elseif percentageToBeDone >= .50 and isCurrentBoosted == false and cqui_halfwayNotified[currentTechID] ~= true then
+                LuaEvents.CQUI_AddStatusMessage("The current Technology, " .. Locale.ToUpper( techName ) .. ", is at least 50% completed: " .. tostring(round(percentageToBeDone*100,2)) .. "%", 10, STATUS_MESSAGE_TECHS);
+                cqui_halfwayNotified[currentTechID] = true;
+            end
+        end
+
+        
+
+        --------------------------------------------------------------------------
+
     end
+
+    
+
+end
+
+function round(num, idp)
+  local mult = 10^(idp or 0)
+  return math.floor(num * mult + 0.5) / mult
 end
 
 -- ===========================================================================

--- a/UI/Screens/TechTree.lua
+++ b/UI/Screens/TechTree.lua
@@ -1040,31 +1040,22 @@ function OnLocalPlayerTurnBegin()
 	        local currentProgress	    = playerTechs:GetResearchProgress(currentTechID);
             local currentYield          = playerTechs:GetScienceYield();
             local percentageToBeDone    = (currentProgress + currentYield) / currentCost;
-
+            local percentageNextTurn    = (currentProgress + currentYield*2) / currentCost;
         
-            -- Is the current tech completed?
+            -- Is the current tech completed? -> Could be moved to the "OnResearchComplete" function
             -- Else is it greater than 50% and has yet to be displayed?
             if percentageToBeDone >= 1 then
                 LuaEvents.CQUI_AddStatusMessage("The Technology, " .. Locale.ToUpper( techName ) .. ", is completed.", 10, STATUS_MESSAGE_TECHS);
-            elseif percentageToBeDone >= .50 and isCurrentBoosted == false and cqui_halfwayNotified[currentTechID] ~= true then
-                LuaEvents.CQUI_AddStatusMessage("The current Technology, " .. Locale.ToUpper( techName ) .. ", is at least 50% completed: " .. tostring(round(percentageToBeDone*100,2)) .. "%", 10, STATUS_MESSAGE_TECHS);
+            elseif percentageNextTurn >= .50 and isCurrentBoosted == false and cqui_halfwayNotified[currentTechID] ~= true then
+                LuaEvents.CQUI_AddStatusMessage("The current Technology, " .. Locale.ToUpper( techName ) .. ", is one turn from 50%.", 10, STATUS_MESSAGE_TECHS);
                 cqui_halfwayNotified[currentTechID] = true;
             end
         end
-
-        
 
         --------------------------------------------------------------------------
 
     end
 
-    
-
-end
-
-function round(num, idp)
-  local mult = 10^(idp or 0)
-  return math.floor(num * mult + 0.5) / mult
 end
 
 -- ===========================================================================
@@ -1593,6 +1584,7 @@ function OnSearchCharCallback()
 		end
 	end
 end
+
 
 -- ===========================================================================
 --	Load all static information as well as display information for the


### PR DESCRIPTION
When a player reaches the turn prior to achieving 50% on a given tech or civic, the player get a status message saying they are one turn away. The player also gets a message upon completion of that tech or civic.