### PR TITLE
100% Notification to OnComplete -> Resolves #102

### DIFF
--- a/UI/Screens/CivicsTree.lua
+++ b/UI/Screens/CivicsTree.lua
@@ -1148,12 +1148,9 @@ function OnLocalPlayerTurnBegin()
       if(PlayerConfigurations[Game.GetLocalPlayer()]:GetCivilizationTypeName() == "CIVILIZATION_CHINA") then
         CQUI_halfway = CQUI_halfway - .1;
       end
-        
-      -- Is the current civic completed? -> Could be moved to the "OnCivicComplete" function
-      -- Else is it greater than 50% and has yet to be displayed?
-      if percentageToBeDone >= 1 then
-          LuaEvents.CQUI_AddStatusMessage("The Civic, " .. Locale.Lookup( civicName ) .. ", is completed.", 10, CQUI_STATUS_MESSAGE_CIVIC);
-      elseif isCurrentBoosted then
+
+      -- Is it greater than 50% and has yet to be displayed?
+      if isCurrentBoosted then
         CQUI_halfwayNotified[civicName] = true;
       elseif percentageNextTurn >= CQUI_halfway and CQUI_halfwayNotified[civicName] ~= true then
           LuaEvents.CQUI_AddStatusMessage("The current Civic, " .. Locale.Lookup( civicName ) .. ", is one turn away from maximum Inspiration potential.", 10, CQUI_STATUS_MESSAGE_CIVIC);
@@ -1201,6 +1198,24 @@ function OnCivicComplete( ePlayer:number, eTech:number)
     if not ContextPtr:IsHidden() then
       View( m_kCurrentData );
     end
+
+    --------------------------------------------------------------------------
+    -- CQUI Civic Complete
+
+    -- Get the current tech
+    local kPlayer       :table  = Players[ePlayer];
+    local currentCivicID  :number = eTech;
+
+    -- Make sure there is a civic selected before continuing with checks
+    if currentCivicID ~= -1 then
+      local civicName = GameInfo.Civics[currentCivicID].Name;
+
+      LuaEvents.CQUI_AddStatusMessage("The Civic, " .. Locale.Lookup( civicName ) .. ", is completed.", 10, CQUI_STATUS_MESSAGE_CIVIC);
+
+    end -- end of if currentCivivID ~= -1
+
+    --------------------------------------------------------------------------
+
   end
 end
 

--- a/UI/Screens/TechTree.lua
+++ b/UI/Screens/TechTree.lua
@@ -1035,6 +1035,7 @@ function OnLocalPlayerTurnBegin()
         -- Make sure there is a technology selected before continuing with checks
         if currentTechID ~= -1 then
           local techName = GameInfo.Technologies[currentTechID].Name;
+          local techType = GameInfo.Technologies[currentTechID].Type;
 
           local currentCost         = playerTechs:GetResearchCost(currentTechID);
           local currentProgress     = playerTechs:GetResearchProgress(currentTechID);
@@ -1045,7 +1046,7 @@ function OnLocalPlayerTurnBegin()
 
           -- Finds boost amount, always 50 in base game, China's +10% modifier is not applied here
           for row in GameInfo.Boosts() do
-            if(row.CivicType == civicType) then
+            if(row.ResearchType == techType) then
               CQUI_halfway = (100 - row.Boost) / 100;
               break;
             end
@@ -1055,11 +1056,8 @@ function OnLocalPlayerTurnBegin()
             CQUI_halfway = CQUI_halfway - .1;
           end
         
-          -- Is the current tech completed? -> Could be moved to the "OnResearchComplete" function
-          -- Else is it greater than 50% and has yet to be displayed?
-          if percentageToBeDone >= 1 then
-              LuaEvents.CQUI_AddStatusMessage("The Technology, " .. Locale.Lookup( techName ) .. ", is completed.", 10, CQUI_STATUS_MESSAGE_TECHS);
-          elseif isCurrentBoosted then
+          -- Is it greater than 50% and has yet to be displayed?
+          if isCurrentBoosted then
             CQUI_halfwayNotified[techName] = true;
           elseif percentageNextTurn >= CQUI_halfway and isCurrentBoosted == false and CQUI_halfwayNotified[techName] ~= true then
               LuaEvents.CQUI_AddStatusMessage("The current Technology, " .. Locale.Lookup( techName ) .. ", is one turn away from maximum Eureka potential.", 10, CQUI_STATUS_MESSAGE_TECHS);
@@ -1108,6 +1106,25 @@ function OnResearchComplete( ePlayer:number, eTech:number)
     if not ContextPtr:IsHidden() then
       View( m_kCurrentData );
     end
+
+
+    --------------------------------------------------------------------------
+        -- CQUI Completion Notification
+
+        -- Get the current tech
+        local kPlayer   :table      = Players[ePlayer];
+        local currentTechID :number = eTech;
+        
+        -- Make sure there is a technology selected before continuing with checks
+        if currentTechID ~= -1 then
+          local techName = GameInfo.Technologies[currentTechID].Name;
+
+          LuaEvents.CQUI_AddStatusMessage("The Technology, " .. Locale.Lookup( techName ) .. ", is completed.", 10, CQUI_STATUS_MESSAGE_TECHS);
+
+        end -- end of techID check
+
+        --------------------------------------------------------------------------
+
   end
 end
 


### PR DESCRIPTION
Moves the message for  100% completion of tech/civics to the respective
"On Complete" functions as the check for greater than 1 progress at the
beginning of the turn wasn't 100% reliable.