### PR TITLE
User-configurable default settings

### DIFF
--- a/CQUI/CQUI_SettingsElement.lua
+++ b/CQUI/CQUI_SettingsElement.lua
@@ -1,4 +1,4 @@
-﻿--Custom localizations are temporarily disabled due to reloads breaking them at the moment. Localizations are complete, so remember to enable them once Firaxis fixes this!
+--Custom localizations are temporarily disabled due to reloads breaking them at the moment. Localizations are complete, so remember to enable them once Firaxis fixes this!
 
 include("Civ6Common");
 
@@ -18,8 +18,11 @@ function PopulateComboBox(control, values, default_value, setting_name, tooltip)
   control:ClearEntries();
   local current_value = GameConfiguration.GetValue(setting_name);
   if(current_value == nil) then
-    current_value = default_value;
-    GameConfiguration.SetValue(setting_name, default_value);
+	if(GameInfo.CQUI_Settings[setting_name]) then --LY Checks if this setting has a default state defined in the database
+		current_value = GameInfo.CQUI_Settings[setting_name].Value; --reads the default value from the database. Set them in Settings.sql
+	else current_value = default_value;
+	end
+    GameConfiguration.SetValue(setting_name, current_value); --/LY
   end
   for i, v in ipairs(values) do
     local instance = {};
@@ -52,9 +55,16 @@ end
 function PopulateCheckBox(control, default_value, setting_name, tooltip)
   local current_value = GameConfiguration.GetValue(setting_name);
   if(current_value == nil) then
-    GameConfiguration.SetValue(setting_name, default_value);
-    current_value = default_value;
-  end
+	if(GameInfo.CQUI_Settings[setting_name]) then --LY Checks if this setting has a default state defined in the database
+		if(GameInfo.CQUI_Settings[setting_name].Value == 0) then --because 0 is true in Lua
+			current_value = false;
+		else
+			current_value = true;
+		end
+	else current_value = default_value;
+	end
+		GameConfiguration.SetValue(setting_name, current_value); --/LY
+	end
     if(current_value == false) then
         control:SetSelected(false);
     else

--- a/CQUI/CQUI_databaseShema.sql
+++ b/CQUI/CQUI_databaseShema.sql
@@ -1,0 +1,19 @@
+/*
+    Created by LordYanaek for CQUI mod by chaorace.
+	This file contains queries used to create the mod's tables in the database.
+	Don't touch this unless you know what you do.
+*/
+
+CREATE TABLE 'CQUI_Bindings' (
+	'Action' TEXT NOT NULL,
+	'Keys' TEXT NOT NULL,
+	'keyMod' INTEGER,
+	'keyMain' INTEGER,
+	PRIMARY KEY('Action')
+);
+
+CREATE TABLE 'CQUI_Settings' (
+	'Setting' TEXT NOT NULL,
+	'Value' INTEGER NOT NULL,
+	PRIMARY KEY('Setting')
+);

--- a/Settings.sql
+++ b/Settings.sql
@@ -1,0 +1,39 @@
+/*  
+    ╔════════════════════════════════════════════════════════════════════════════════════════════╗
+    ║                                   CQUI Default settings                                    ║
+    ╠════════════════════════════════════════════════════════════════════════════════════════════╣
+    ║Created by LordYanaek for CQUI mod by chaorace.                                             ║
+    ║Those are the settings loaded by default by CQUI.                                           ║
+    ║You can change many of those from the in-game GUI but settings changed in this config file  ║
+    ║will persist between games (settings changed from the GUI won't affect a new game)          ║
+    ╚════════════════════════════════════════════════════════════════════════════════════════════╝
+*/
+  
+  
+/*  
+    ┌────────────────────────────────────────────────────────────────────────────────────────────┐
+    │                                    Checkbox settings                                       │
+    ├────────────────────────────────────────────────────────────────────────────────────────────┤
+    │These settings control the default state of the CQUI configuration checkboxes.              │
+    │Valid values are 0 (disabled) or 1 (unabled). Don't change the names or the first line!     │
+    └────────────────────────────────────────────────────────────────────────────────────────────┘
+*/
+
+INSERT INTO CQUI_Settings -- Don't touch this line!
+	VALUES	("CQUI_ShowLuxuries", 1), -- Luxury resources will show in the top-bar next to strategic resources
+			("CQUI_Smartbanner", 1), -- Additional informations such as districts will show in the city banner
+			("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
+			("CQUI_TechPopupAudio", 1); -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
+			
+/*  
+    ┌────────────────────────────────────────────────────────────────────────────────────────────┐
+    │                                    Combobox settings                                       │
+    ├────────────────────────────────────────────────────────────────────────────────────────────┤
+    │These settings control the default state of the CQUI configuration comboboxes.              │
+    │Different values can be used depending on individual settings.                              │
+    │Don't change the names of the settings or the first line!                                   │
+    └────────────────────────────────────────────────────────────────────────────────────────────┘
+*/
+
+INSERT INTO CQUI_Settings -- Don't touch this line!
+	VALUES	("CQUI_BindingsMode", 1); -- Set of keybindings used │ 0=Civ6 default │ 1=keybinds from Civ5 │ 2=Civ5 with additions such as WASD camera control │

--- a/qui.modinfo
+++ b/qui.modinfo
@@ -57,6 +57,15 @@
 				<File>CQUI/CQUI_Text_Settings.xml</File>
 			</Items>
 		</LocalizedText>
+		<UpdateDatabase id="CQUI_Settings">
+            <Properties>
+                <Name>CQUI Settings</Name>
+            </Properties>
+            <Items>
+                <File>CQUI/CQUI_databaseShema.sql</File>
+                <File>Settings.sql</File>
+            </Items>
+        </UpdateDatabase>
 		<ImportFiles id="BETTER_TRADE_SCREEN_IMPORT_FILES">
 			<Items>
 				<File>BTS/TradeOverview.xml</File>
@@ -78,6 +87,8 @@
 		<File>CQUI/CQUI_SettingsElement.xml</File>
 		<File>CQUI/CQUI_Text_General.xml</File>
 		<File>CQUI/CQUI_Text_Settings.xml</File>
+		<File>CQUI/CQUI_databaseShema.sql</File>
+		<File>Settings.sql</File>
 		<File>UI/ActionPanel.lua</File>
 		<File>UI/CitySupport.lua</File>
 		<File>UI/MapPinManager.lua</File>


### PR DESCRIPTION
Adds tables for user-configurable default settings and future user-configurable keybindings in the game database. Also changes CQUI_settings to read the default values in the database (if the entry exists) rather than the default state coded in the function call. That one should be used as fall-back value if the database doesn't have a default state for a given setting.