### PR TITLE
1.0.0.38 Compatibility (Resolves #111)

### DIFF
--- a/UI/Civilopedia/CivilopediaSupport.lua
+++ b/UI/Civilopedia/CivilopediaSupport.lua
@@ -805,16 +805,6 @@ function OnInputHandler( input )
     if key == Keys.VK_ESCAPE then
       OnClose();
       return true;
-    elseif (key == Keys.VK_RETURN) then
-      print("RETURN" .. tostring(_SearchQuery));
-      if(_SearchQuery and #_SearchQuery > 0 and _SearchQuery ~= LOC_TREE_SEARCH_W_DOTS) then
-        OnOpenCivilopedia(_SearchQuery);
-        Controls.SearchResultsPanelContainer:SetHide(true);
-        _SearchQuery = nil; -- clear query.
-      end
-
-      -- Don't let enter propigate or it will hit action panel which will raise a screen (potentially this one again) tied to the action.
-      return true;
     end
   end
   return false;
@@ -836,10 +826,6 @@ end
 function OnSearchBarGainFocus()
   Controls.SearchEditBox:ClearString();
   Controls.SearchResultsPanelContainer:SetHide(true);
-end
-
-function OnSearchBarLoseFocus()
-  Controls.SearchEditBox:SetText(LOC_TREE_SEARCH_W_DOTS);
 end
 
 function OnSearchCharCallback()
@@ -884,6 +870,15 @@ function OnSearchCharCallback()
   end
 end
 
+function OnSearchCommitCallback()
+  if(_SearchQuery and #_SearchQuery > 0 and _SearchQuery ~= LOC_TREE_SEARCH_W_DOTS) then
+    Controls.SearchEditBox:SetText(LOC_TREE_SEARCH_W_DOTS);
+    OnOpenCivilopedia(_SearchQuery);
+    Controls.SearchResultsPanelContainer:SetHide(true);
+    _SearchQuery = nil; -- clear query.
+  end
+end
+
 -------------------------------------------------------------------------------
 --
 -------------------------------------------------------------------------------
@@ -905,8 +900,8 @@ function Initialize()
 
   -- Search support
   Controls.SearchEditBox:RegisterStringChangedCallback(OnSearchCharCallback);
-  Controls.SearchEditBox:RegisterHasFocusCallback( OnSearchBarGainFocus);
-  Controls.SearchEditBox:RegisterCommitCallback( OnSearchBarLoseFocus);
+  Controls.SearchEditBox:RegisterHasFocusCallback(OnSearchBarGainFocus);
+  Controls.SearchEditBox:RegisterCommitCallback(OnSearchCommitCallback);
 
   CacheData();
   RefreshSections();

--- a/UI/Panels/CityPanel.xml
+++ b/UI/Panels/CityPanel.xml
@@ -1,13 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Context xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="..\..\..\..\..\CivTech\Libs\ForgeUI\ForgeUI_Assets\Controls.xsd">
-  <WorldAnchor ID="GrowthHexAnchor" Hidden="1">
-    <AlphaAnim ID="GrowthHexAlpha" AlphaBegin="1" AlphaEnd="0" Stopped="1" Function="OutQuad">
-      <Stack   ID="GrowthHexStack" Anchor="C,T" StackGrowth="Right" Padding="5">
-        <Label ID="TurnsLeftLabel" Anchor="L,C" Style="FontFlair26" Color0="255,113,246,255" Color1="52,33,90,128" Color2="248,188,238,255" FontStyle="Stroke"/>
-        <Label ID="TurnsLeftDescription" Anchor="L,C" Style="FontNormal14" Color0="252,201,247,255" Color1="0,0,0,100" FontStyle="Stroke" WrapWidth="130" />
-      </Stack>
-    </AlphaAnim>
-  </WorldAnchor>
   <AlphaAnim                ID="CityPanelAlpha"       AlphaBegin="0" AlphaEnd="1" Speed="3"   Function="OutSine" Cycle="Once" Size="full,full">
     <SlideAnim              ID="CityPanelSlide"       Start="200,0" End="-175,0"     Speed="3.5" Function="OutSine" Cycle="Once" Size="full,full">
       <Grid                 ID="WoodBacking"          Anchor="R,B" Offset="175,-5"  Size="500,162"          Texture="SelectionPanel_WoodBacking"  SliceCorner="51,50"  SliceSize="1,1" SliceTextureSize="148,156" ConsumeMouse="1">

--- a/UI/Panels/CityPanel.xml
+++ b/UI/Panels/CityPanel.xml
@@ -1,5 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Context xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="..\..\..\..\..\CivTech\Libs\ForgeUI\ForgeUI_Assets\Controls.xsd">
+  <WorldAnchor ID="GrowthHexAnchor" Hidden="1">
+    <AlphaAnim ID="GrowthHexAlpha" AlphaBegin="1" AlphaEnd="0" Stopped="1" Function="OutQuad">
+      <Stack   ID="GrowthHexStack" Anchor="C,T" StackGrowth="Right" Padding="5">
+        <Label ID="TurnsLeftLabel" Anchor="L,C" Style="FontFlair26" Color0="255,113,246,255" Color1="52,33,90,128" Color2="248,188,238,255" FontStyle="Stroke"/>
+        <Label ID="TurnsLeftDescription" Anchor="L,C" Style="FontNormal14" Color0="252,201,247,255" Color1="0,0,0,100" FontStyle="Stroke" WrapWidth="130" />
+      </Stack>
+    </AlphaAnim>
+  </WorldAnchor>
   <AlphaAnim                ID="CityPanelAlpha"       AlphaBegin="0" AlphaEnd="1" Speed="3"   Function="OutSine" Cycle="Once" Size="full,full">
     <SlideAnim              ID="CityPanelSlide"       Start="200,0" End="-175,0"     Speed="3.5" Function="OutSine" Cycle="Once" Size="full,full">
       <Grid                 ID="WoodBacking"          Anchor="R,B" Offset="175,-5"  Size="500,162"          Texture="SelectionPanel_WoodBacking"  SliceCorner="51,50"  SliceSize="1,1" SliceTextureSize="148,156" ConsumeMouse="1">
@@ -178,6 +186,4 @@
       </Grid>
     </SlideAnim>
   </AlphaAnim>
-  
-
 </Context>

--- a/UI/Panels/CityPanelOverview.xml
+++ b/UI/Panels/CityPanelOverview.xml
@@ -207,12 +207,12 @@
                   <Stack StackGrowth="Down" Anchor="C,C">
                     <Stack StackGrowth="Right" Padding="3">
                       <Label  ID="HousingTotalNum"    Anchor="L,C"                      Style="CityPanelSubPanelTitle" String="-" />
-                      <Label  Anchor="L,C"                      Style="CityPanelTextSmall" String="LOC_HUD_CITY_HOUSING"  WrapWidth="100"/>
+                      <Label  ID="HousingTotalNumLabel" Anchor="L,C" Style="CityPanelTextSmall" String="-" WrapWidth="100"/>
                     </Stack>
                     <Label                                  Anchor="L,C" Offset="28,0"                        Style="CityPanelTextSmall" String="LOC_HUD_CITY_FOR" FontSize="12"/>
                     <Stack StackGrowth="Right" Padding="3">
                       <Label  ID="CitizensNum"        Anchor="L,C"              Style="CityPanelSubPanelTitle" String="-" />
-                      <Label  ID="CitizensName"                               Anchor="L,C"            Style="CityPanelTextSmall" String="LOC_HUD_CITY_CITIZENS" WrapWidth="100"/>
+                      <Label  ID="CitizensName" Anchor="L,C" Style="CityPanelTextSmall" String="-" WrapWidth="100"/>
                     </Stack>
                   </Stack>
                   <Image  Anchor="R,C" AnchorSide="O,I" Offset="-5,0" Texture="Controls_ThereforeArrow" Size="27,41"/>
@@ -396,13 +396,16 @@
       <Image Texture="Controls_GradientSmall" Anchor="R,T" Size="parent-12,20" Color="8,34,56,255" Offset="0,90"/>
      
     </Box>
-    <Grid         ID="OverviewHeader"     Style="HeaderBannerLeft" Size="320,59" Anchor="L,T" Offset="0,0">
-      <Container Size="parent-20,parent-27" Anchor="L,T">
+    <Grid         ID="OverviewHeader"     Style="HeaderBannerLeft" Size="320,65" Anchor="L,T" Offset="0,0">
+      <Container Size="parent-20,28" Anchor="L,T">
         <Label      ID="OverviewTitle"      Style="BannerHeaderText" Anchor="C,C" String="{LOC_HUD_CITY_DETAILS:upper}"/>
       </Container>
       
-      <Grid Size="parent-20,parent-27" Anchor="L,B" Style="Subheader">
-        <Label      ID="OverviewSubheader" Anchor="C,C" String="{LOC_HUD_CITY_DETAILS:upper}" Style="HeaderSmallCaps"/>
+      <Grid Size="parent-20,parent-27" Anchor="L,B" Offset="0,2" Style="Subheader">
+        <GridButton	ID="RenameCityButton" Size="parent,26" Offset="0,0" Anchor="C,C" Texture="Controls_TextEntry" SliceCorner="30,0" SliceTextureSize="44,26" StateOffsetIncrement="0,26">
+          <EditBox ID="EditCityName" Offset="25,0" Size="parent-25,parent" Anchor="L,C" EditMode="1" Style="HeaderSmallCaps" String="ChooseReligionName" MaxLength="32" Hidden="1" />
+          <Label      ID="OverviewSubheader" Anchor="C,C" String="{LOC_HUD_CITY_DETAILS:upper}" Style="HeaderSmallCaps"/>
+        </GridButton>
       </Grid>
       
       <Image Texture="Controls_TabLedgeFill" Size="parent-100,23" StretchMode="Tile" AnchorSide="I,O" Anchor="C,B" Offset="0,0"/>

--- a/UI/Panels/ProductionPanel.lua
+++ b/UI/Panels/ProductionPanel.lua
@@ -600,7 +600,7 @@ function PopulateList(data, listIM)
       else
         unitListing.FaithPurchaseButton:SetHide(true);
       end
-
+      unitListing.TrainUnit:RegisterCallback( Mouse.eMouseEnter,  function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
       unitListing.TrainUnit:RegisterCallback( Mouse.eRClick, function()
         LuaEvents.OpenCivilopedia(item.Type);
       end); 
@@ -938,9 +938,11 @@ function PopulateList(data, listIM)
       districtList.Header:RegisterCallback( Mouse.eLClick, function()
         OnExpand(dL);         
         end);
+      districtList.Header:RegisterCallback( Mouse.eMouseEnter,  function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
       districtList.HeaderOn:RegisterCallback( Mouse.eLClick, function()
         OnCollapse(dL);         
         end);
+      districtList.HeaderOn:RegisterCallback( Mouse.eMouseEnter,  function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
     end
 
     prodDistrictList = dL;
@@ -1013,6 +1015,7 @@ function PopulateList(data, listIM)
           buildingListing.Button:RegisterCallback( Mouse.eRClick, function()
             LuaEvents.OpenCivilopedia(buildingItem.Type);
           end);
+          buildingListing.Button:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
 
           buildingListing.Button:SetTag(UITutorialManager:GetHash(buildingItem.Type));
 
@@ -1117,6 +1120,7 @@ function PopulateList(data, listIM)
           wonderListing.Button:SetColor(0xffffffff);
         end
         wonderListing.Button:SetDisabled(item.Disabled);
+        wonderListing.Button:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
         wonderListing.Button:RegisterCallback( Mouse.eLClick, function()
           BuildBuilding(data.City, item);
         end);
@@ -1139,9 +1143,11 @@ function PopulateList(data, listIM)
       wonderList.Header:RegisterCallback( Mouse.eLClick, function()
         OnExpand(wL);         
         end);
+      wonderList.Header:RegisterCallback( Mouse.eMouseEnter,  function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
       wonderList.HeaderOn:RegisterCallback( Mouse.eLClick, function()
         OnCollapse(wL);         
         end);
+      wonderList.HeaderOn:RegisterCallback( Mouse.eMouseEnter,  function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
     end
     prodWonderList = wL;
 

--- a/UI/Panels/UnitPanel.lua
+++ b/UI/Panels/UnitPanel.lua
@@ -2775,7 +2775,7 @@ function ShowCombatAssessment( )
                 combatAssessmentStr = Locale.Lookup("LOC_HUD_UNIT_PANEL_OUTCOME_MINOR_WALL_DAMAGE");
                 ShowCombatStalemateBanner();
               else
-                damagePercentToDefenses = Locale.Lookup("LOC_HUD_UNIT_PANEL_OUTCOME_MAJOR_WALL_DAMAGE"); 
+                combatAssessmentStr = Locale.Lookup("LOC_HUD_UNIT_PANEL_OUTCOME_MAJOR_WALL_DAMAGE"); 
                 ShowCombatVictoryBanner();
               end
             end
@@ -3643,6 +3643,20 @@ function OnPortraitClick()
   end
 end
 
+function OnPortraitRightClick()
+  if m_selectedPlayerId ~= nil then
+    local pUnits  :table = Players[m_selectedPlayerId]:GetUnits( );
+    local pUnit   :table = pUnits:FindID( m_UnitId );
+    if (pUnit ~= nil) then
+      local unitType = GameInfo.Units[pUnit:GetUnitType()];
+      if(unitType) then
+        LuaEvents.OpenCivilopedia(unitType.UnitType);
+      end
+    end
+  end
+end
+
+
 -- ===========================================================================
 function Initialize()
 
@@ -3663,6 +3677,7 @@ function Initialize()
   Controls.UnitName:RegisterCallback( Mouse.eLClick, OnUnitListPopupClicked );
   Controls.UnitListPopup:RegisterSelectionCallback( OnUnitListSelection );
   Controls.SelectionPanelUnitPortrait:RegisterCallback( Mouse.eLClick, OnPortraitClick );
+  Controls.SelectionPanelUnitPortrait:RegisterCallback( Mouse.eRClick, OnPortraitRightClick);
 
   Events.BeginWonderReveal.Add( OnBeginWonderReveal );
   Events.CitySelectionChanged.Add( OnCitySelectionChanged );

--- a/UI/Popups/TechCivicCompletedPopup.lua
+++ b/UI/Popups/TechCivicCompletedPopup.lua
@@ -300,6 +300,19 @@ function OnClose()
 end
 
 -- ===========================================================================
+function OnInputHandler( input )
+  local msg = input:GetMessageType();
+  if (msg == KeyEvents.KeyUp) then
+    local key = input:GetKey();
+    if key == Keys.VK_ESCAPE then
+      OnClose();
+      return true;
+    end
+  end
+  return false;
+end
+
+-- ===========================================================================
 function OnChangeGovernment() 
   Close();
   LuaEvents.TechCivicCompletedPopup_GovernmentOpenGovernments();  -- Open Government Screen 
@@ -389,6 +402,7 @@ function Initialize()
   Controls.CloseButton:RegisterCallback( eLClick, OnClose );
   Controls.CloseButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
   ContextPtr:SetInitHandler( OnInit );
+  ContextPtr:SetInputHandler( OnInputHandler, true );
   ContextPtr:SetShutdown( OnShutdown );
     ContextPtr:SetShowHandler( OnShow );
 

--- a/UI/Screens/CivicsTree.lua
+++ b/UI/Screens/CivicsTree.lua
@@ -20,7 +20,7 @@ include( "SupportFunctions" );
 include( "Civ6Common" );      -- Tutorial check support
 include( "TechAndCivicSupport" );
 include( "TechFilterFunctions" );
-
+include( "ModalScreen_PlayerYieldsHelper" );
 
 -- ===========================================================================
 --  DEBUG
@@ -780,6 +780,14 @@ function View( playerTechData:table )
     else
       node.FilteredOut:SetHide( false );
     end
+
+    -- Show/Hide Recommended Icon
+    if live.IsRecommended and live.AdvisorType ~= nil then
+      node.RecommendedIcon:SetIcon(live.AdvisorType);
+      node.RecommendedIcon:SetHide(false);
+    else
+      node.RecommendedIcon:SetHide(true);
+    end
   end
 
   -- Fill in where the markers (representing players) are at:
@@ -1482,6 +1490,9 @@ function OnOpen()
   UI.PlaySound("UI_Screen_Open");
   View( m_kCurrentData );
   ContextPtr:SetHide(false);
+
+  -- From ModalScreen_PlayerYieldsHelper
+  RefreshYields();
 
   -- From Civ6_styles: FullScreenVignetteConsumer
   Controls.ScreenAnimIn:SetToBeginning();

--- a/UI/Screens/GovernmentScreen.lua
+++ b/UI/Screens/GovernmentScreen.lua
@@ -12,7 +12,7 @@ include("SupportFunctions");  -- Clamp
 include("TabSupport");
 include("Civ6Common");
 include("PopupDialogSupport");
-
+include("ModalScreen_PlayerYieldsHelper");
 
 -- ===========================================================================
 --  DEBUG
@@ -1444,7 +1444,7 @@ function OnMyGovernmentClick()
   local isPlayingAnimation:boolean = true;
   if m_tabs.prevSelectedControl == Controls.ButtonGovernments then
     Controls.SelectGovernments:SetHide( true );
-    Controls.PolicyPanelCheckbox:SetHide( true );
+    Controls.PolicyPanelGrid:SetHide( true );
   elseif m_tabs.prevSelectedControl == Controls.ButtonPolicies then
     Controls.SelectPolicies:SetHide( true );
   elseif m_tabs.prevSelectedControl == nil then
@@ -1560,7 +1560,7 @@ function OnGovernmentsClick()
     Controls.SelectGovernments:SetHide( false );
     Controls.SelectGovernments:SetToBeginning();
     Controls.SelectGovernments:Play();
-    Controls.PolicyPanelCheckbox:SetHide( false );
+    Controls.PolicyPanelGrid:SetHide( false );
 
     -- Fade
     local progress    :number = Controls.AlphaAnim:GetProgress();
@@ -1603,7 +1603,7 @@ function OnPoliciesClick()
     Controls.SelectMyGovernment:SetHide( true );
   elseif m_tabs.prevSelectedControl == Controls.ButtonGovernments then
     Controls.SelectGovernments:SetHide( true );
-    Controls.PolicyPanelCheckbox:SetHide( true );
+    Controls.PolicyPanelGrid:SetHide( true );
   elseif m_tabs.prevSelectedControl == nil then
     -- Do nothing, initial/reload call.
   else
@@ -1699,6 +1699,9 @@ end
 function RefreshAllData()
   PopulateLivePlayerData( m_ePlayer );
   RealizeTabs();
+
+  -- From ModalScreen_PlayerYieldsHelper
+  RefreshYields();
 end
 
 
@@ -2662,5 +2665,7 @@ function Initialize()
   Controls.ModalScreenTitle:SetText(Locale.ToUpper("LOC_GOVT_GOVERNMENT"));
   Controls.ModalScreenClose:RegisterCallback(Mouse.eLClick, OnClose);
   Controls.ModalBG:SetHide(true);
+  
+  Controls.PolicyPanelHeaderLabel:SetText(Locale.ToUpper("LOC_TREE_OPTIONS"));
 end
 Initialize();

--- a/UI/Screens/GovernmentScreen.xml
+++ b/UI/Screens/GovernmentScreen.xml
@@ -248,15 +248,6 @@
         </ScrollBar>
       </ScrollPanel>
       <Container                                                              Size="parent,parent">
-        <Grid         ID="PolicyListPanel"  Offset="0,55"       Anchor="R,T"      Size="300,425"        Texture="Controls_PanelBlue"  SliceCorner="25,28" SliceSize="33,18" SliceTextureSize="83,75" Hidden="1">
-          <Line                                   Start="20,16" End="280,16"  Color="55,95,126,255" Width="2" />    
-          <Label      ID="PoliciesListLabel"      Anchor="C,T"  Offset="0,20" Style="FontFlair16" SmallCaps="20" String="{LOC_GOVT_POLICIES_LIST:upper}" Color0="58,99,131,255" Color1="0,0,0,0" Color2="78,119,151,255" />
-          <Line                                   Start="20,40" End="280,40"  Color="55,95,126,255" Width="2" />
-          <ScrollPanel ID="PolicyListScroller"    Offset="0, 50"              Size="300,425" Vertical="1" AutoScrollBar="1" FullClip="1" Hidden="1">
-            <Stack      ID="PoliciesListStack"                    Offset="10,0" />
-            <ScrollBar        Anchor="R,T" AnchorSide="I,I"  Offset="10,0"  Style="ScrollVerticalBar" Size="8,parent-10"/>
-          </ScrollPanel>
-        </Grid>   
       </Container>
       <Box ID="UnlockGovernmentsContainer" Size="parent,parent" Color="0,0,0,180">
         <Grid Texture="Controls_LightweightLayer" SliceCorner="38,30" SliceTextureSize="76,60" Size="250,60" Anchor="C,B" AutoSize="H" AutoSizePadding="50" Offset="0,50">
@@ -272,8 +263,24 @@
 </ScrollPanel>
 
 <!-- Tabs -->
-<Container Style="ModalScreenWide">
-  <GridButton   ID="PolicyPanelCheckbox"  Style="CheckBoxControl" Size="250,24" String="LOC_GOVERNMENT_TOGGLE_POLICY_TEXT" Anchor="R,T" Offset="35,5" Hidden="1"/>
+<Container Anchor="C,C"                 Size="parent,768">
+  <!-- Policy Panel -->
+  <Grid ID="PolicyPanelGrid" Size="300,34" Offset="0,92" Texture="Controls_TitleBarDark" SliceCorner="10,4" SliceSize="22,24" SliceTextureSize="42,34" Hidden="1">
+    <Grid Size="Parent+16,59" Offset="0,-26" Style="HeaderBannerLeft">
+      <Label ID="PolicyPanelHeaderLabel" Anchor="C,T" Offset="-4,8" Style="BannerHeaderText"/>
+    </Grid>
+    <GridButton   ID="PolicyPanelCheckbox"  Style="CheckBoxControl" Size="Parent,24" String="LOC_GOVERNMENT_TOGGLE_POLICY_TEXT" Anchor="C,C" Offset="0,0" >
+      <Grid         ID="PolicyListPanel"  Offset="-1,29"        Anchor="L,T"      Size="Parent+4,425"       Texture="Controls_PanelBlue"  SliceCorner="25,28" SliceSize="33,18" SliceTextureSize="83,75" Hidden="1">
+        <Line                                   Start="20,16" End="280,16"  Color="55,95,126,255" Width="2" />
+        <Label      ID="PoliciesListLabel"      Anchor="C,T"  Offset="0,20" Style="FontFlair16" SmallCaps="20" String="{LOC_GOVT_POLICIES_LIST:upper}" Color0="58,99,131,255" Color1="0,0,0,0" Color2="78,119,151,255" />
+        <Line                                   Start="20,40" End="280,40"  Color="55,95,126,255" Width="2" />
+        <ScrollPanel ID="PolicyListScroller"    Offset="0, 50"              Size="300,425" Vertical="1" AutoScrollBar="1" FullClip="1" Hidden="1">
+          <Stack      ID="PoliciesListStack"                    Offset="10,0" />
+          <ScrollBar        Anchor="R,T" AnchorSide="I,I"  Offset="10,0"  Style="ScrollVerticalBar" Size="8,parent-10"/>
+        </ScrollPanel>
+      </Grid>
+    </GridButton>
+  </Grid>
   <Container ID="TabArea" Anchor="C,T"  Offset="0,35" Size="parent,31">
     <Image Texture="Controls_TabLedgeFill" Size="parent-100,23" StretchMode="Tile" Anchor="C,T" Offset="0,4"/>
     <Grid Style="WoodenTabBacking"  Size="parent-7,31" Anchor="C,T"/>
@@ -300,6 +307,8 @@
       </SlideAnim>
     </Container>
   </Container>
+  
+  <Container Style="ModalScreenWide"/>
 
   <Tutorial ID="TutChangePolicies"  Style="TutorialContainer" Anchor="C,T" AnchorSide="I,I" Offset="-30,126" TriggerBy="TutorialChangePolicies">
     <Grid Style="TutorialCalloutGrid">

--- a/UI/Screens/TechTree.lua
+++ b/UI/Screens/TechTree.lua
@@ -25,7 +25,7 @@ include( "SupportFunctions" );
 include( "Civ6Common" );      -- Tutorial check support
 include( "TechAndCivicSupport");  -- (Already includes Civ6Common and InstanceManager) PopulateUnlockablesForTech
 include( "TechFilterFunctions" );
-
+include( "ModalScreen_PlayerYieldsHelper" );
 
 -- ===========================================================================
 --  DEBUG
@@ -703,7 +703,15 @@ function View( playerTechData:table )
       node.ProgressMeter:SetHide( false );      
       node.ProgressMeter:SetPercent(live.Progress / live.Cost);
     else
-      node.ProgressMeter:SetHide( true );     
+      node.ProgressMeter:SetHide( true );
+    end
+
+    -- Show/Hide Recommended Icon
+    if live.IsRecommended and live.AdvisorType ~= nil then
+      node.RecommendedIcon:SetIcon(live.AdvisorType);
+      node.RecommendedIcon:SetHide(false);
+    else
+      node.RecommendedIcon:SetHide(true);
     end
 
     -- Set art for icon area
@@ -1386,6 +1394,9 @@ function OnOpen()
   UI.PlaySound("UI_Screen_Open");
   View( m_kCurrentData );
   ContextPtr:SetHide(false);
+
+  -- From ModalScreen_PlayerYieldsHelper
+  RefreshYields();
 
   -- From Civ6_styles: FullScreenVignetteConsumer
   Controls.ScreenAnimIn:SetToBeginning();

--- a/UI/WorldInput.lua
+++ b/UI/WorldInput.lua
@@ -1054,8 +1054,13 @@ function DefaultKeyUpHandler( uiKey:number )
       CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), 168372657); --Farm
     end
     if( uiKey == Keys.P ) then
-      CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), 154488225); --Pasture
-      CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), 1523996587); --Plantation
+		local selectedUnit = UI.GetHeadSelectedUnit();
+		if (selectedUnit) then
+			CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), 154488225); --Pasture
+			CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), 1523996587); --Plantation
+		else 
+			PlaceMapPin();
+		end
     end
     if( uiKey == Keys.N ) then
       CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), 1001859687); --Mine

--- a/UI/WorldInput.lua
+++ b/UI/WorldInput.lua
@@ -1090,15 +1090,6 @@ function DefaultKeyUpHandler( uiKey:number )
       CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), -1355513600); --Oil Well
       CQUI_BuildImprovement(UI.GetHeadSelectedUnit(), -396628467); --Offshore Platform
     end
-    if( uiKey == Keys.Y ) then
-      LuaEvents.CQUI_Option_ToggleYields();
-    end
-    if( uiKey == Keys.VK_OEM_PERIOD ) then
-      UI.SelectNextReadyUnit();
-    end
-    if( uiKey == Keys.VK_OEM_COMMA ) then
-      UI.SelectPrevReadyUnit();
-    end
     if( m_isALTDown ) then --Overridden classic binds get an alt-version as well as the normal alt-shortcuts
       if( uiKey == Keys.C ) then
         UnitManager.RequestOperation(UI.GetHeadSelectedUnit(), UnitOperationTypes.HARVEST_RESOURCE);

--- a/UI/WorldInput.lua
+++ b/UI/WorldInput.lua
@@ -82,6 +82,11 @@ InterfaceModeMessageHandler =
 local DefaultMessageHandler   :table  = {};
 local m_actionHotkeyToggleGrid  :number = Input.GetActionId("ToggleGrid");    --  Hot Key Handling
 local m_actionHotkeyOnlinePause :number = Input.GetActionId("OnlinePause");   --  Hot Key Handling
+local m_actionHotkeyToggleYield :number = Input.GetActionId("ToggleYield");   --  Hot Key Handling
+local m_actionHotkeyPrevUnit  :number = Input.GetActionId("PrevUnit");    --  Hot Key Handling
+local m_actionHotkeyNextUnit  :number = Input.GetActionId("NextUnit");    --  Hot Key Handling
+local m_actionHotkeyPrevCity  :number = Input.GetActionId("PrevCity");    --  Hot Key Handling
+local m_actionHotkeyNextCity  :number = Input.GetActionId("NextCity");    --  Hot Key Handling
 local m_kTouchesDownInWorld   :table  = {};   -- Tracks "down" touches that occurred in this context.
 local m_isTouchEnabled      :boolean= false;
 local m_isALTDown       :boolean= false;
@@ -1618,8 +1623,41 @@ end
 -- ===========================================================================
 --  Start touch, until release or move, do not take action.
 -- ===========================================================================
-function OnTouchSelectionStart( pInputStruct:table )
+function OnTouchDebugEnd( pInputStruct:table )
 
+  -- If last touch in a sequence or double tapping.
+  if m_touchCount > 0 then
+    return true;
+  end
+
+  -- If a drag was occurring, end it; otherwise attempt selection of whatever
+  -- is in the plot the mouse is currently at.
+  if m_isTouchDragging then
+    m_isTouchDragging = false;
+  else
+    if m_touchTotalNum == 1 then
+      print("Debug placing!!!");
+      local plotID:number = UI.GetCursorPlotID();
+      if (Map.IsPlot(plotID)) then
+        local edge = UI.GetCursorNearestPlotEdge();
+        DebugPlacement( plotID, edge );
+      end
+    else
+      print("Debug removing!!!");
+      OnDebugCancelPlacement( pInputStruct );
+    end
+  end
+
+  EndDragMap(); -- Reset any dragging
+  m_touchTotalNum = 0;
+  m_isTouchZooming  = false;
+  m_touchStartPlotX = -1;
+  m_touchStartPlotY = -1;
+  return true;
+end
+
+function OnTouchSelectionStart( pInputStruct:table )
+  -- Determine maximum # of touches that have occurred.
   if m_touchCount > m_touchTotalNum then
     m_touchTotalNum = m_touchCount;
   end
@@ -3285,9 +3323,35 @@ function OnInputActionTriggered( actionId )
         -- TODO: query if already on (or will get out of sync with button presses!)
         ms_bGridOn = not ms_bGridOn;
         UI.ToggleGrid( ms_bGridOn );
-    end
+    elseif actionId == m_actionHotkeyToggleYield then
+        if m_bShowYield then
+            LuaEvents.MinimapPanel_HideYieldIcons();
+            m_bShowYield = false;
+            UI.PlaySound("Play_UI_Click");
+        else
+            LuaEvents.MinimapPanel_ShowYieldIcons();
+            m_bShowYield = true;
+            UI.PlaySound("Play_UI_Click");
+        end
+    elseif actionId == m_actionHotkeyPrevUnit then
+        UI.SelectPrevReadyUnit();
+        UI.PlaySound("Play_UI_Click");
 
-    if actionId == m_actionHotkeyOnlinePause then
+    elseif actionId == m_actionHotkeyNextUnit then
+        UI.SelectNextReadyUnit();
+        UI.PlaySound("Play_UI_Click");
+
+    elseif actionId == m_actionHotkeyPrevCity then
+        local curCity:table = UI.GetHeadSelectedCity();
+        UI.SelectPrevCity(curCity);
+        UI.PlaySound("Play_UI_Click");
+
+    elseif actionId == m_actionHotkeyNextCity then
+        local curCity:table = UI.GetHeadSelectedCity();
+        UI.SelectNextCity(curCity);
+        UI.PlaySound("Play_UI_Click");
+
+    elseif actionId == m_actionHotkeyOnlinePause then
         if GameConfiguration.IsNetworkMultiplayer() then
             TogglePause();
         end
@@ -3425,7 +3489,9 @@ function Initialize()
 
   -- Touch Events (if a touch system)
   if m_isTouchEnabled then
-    InterfaceModeMessageHandler[InterfaceModeTypes.DEBUG]       [MouseEvents.PointerUp]   = DebugPlacement;
+    InterfaceModeMessageHandler[InterfaceModeTypes.DEBUG]       [MouseEvents.PointerDown] = OnTouchStart;
+    InterfaceModeMessageHandler[InterfaceModeTypes.DEBUG]       [MouseEvents.PointerUpdate] = OnTouchUpdate;
+    InterfaceModeMessageHandler[InterfaceModeTypes.DEBUG]       [MouseEvents.PointerUp]   = OnTouchDebugEnd;
     InterfaceModeMessageHandler[InterfaceModeTypes.SELECTION]     [MouseEvents.PointerDown] = OnTouchSelectionStart;
     InterfaceModeMessageHandler[InterfaceModeTypes.SELECTION]     [MouseEvents.PointerUpdate] = OnTouchSelectionUpdate;
     InterfaceModeMessageHandler[InterfaceModeTypes.SELECTION]     [MouseEvents.PointerUp]   = OnTouchSelectionEnd;

--- a/UI/WorldView/CityBannerManager.lua
+++ b/UI/WorldView/CityBannerManager.lua
@@ -1159,7 +1159,7 @@ function CityBanner.UpdateName( self : CityBanner )
         self.m_Instance.CityUnderSiegeIcon:SetHide(false);
       else
         self.m_Instance.CityUnderSiegeIcon:SetHide(true);
-      end
+      end      
 
       -- Update district icons
       -- districtType:number == Index
@@ -1275,6 +1275,15 @@ function CityBanner.UpdateName( self : CityBanner )
           self.m_Instance.CityAmenitiesInsufficientIcon:SetHide(false);
         else
           self.m_Instance.CityAmenitiesInsufficientIcon:SetHide(true);
+        end
+      end
+
+      -- Update occupied icon
+      if self.m_Instance.CityOccupiedIcon ~= nil then
+        if pCity:IsOccupied() then
+          self.m_Instance.CityOccupiedIcon:SetHide(false);
+        else
+          self.m_Instance.CityOccupiedIcon:SetHide(true);
         end
       end
 
@@ -2014,6 +2023,7 @@ function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
         end
       else
         miniBanner.UpdateStats();
+        miniBanner.SetColor();
       end
     end
   end
@@ -2064,11 +2074,14 @@ end
 
 -- ===========================================================================
 function OnCityVisibilityChanged( playerID: number, cityID : number, eVisibility : number)
-
-    local bannerInstance = GetCityBanner( playerID, cityID );
+  local bannerInstance = GetCityBanner( playerID, cityID );
   if (bannerInstance ~= nil) then
     bannerInstance:SetFogState( eVisibility );
-    end
+  end
+end
+
+function OnCityOccupationChanged( playerID: number, cityID : number )
+  RefreshBanner( playerID, cityID );
 end
 
 -- ===========================================================================
@@ -2131,6 +2144,13 @@ function OnBuildingChanged( plotX:number, plotY:number, buildingIndex:number, pl
     end
   end
 
+end
+
+function OnCityNameChange( playerID: number, cityID : number)
+  local banner:CityBanner = GetCityBanner( playerID, cityID );
+  if (banner ~= nil ) then
+    banner:UpdateName();   
+  end
 end
 
 -- ===========================================================================
@@ -2861,6 +2881,7 @@ function Initialize()
   Events.CityAddedToMap.Add(          OnCityAddedToMap );
   Events.CityDefenseStatusChanged.Add(    OnCityDefenseStatusChanged );
   Events.CityFocusChanged.Add(        OnCityFocusChange );
+  Events.CityNameChanged.Add(         OnCityNameChange );
   Events.CityProductionChanged.Add(     OnCityProductionChanged);
   Events.CityProductionUpdated.Add(     OnCityProductionUpdate); 
   Events.CityProductionCompleted.Add(     OnCityProductionCompleted);
@@ -2870,6 +2891,7 @@ function Initialize()
   Events.CitySelectionChanged.Add(      OnSelectionChanged );
   Events.CityUnitsChanged.Add(                OnCityUnitsChanged );
   Events.CityVisibilityChanged.Add(     OnCityVisibilityChanged );
+  Events.CityOccupationChanged.Add(     OnCityOccupationChanged );
   Events.DiplomacyDeclareWar.Add(       OnDiplomacyDeclareWar );
   Events.DiplomacyMakePeace.Add(        OnDiplomacyMakePeace );
   Events.DistrictAddedToMap.Add(        OnDistrictAddedToMap );

--- a/UI/WorldView/CityBannerManager.xml
+++ b/UI/WorldView/CityBannerManager.xml
@@ -51,6 +51,7 @@
                 <Label      ID="TradingPostDisabledIcon"    Anchor="C,C"  String="[ICON_Exclamation]" Hidden="1"/>
               </Label>
               <Label        ID="CityUnderSiegeIcon"         Anchor="L,C"  Style="FontNormal20" String="[ICON_UnderSiege]" ConsumeMouse="1" ToolTip="LOC_HUD_REPORTS_STATUS_UNDER_SEIGE"/>
+              <Label        ID="CityOccupiedIcon"             Anchor="L,C"  Style="FontNormal20" String="[ICON_Occupied]" ConsumeMouse="1" ToolTip="LOC_HUD_CITY_GROWTH_OCCUPIED"/>
               <Label        ID="CityHousingInsufficientIcon"    Anchor="L,C"  Style="FontNormal20" String="[ICON_HousingInsufficient]"/>
               <Label        ID="CityAmenitiesInsufficientIcon"  Anchor="L,C"  Style="FontNormal20" String="[ICON_AmenitiesInsufficient]"/>
 

--- a/UI/WorldView/PlotInfo.lua
+++ b/UI/WorldView/PlotInfo.lua
@@ -203,9 +203,12 @@ function ShowPurchases()
               pInstance.PurchaseButton:SetToolTipString("");
             end
             if (index == pNextPlotID ) then
-              pInstance.NextPlotLabel:SetString("[ICON_Turn]" .. Locale.Lookup("LOC_HUD_CITY_IN_TURNS" , TurnsUntilExpansion ) .. "   ");
-              pInstance.NextPlotLabel:SetToolTipString( " " .. Round(pCityCulture:GetCurrentCulture(), 1) .. "/" .. pCityCulture:GetNextPlotCultureCost() .. " (+" .. Round(pCityCulture:GetCultureYield(), 1) .. "[ICON_CULTURE]) " .. Locale.Lookup( "LOC_HUD_CITY_BORDER_EXPANSION" , TurnsUntilExpansion ).."[ICON_Turn]");
-              pInstance.NextPlotButton:SetHide( false );
+              pInstance.CQUI_NextPlotLabel:SetString("[ICON_Turn]" .. Locale.Lookup("LOC_HUD_CITY_IN_TURNS" , TurnsUntilExpansion ) .. "   ");
+              pInstance.CQUI_NextPlotLabel:SetToolTipString( " " .. Round(pCityCulture:GetCurrentCulture(), 1) .. "/" .. pCityCulture:GetNextPlotCultureCost() .. " (+" .. Round(pCityCulture:GetCultureYield(), 1) .. "[ICON_CULTURE]) " .. Locale.Lookup( "LOC_HUD_CITY_BORDER_EXPANSION" , TurnsUntilExpansion ).."[ICON_Turn]");
+              pInstance.CQUI_NextPlotButton:RegisterCallback( Mouse.eLClick, function()
+                LuaEvents.CQUI_ToggleGrowthTile();
+              end);
+              pInstance.CQUI_NextPlotButton:SetHide( false );
             end
             pInstance.PurchaseButton:SetHide( false );
             table.insert( m_uiPurchase, pInstance );
@@ -541,7 +544,7 @@ end
 function HidePurchases()  
   for _,pInstance in ipairs(m_uiPurchase) do
     pInstance.PurchaseButton:SetHide( true );
-    pInstance.NextPlotButton:SetHide( true );
+    pInstance.CQUI_NextPlotButton:SetHide( true );
     -- NOTE: This plot can't be returned to the instnace manager 
     -- (ReleaseInstance) unless the local cached version in (m_uiWorldMap) 
     -- is removed too; which is only safe if NOTHING else utilizing this 

--- a/UI/WorldView/PlotInfo.lua
+++ b/UI/WorldView/PlotInfo.lua
@@ -288,9 +288,11 @@ function ShowCitizens()
         --pInstance.CitizenButton:SetSizeVal(48, 48);
         pInstance.CitizenButton:SetHide(isCityCenterPlot);      
         pInstance.CitizenButton:SetDisabled(isCityCenterPlot);
-        
+
+        local numUnits:number = tUnits[i];
+        local maxUnits:number = tMaxUnits[i];
         --CQUI Citizen buttons tweaks
-        if(tUnits[i] >= 1) then
+        if(numUnits >= 1) then
           pInstance.CitizenButton:SetTextureOffsetVal(0, CITIZEN_BUTTON_HEIGHT*4);
           pInstance.CitizenButton:SetSizeVal(64,64);
           pInstance.CitizenButton:SetAlpha(.45);
@@ -300,11 +302,18 @@ function ShowCitizens()
           pInstance.CitizenButton:SetAlpha(.6);
         end
 
-        if(tMaxUnits[i] > 1) then
-          pInstance.CurrentAmount:SetText(tUnits[i]);
-          pInstance.TotalAmount:SetText(tMaxUnits[i]);
+        if(maxUnits > 1) then
+          --[[ TODO: Add back for Patch2, wasn't in due to missing TEXT lock. 
+          local toolTip:string = Locale.Lookup("LOC_HUD_CITY_SPECIALISTS", numUnits, maxUnits);
+          pInstance.CitizenMeterBG:SetToolTipString( toolTip );
+          --]]
+          pInstance.CitizenMeterBG:SetHide(false);          
+          pInstance.CurrentAmount:SetText(numUnits);
+          pInstance.TotalAmount:SetText(maxUnits);
+          pInstance.CitizenMeter:SetPercent(numUnits / maxUnits);         
+        else
+          pInstance.CitizenMeterBG:SetHide(true);
         end
-
         if(tLockedUnits[i] > 0) then
           pInstance.LockedIcon:SetHide(false);
         else
@@ -509,6 +518,7 @@ function HideCitizens()
 
   for _,kInstance in ipairs(m_uiCitizens) do
     kInstance.CitizenButton:SetHide( true );
+    kInstance.CitizenMeterBG:SetHide( true );
     kInstance.LockedIcon:SetHide( true );
   end
   m_uiCitizens = {};
@@ -735,6 +745,7 @@ end
 function OnCityWorkerChanged( owner:number, cityID:number, plotX:number, plotY:number )
   if owner == Game.GetLocalPlayer() then
     RefreshCitizenManagement();
+    LuaEvents.PlotInfo_UpdatePlotTooltip(true);
   end
 end
 

--- a/UI/WorldView/PlotInfo.xml
+++ b/UI/WorldView/PlotInfo.xml
@@ -18,8 +18,8 @@
         <Line                               Anchor="L,T"                  Start="49,37" End="67,25" Width="1" Color="201,217,227,255" />
         <Label      ID="TotalAmount"        Anchor="R,B"  Offset="9,7"    Style="FontFlair18"   FontStyle="Stroke"  Color="201,217,227,255" EffectColor="0,0,0,150"/>
       </Image>
-      <GridButton       ID="NextPlotButton" Anchor="C,T"  Offset="0,-10" Size="95,30" Hidden="1" Style="PurchaseTileButton" ToolTip="The city will expand to this tile upon the next cultural borders growth">
-        <Label      ID="NextPlotLabel" String="Next Tile" ToolTip="The city will expand to this tile upon the next cultural borders growth" Anchor="C,C"  Offset="0,0" Style="CityPanelCBCulture" Align="Left"/>
+      <GridButton       ID="CQUI_NextPlotButton" Anchor="C,T"  Offset="0,-10" Size="95,30" Hidden="1" Style="PurchaseTileButton" ToolTip="The city will expand to this tile upon the next cultural borders growth">
+        <Label      ID="CQUI_NextPlotLabel" String="Next Tile" ToolTip="The city will expand to this tile upon the next cultural borders growth" Anchor="C,C"  Offset="0,0" Style="CityPanelCBCulture" Align="Left"/>
       </GridButton>
       <Button       ID="CitizenButton"  Anchor="C,T"  Offset="0,-50"  Size="64,64" Alpha=".50"      Texture="CityPanel_ManageCitizenButton.dds" Hidden="1"  NoStateChange="1" />
       <Image      ID="LockedIcon"     Anchor="R,B"  Offset="-35,30" Size="32,32"    Texture="Padlock" Hidden="1"/>

--- a/UI/WorldView/PlotInfo.xml
+++ b/UI/WorldView/PlotInfo.xml
@@ -12,15 +12,17 @@
       <GridButton       ID="SwapTileOwnerButton" Anchor="C,T" Offset="0,-40" Size="61,30" Hidden="1" Style="PurchaseTileButton">
         <Label      ID="SwapLabel" String="LOC_PLOTINFO_SWAP_TILE_OWNER" ToolTip="LOC_PLOTINFO_SWAP_TILE_OWNER_TOOLTIP" Anchor="C,C"  Offset="0,0" Style="CityPanelText" Align="Center"/>
       </GridButton>
+      <Image      ID="CitizenMeterBG"       Anchor="L,C"  Offset="-10,-20"  Size="76,62"  Texture="CityPanel_ManageCitizensMeterBacking" Hidden="1">
+        <TextureBar ID="CitizenMeter"       Anchor="C,B"  Offset="19,3"   Direction="Up" Speed="0" Size="31,56" Texture="CityPanel_ManageCitizensMeter"/>
+        <Label      ID="CurrentAmount"      Anchor="L,T"  Offset="49,10"  Style="FontFlair18"   FontStyle="Stroke"  Color="201,217,227,255" EffectColor="0,0,0,150"/>
+        <Line                               Anchor="L,T"                  Start="49,37" End="67,25" Width="1" Color="201,217,227,255" />
+        <Label      ID="TotalAmount"        Anchor="R,B"  Offset="9,7"    Style="FontFlair18"   FontStyle="Stroke"  Color="201,217,227,255" EffectColor="0,0,0,150"/>
+      </Image>
       <GridButton       ID="NextPlotButton" Anchor="C,T"  Offset="0,-10" Size="95,30" Hidden="1" Style="PurchaseTileButton" ToolTip="The city will expand to this tile upon the next cultural borders growth">
         <Label      ID="NextPlotLabel" String="Next Tile" ToolTip="The city will expand to this tile upon the next cultural borders growth" Anchor="C,C"  Offset="0,0" Style="CityPanelCBCulture" Align="Left"/>
       </GridButton>
-      <Button       ID="CitizenButton"  Anchor="C,T"  Offset="0,-50"  Size="64,64" Alpha=".50"      Texture="CityPanel_ManageCitizenButton.dds" Hidden="1"  NoStateChange="1">
-        <Label      ID="CurrentAmount"  Anchor="R,C"  Offset="20,-10" AnchorSide="O,I"  Style="CityPanelNumLarge" />
-        <Label      ID="LabelOf"        Anchor="R,C"  Offset="20,5"   AnchorSide="O,I"  Style="CityPanelNumLarge" Text="Of" />
-        <Label      ID="TotalAmount"    Anchor="R,C"  Offset="20,20"  AnchorSide="O,I"  Style="CityPanelNumLarge" />
-      </Button>
-    <Image      ID="LockedIcon"     Anchor="R,B"  Offset="-35,30" Size="32,32"    Texture="Padlock" Hidden="1"/>
+      <Button       ID="CitizenButton"  Anchor="C,T"  Offset="0,-50"  Size="64,64" Alpha=".50"      Texture="CityPanel_ManageCitizenButton.dds" Hidden="1"  NoStateChange="1" />
+      <Image      ID="LockedIcon"     Anchor="R,B"  Offset="-35,30" Size="32,32"    Texture="Padlock" Hidden="1"/>
     </WorldAnchor>
   </Instance>
 

--- a/URS/ReportScreen.lua
+++ b/URS/ReportScreen.lua
@@ -1,6 +1,6 @@
 -- ===========================================================================
--- ReportScreen
--- All the data
+--	ReportScreen
+--	All the data
 --
 -- ===========================================================================
 include("CitySupport");
@@ -9,1653 +9,1867 @@ include("InstanceManager");
 include("SupportFunctions");
 include("TabSupport");
 
--- ===========================================================================
--- DEBUG
--- Toggle these for temporary debugging help.
--- ===========================================================================
-local m_debugFullHeight :boolean = false; -- (false) if the screen area should resize to full height of the available space.
 
 -- ===========================================================================
--- CONSTANTS
+--	DEBUG
+--	Toggle these for temporary debugging help.
 -- ===========================================================================
-local DARKEN_CITY_INCOME_AREA_ADDITIONAL_Y :number = 6;
-local DATA_FIELD_SELECTION :string = "Selection";
-local SIZE_HEIGHT_BOTTOM_YIELDS :number = 135;
-local SIZE_HEIGHT_PADDING_BOTTOM_ADJUST :number = 85; -- (Total Y - (scroll area + THIS PADDING)) = bottom area
+local m_debugFullHeight				:boolean = true;		-- (false) if the screen area should resize to full height of the available space.
+local m_debugNumResourcesStrategic	:number = 0;			-- (0) number of extra strategics to show for screen testing.
+local m_debugNumBonuses				:number = 0;			-- (0) number of extra bonuses to show for screen testing.
+local m_debugNumResourcesLuxuries	:number = 0;			-- (0) number of extra luxuries to show for screen testing.
+
+
+-- ===========================================================================
+--	CONSTANTS
+-- ===========================================================================
+local DARKEN_CITY_INCOME_AREA_ADDITIONAL_Y		:number = 6;
+local DATA_FIELD_SELECTION						:string = "Selection";
+local SIZE_HEIGHT_BOTTOM_YIELDS					:number = 135;
+local SIZE_HEIGHT_PADDING_BOTTOM_ADJUST			:number = 85;	-- (Total Y - (scroll area + THIS PADDING)) = bottom area
 
 -- Mapping of unit type to cost.
 local UnitCostMap:table = {};
 do
-  for row in GameInfo.Units() do
-    UnitCostMap[row.UnitType] = row.Maintenance;
-  end
+	for row in GameInfo.Units() do
+		UnitCostMap[row.UnitType] = row.Maintenance;
+	end
 end
+
 
 -- !! Added function to sort out tables for units
 local bUnits = { group = {}, parent = {}, type = "" }
 
 function spairs( t, order )
-  local keys = {}
+		local keys = {}
 
-  for k in pairs(t) do keys[#keys+1] = k end
+		for k in pairs(t) do keys[#keys+1] = k end
+		
+		if order then
+			table.sort(keys, function(a,b) return order(t, a, b) end)
+		else
+			table.sort(keys)
+		end
 
-  if order then
-    table.sort(keys, function(a,b) return order(t, a, b) end)
-  else
-    table.sort(keys)
-  end
-
-  local i = 0
-  return function()
-    i = i + 1
-    if keys[i] then
-      return keys[i], t[keys[i]]
-    end
-  end
-end
+		local i = 0
+		return function()
+			i = i + 1
+			if keys[i] then
+				return keys[i], t[keys[i]]
+			end
+		end
+	end
 -- !! end of function
 
--- ===========================================================================
--- VARIABLES
--- ===========================================================================
-
-local m_groupIM :table = InstanceManager:new("GroupInstance", "Top", Controls.Stack); -- Collapsable
-local m_simpleIM :table = InstanceManager:new("SimpleInstance", "Top", Controls.Stack); -- Non-Collapsable, simple
-local m_tabIM :table = InstanceManager:new("TabInstance", "Button", Controls.TabContainer);
-local m_tabs :table;
-local m_kCityData :table = nil;
-local m_kCityTotalData :table = nil;
-local m_kUnitData :table = nil; -- TODO: Show units by promotion class
-local m_kResourceData :table = nil;
-local m_kDealData :table = nil;
-local m_kCultureData :table = nil;
-local m_kCurrentDeals :table = nil;
-local m_uiGroups :table = nil; -- Track the groups on-screen for collapse all action.
 
 -- ===========================================================================
--- Single exit point for display
+--	VARIABLES
+-- ===========================================================================
+
+local m_groupIM				:table = InstanceManager:new("GroupInstance",			"Top",		Controls.Stack);				-- Collapsable
+local m_simpleIM			:table = InstanceManager:new("SimpleInstance",			"Top",		Controls.Stack);				-- Non-Collapsable, simple
+local m_tabIM				:table = InstanceManager:new("TabInstance",				"Button",	Controls.TabContainer);
+local m_bonusResourcesIM	:table = InstanceManager:new("ResourceAmountInstance",	"Info",		Controls.BonusResources);
+local m_luxuryResourcesIM	:table = InstanceManager:new("ResourceAmountInstance",	"Info",		Controls.LuxuryResources);
+local m_strategicResourcesIM:table = InstanceManager:new("ResourceAmountInstance",	"Info",		Controls.StrategicResources);
+
+local m_tabs				:table;
+local m_kCityData			:table = nil;
+local m_kCityTotalData		:table = nil;
+local m_kUnitData			:table = nil;	-- TODO: Show units by promotion class
+local m_kResourceData		:table = nil;
+local m_kDealData			:table = nil;
+local m_uiGroups			:table = nil;	-- Track the groups on-screen for collapse all action.
+
+-- !! new variables
+local m_kCultureData	:table = nil;
+local m_kCurrentDeals	:table = nil;
+-- !!
+
+-- ===========================================================================
+--	Single exit point for display
 -- ===========================================================================
 function Close()
-  UIManager:DequeuePopup(ContextPtr);
-  UI.PlaySound("UI_Screen_Close");
+	UIManager:DequeuePopup(ContextPtr);
+	UI.PlaySound("UI_Screen_Close");
 end
 
+
 -- ===========================================================================
--- UI Callback
+--	UI Callback
 -- ===========================================================================
 function OnCloseButton()
-  Close();
+	Close();
 end
 
 -- ===========================================================================
--- Single entry point for display
+--	Single entry point for display
 -- ===========================================================================
 function Open()
-  UIManager:QueuePopup( ContextPtr, PopupPriority.Normal );
-  Controls.ScreenAnimIn:SetToBeginning();
-  Controls.ScreenAnimIn:Play();
-  UI.PlaySound("UI_Screen_Open");
+	UIManager:QueuePopup( ContextPtr, PopupPriority.Normal );
+	Controls.ScreenAnimIn:SetToBeginning();
+	Controls.ScreenAnimIn:Play();
+	UI.PlaySound("UI_Screen_Open");
 
-  m_kCityData, m_kCityTotalData, m_kResourceData, m_kUnitData, m_kDealData, m_kCultureData, m_kCurrentDeals = GetData();
-
-  m_tabs.SelectTab( 1 );
-
+	-- !! new line to add new variables 
+	-- m_kCityData, m_kCityTotalData, m_kResourceData, m_kUnitData, m_kDealData = GetData();
+	m_kCityData, m_kCityTotalData, m_kResourceData, m_kUnitData, m_kDealData, m_kCultureData, m_kCurrentDeals = GetData();
+	
+	m_tabs.SelectTab( 1 );
 end
 
 -- ===========================================================================
--- LUA Events
--- Opened via the top panel
+--	LUA Events
+--	Opened via the top panel
 -- ===========================================================================
 function OnTopOpenReportsScreen()
-  Open();
+	Open();
 end
 
 -- ===========================================================================
--- LUA Events
--- Closed via the top panel
+--	LUA Events
+--	Closed via the top panel
 -- ===========================================================================
 function OnTopCloseReportsScreen()
-  Close();
+	Close();	
 end
 
 -- ===========================================================================
--- UI Callback
--- Collapse all the things!
+--	UI Callback
+--	Collapse all the things!
 -- ===========================================================================
 function OnCollapseAllButton()
-  if m_uiGroups == nil or table.count(m_uiGroups) == 0 then
-    return;
-  end
+	if m_uiGroups == nil or table.count(m_uiGroups) == 0 then
+		return;
+	end
 
-  for i,instance in ipairs( m_uiGroups ) do
-    if instance["isCollapsed"] == false then
-      instance["isCollapsed"] = true;
-      instance.CollapseAnim:Reverse();
-      RealizeGroup( instance );
-    end
-  end
+	for i,instance in ipairs( m_uiGroups ) do
+		if instance["isCollapsed"] == false then
+			instance["isCollapsed"] = true;
+			instance.CollapseAnim:Reverse();
+			RealizeGroup( instance );
+		end
+	end
 end
 
-function l(object) print("Attributes:") for k, v in pairs(getmetatable(object).__index) do print(k); end; print("End attributes."); end
-
 -- ===========================================================================
--- Populate with all data required for any/all report tabs.
+--	Populate with all data required for any/all report tabs.
 -- ===========================================================================
 function GetData()
-  local kResources :table = {};
-  local kCityData :table = {};
-  local kCityTotalData:table = {
-    Income = {},
-    Expenses= {},
-    Net = {},
-    Treasury= {}
-  };
-  local kUnitData :table = {};
+	local kResources	:table = {};
+	local kCityData		:table = {};
+	local kCityTotalData:table = {
+		Income	= {},
+		Expenses= {},
+		Net		= {},
+		Treasury= {}
+	};
+	local kUnitData		:table = {};
 
-  kCityTotalData.Income[YieldTypes.CULTURE] = 0;
-  kCityTotalData.Income[YieldTypes.FAITH] = 0;
-  kCityTotalData.Income[YieldTypes.FOOD] = 0;
-  kCityTotalData.Income[YieldTypes.GOLD] = 0;
-  kCityTotalData.Income[YieldTypes.PRODUCTION]= 0;
-  kCityTotalData.Income[YieldTypes.SCIENCE] = 0;
-  kCityTotalData.Income["TOURISM"] = 0;
-  kCityTotalData.Expenses[YieldTypes.GOLD] = 0;
+	kCityTotalData.Income[YieldTypes.CULTURE]	= 0;
+	kCityTotalData.Income[YieldTypes.FAITH]		= 0;
+	kCityTotalData.Income[YieldTypes.FOOD]		= 0;
+	kCityTotalData.Income[YieldTypes.GOLD]		= 0;
+	kCityTotalData.Income[YieldTypes.PRODUCTION]= 0;
+	kCityTotalData.Income[YieldTypes.SCIENCE]	= 0;
+	kCityTotalData.Income["TOURISM"]			= 0;
+	kCityTotalData.Expenses[YieldTypes.GOLD]	= 0;
+	
+	local playerID	:number = Game.GetLocalPlayer();
+	if playerID == PlayerTypes.NONE then
+		UI.DataError("Unable to get valid playerID for report screen.");
+		return;
+	end
 
-  local playerID :number = Game.GetLocalPlayer();
-  if playerID == PlayerTypes.NONE then
-    UI.DataError("Unable to get valid playerID for report screen.");
-    return;
-  end
+	local player	:table  = Players[playerID];
+	local pCulture	:table	= player:GetCulture();
+	local pTreasury	:table	= player:GetTreasury();
+	local pReligion	:table	= player:GetReligion();
+	local pScience	:table	= player:GetTechs();
+	local pResources:table	= player:GetResources();
 
-  local player :table = Players[playerID];
-  local pCulture :table = player:GetCulture();
-  local pTreasury :table = player:GetTreasury();
-  local pReligion :table = player:GetReligion();
-  local pScience :table = player:GetTechs();
+	-- ==========================
+	-- !! this will use the m_kUnitData to fill out player's unit info
+	-- ==========================
+	local group_name : string = "default"
 
-  -- ==========================
-  -- !! this will use the m_kUnitData to fill out player's unit info
-  -- ==========================
-  local group_name : string = "default"
+	kUnitData["Unit_Expenses"] = {}
+	kUnitData["Unit_Report"] = {}
 
-  kUnitData["Unit_Expenses"] = {}
-  kUnitData["Unit_Report"] = {}
+	for _, unit in player:GetUnits():Members() do
+		local unitInfo : table = GameInfo.Units[unit:GetUnitType()]
+		local unitGreatPerson = unit:GetGreatPerson()
 
-  for _, unit in player:GetUnits():Members() do
-    local unitInfo : table = GameInfo.Units[unit:GetUnitType()]
-    local unitGreatPerson = unit:GetGreatPerson()
+		if GameInfo.GreatPersonClasses[unitGreatPerson:GetClass()] then group_name = "GREAT_PERSON"
+		elseif unitInfo.MakeTradeRoute == true then group_name = "TRADER"
+		elseif GameInfo.Units[unitInfo.UnitType].Spy == true then group_name = "SPY"
+		elseif unit:GetReligiousStrength() > 0 then group_name = "RELIGIOUS"
+		elseif unit:GetCombat() == 0 and unit:GetRangedCombat() == 0 then group_name = "CIVILIAN"
+		elseif unitInfo.Domain == "DOMAIN_LAND" then group_name = "MILITARY_LAND"
+		elseif unitInfo.Domain == "DOMAIN_AIR" then group_name = "MILITARY_AIR"
+		elseif unitInfo.Domain == "DOMAIN_SEA" then group_name = "MILITARY_SEA"
+		end
 
-    if GameInfo.GreatPersonClasses[unitGreatPerson:GetClass()] then group_name = "GREAT_PERSON"
-    elseif unitInfo.MakeTradeRoute == true then group_name = "TRADER"
-    elseif GameInfo.Units[unitInfo.UnitType].Spy == true then group_name = "SPY"
-    elseif unit:GetReligiousStrength() > 0 then group_name = "RELIGIOUS"
-    elseif unit:GetCombat() == 0 and unit:GetRangedCombat() == 0 then group_name = "CIVILIAN"
-    elseif unitInfo.Domain == "DOMAIN_LAND" then group_name = "MILITARY_LAND"
-    elseif unitInfo.Domain == "DOMAIN_AIR" then group_name = "MILITARY_AIR"
-    elseif unitInfo.Domain == "DOMAIN_SEA" then group_name = "MILITARY_SEA"
-    end
+		if kUnitData["Unit_Report"][group_name] == nil then
+			if group_name == "GREAT_PERSON" then
+				kUnitData["Unit_Report"][group_name] = { Name = "Great People", ID = 6, func = group_great, Header = "UnitsGreatPeopleHeaderInstance", Entry = "UnitsGreatPeopleEntryInstance", units = {} }
+			elseif group_name == "SPY" then
+				kUnitData["Unit_Report"][group_name] = { Name = "Spy", ID = 8, func = group_spy, Header = "UnitsSpyHeaderInstance", Entry = "UnitsSpyEntryInstance", units = {} }
+			elseif group_name == "RELIGIOUS" then
+				kUnitData["Unit_Report"][group_name] = { Name = "Religious", ID = 5, func = group_religious, Header = "UnitsReligiousHeaderInstance", Entry = "UnitsReligiousEntryInstance", units = {} }
+			elseif group_name == "TRADER" then
+				kUnitData["Unit_Report"][group_name] = { Name = "Trader", ID = 7, func = group_trader, Header = "UnitsTraderHeaderInstance", Entry = "UnitsTraderEntryInstance", units = {} }
+			elseif group_name == "MILITARY_LAND" then
+				kUnitData["Unit_Report"][group_name] = { Name = "Military (Land)", ID = 1, func = group_military,  Header = "UnitsMilitaryHeaderInstance", Entry = "UnitsMilitaryEntryInstance", units = {} }
+			elseif group_name == "MILITARY_AIR" then
+				kUnitData["Unit_Report"][group_name] = { Name = "Military (Air)", ID = 3, func = group_military, Header = "UnitsMilitaryHeaderInstance", Entry = "UnitsMilitaryEntryInstance", units = {} }
+			elseif group_name == "MILITARY_SEA" then
+				kUnitData["Unit_Report"][group_name] = { Name = "Military (Sea)", ID = 2, func = group_military, Header = "UnitsMilitaryHeaderInstance", Entry = "UnitsMilitaryEntryInstance", units = {} }
+			else
+				kUnitData["Unit_Report"][group_name] = { Name = "Civilian and Support", ID = 4, func = group_civilian, Header = "UnitsCivilianHeaderInstance", Entry = "UnitsCivilianEntryInstance", units = {} }
+			end
+		end
 
-    if kUnitData["Unit_Report"][group_name] == nil then
-      if group_name == "GREAT_PERSON" then
-        kUnitData["Unit_Report"][group_name] = { Name = "Great People", ID = 6, func = group_great, Header = "UnitsGreatPeopleHeaderInstance", Entry = "UnitsGreatPeopleEntryInstance", units = {} }
-      elseif group_name == "SPY" then
-        kUnitData["Unit_Report"][group_name] = { Name = "Spy", ID = 8, func = group_spy, Header = "UnitsSpyHeaderInstance", Entry = "UnitsSpyEntryInstance", units = {} }
-      elseif group_name == "RELIGIOUS" then
-        kUnitData["Unit_Report"][group_name] = { Name = "Religious", ID = 5, func = group_religious, Header = "UnitsReligiousHeaderInstance", Entry = "UnitsReligiousEntryInstance", units = {} }
-      elseif group_name == "TRADER" then
-        kUnitData["Unit_Report"][group_name] = { Name = "Trader", ID = 7, func = group_trader, Header = "UnitsTraderHeaderInstance", Entry = "UnitsTraderEntryInstance", units = {} }
-      elseif group_name == "MILITARY_LAND" then
-        kUnitData["Unit_Report"][group_name] = { Name = "Military (Land)", ID = 1, func = group_military, Header = "UnitsMilitaryHeaderInstance", Entry = "UnitsMilitaryEntryInstance", units = {} }
-      elseif group_name == "MILITARY_AIR" then
-        kUnitData["Unit_Report"][group_name] = { Name = "Military (Air)", ID = 3, func = group_military, Header = "UnitsMilitaryHeaderInstance", Entry = "UnitsMilitaryEntryInstance", units = {} }
-      elseif group_name == "MILITARY_SEA" then
-        kUnitData["Unit_Report"][group_name] = { Name = "Military (Sea)", ID = 2, func = group_military, Header = "UnitsMilitaryHeaderInstance", Entry = "UnitsMilitaryEntryInstance", units = {} }
-      else
-        kUnitData["Unit_Report"][group_name] = { Name = "Civilian and Support", ID = 4, func = group_civilian, Header = "UnitsCivilianHeaderInstance", Entry = "UnitsCivilianEntryInstance", units = {} }
-      end
-    end
+		table.insert( kUnitData["Unit_Report"][group_name].units, unit )
 
-    table.insert( kUnitData["Unit_Report"][group_name].units, unit )
+		if kUnitData["Unit_Expenses"][unitInfo.UnitType] == nil then
+			kUnitData["Unit_Expenses"][unitInfo.UnitType] = { Name = Locale.Lookup( unitInfo.Name ), Amount = 0, Cost = unitInfo.Maintenance }
+		end
 
-    if kUnitData["Unit_Expenses"][unitInfo.UnitType] == nil then
-      kUnitData["Unit_Expenses"][unitInfo.UnitType] = { Name = Locale.Lookup( unitInfo.Name ), Amount = 0, Cost = unitInfo.Maintenance }
-    end
+		kUnitData["Unit_Expenses"][unitInfo.UnitType].Amount = kUnitData["Unit_Expenses"][unitInfo.UnitType].Amount + 1
+	end
+	-- ==========================
+	-- !! end of edit
+	-- ==========================
 
-    kUnitData["Unit_Expenses"][unitInfo.UnitType].Amount = kUnitData["Unit_Expenses"][unitInfo.UnitType].Amount + 1
-  end
-  -- ==========================
-  -- !! end of edit
-  -- ==========================
+	local pCities = player:GetCities();
+	for i, pCity in pCities:Members() do	
+		local cityName	:string = pCity:GetName();
+			
+		-- Big calls, obtain city data and add report specific fields to it.
+		local data		:table	= GetCityData( pCity );
+		data.Resources			= GetCityResourceData( pCity );					-- Add more data (not in CitySupport)			
+		data.WorkedTileYields	= GetWorkedTileYieldData( pCity, pCulture );	-- Add more data (not in CitySupport)
 
-  local pCities = player:GetCities();
-  for i, pCity in pCities:Members() do
-    local cityName :string = pCity:GetName();
+		-- Add to totals.
+		kCityTotalData.Income[YieldTypes.CULTURE]	= kCityTotalData.Income[YieldTypes.CULTURE] + data.CulturePerTurn;
+		kCityTotalData.Income[YieldTypes.FAITH]		= kCityTotalData.Income[YieldTypes.FAITH] + data.FaithPerTurn;
+		kCityTotalData.Income[YieldTypes.FOOD]		= kCityTotalData.Income[YieldTypes.FOOD] + data.FoodPerTurn;
+		kCityTotalData.Income[YieldTypes.GOLD]		= kCityTotalData.Income[YieldTypes.GOLD] + data.GoldPerTurn;
+		kCityTotalData.Income[YieldTypes.PRODUCTION]= kCityTotalData.Income[YieldTypes.PRODUCTION] + data.ProductionPerTurn;
+		kCityTotalData.Income[YieldTypes.SCIENCE]	= kCityTotalData.Income[YieldTypes.SCIENCE] + data.SciencePerTurn;
+		kCityTotalData.Income["TOURISM"]			= kCityTotalData.Income["TOURISM"] + data.WorkedTileYields["TOURISM"];
+			
+		kCityData[cityName] = data;
 
-    -- Big calls, obtain city data and add report specific fields to it.
-    local data :table = GetCityData( pCity );
-    data.Resources = GetCityResourceData( pCity ); -- Add more data (not in CitySupport)
-    data.WorkedTileYields = GetWorkedTileYieldData( pCity, pCulture ); -- Add more data (not in CitySupport)
+		-- Add resources
+		if m_debugNumResourcesStrategic > 0 or m_debugNumResourcesLuxuries > 0 or m_debugNumBonuses > 0 then
+			for debugRes=1,m_debugNumResourcesStrategic,1 do
+				kResources[debugRes] = {
+					CityList	= { CityName="Kangaroo", Amount=(10+debugRes) },
+					Icon		= "[ICON_"..GameInfo.Resources[debugRes].ResourceType.."]",
+					IsStrategic	= true,
+					IsLuxury	= false,
+					IsBonus		= false,
+					Total		= 88
+				};
+			end
+			for debugRes=1,m_debugNumResourcesLuxuries,1 do
+				kResources[debugRes] = {
+					CityList	= { CityName="Kangaroo", Amount=(10+debugRes) },
+					Icon		= "[ICON_"..GameInfo.Resources[debugRes].ResourceType.."]",
+					IsStrategic	= false,
+					IsLuxury	= true,
+					IsBonus		= false,
+					Total		= 88
+				};
+			end
+			for debugRes=1,m_debugNumBonuses,1 do
+				kResources[debugRes] = {
+					CityList	= { CityName="Kangaroo", Amount=(10+debugRes) },
+					Icon		= "[ICON_"..GameInfo.Resources[debugRes].ResourceType.."]",
+					IsStrategic	= false,
+					IsLuxury	= false,
+					IsBonus		= true,
+					Total		= 88
+				};
+			end
+		end
 
-    -- Add to totals.
-    kCityTotalData.Income[YieldTypes.CULTURE] = kCityTotalData.Income[YieldTypes.CULTURE] + data.CulturePerTurn;
-    kCityTotalData.Income[YieldTypes.FAITH] = kCityTotalData.Income[YieldTypes.FAITH] + data.FaithPerTurn;
-    kCityTotalData.Income[YieldTypes.FOOD] = kCityTotalData.Income[YieldTypes.FOOD] + data.FoodPerTurn;
-    kCityTotalData.Income[YieldTypes.GOLD] = kCityTotalData.Income[YieldTypes.GOLD] + data.GoldPerTurn;
-    kCityTotalData.Income[YieldTypes.PRODUCTION]= kCityTotalData.Income[YieldTypes.PRODUCTION] + data.ProductionPerTurn;
-    kCityTotalData.Income[YieldTypes.SCIENCE] = kCityTotalData.Income[YieldTypes.SCIENCE] + data.SciencePerTurn;
-    kCityTotalData.Income["TOURISM"] = kCityTotalData.Income["TOURISM"] + data.WorkedTileYields["TOURISM"];
+		for eResourceType,amount in pairs(data.Resources) do
+			AddResourceData(kResources, eResourceType, cityName, "LOC_HUD_REPORTS_TRADE_OWNED", amount);
+		end
+	end
 
-    kCityData[cityName] = data;
+	kCityTotalData.Expenses[YieldTypes.GOLD] = pTreasury:GetTotalMaintenance();
 
-    -- Add resources
-    for eResourceType,amount in pairs(data.Resources) do
-      if kResources[eResourceType] == nil then
-        kResources[eResourceType] = {
-          CityList = {},
-          Icon = "[ICON_"..GameInfo.Resources[eResourceType].ResourceType.."]",
-          IsStrategic = GameInfo.Resources[eResourceType].ResourceClassType == "RESOURCECLASS_STRATEGIC",
-          Total = 0
-        };
-      end
-      table.insert( kResources[eResourceType].CityList,
-        {
-          CityName = cityName,
-          Amount = amount,
-        });
+	-- NET = Income - Expense
+	kCityTotalData.Net[YieldTypes.GOLD]			= kCityTotalData.Income[YieldTypes.GOLD] - kCityTotalData.Expenses[YieldTypes.GOLD];
+	kCityTotalData.Net[YieldTypes.FAITH]		= kCityTotalData.Income[YieldTypes.FAITH];
 
-      kResources[eResourceType].Total = kResources[eResourceType].Total + amount;
-    end
-  end
+	-- Treasury
+	kCityTotalData.Treasury[YieldTypes.CULTURE]		= Round( pCulture:GetCultureYield(), 0 );
+	kCityTotalData.Treasury[YieldTypes.FAITH]		= Round( pReligion:GetFaithBalance(), 0 );
+	kCityTotalData.Treasury[YieldTypes.GOLD]		= Round( pTreasury:GetGoldBalance(), 0 );
+	kCityTotalData.Treasury[YieldTypes.SCIENCE]		= Round( pScience:GetScienceYield(), 0 );
+	kCityTotalData.Treasury["TOURISM"]				= Round( kCityTotalData.Income["TOURISM"], 0 );
 
-  kCityTotalData.Expenses[YieldTypes.GOLD] = pTreasury:GetTotalMaintenance();
 
-  -- NET = Income - Expense
-  kCityTotalData.Net[YieldTypes.GOLD] = kCityTotalData.Income[YieldTypes.GOLD] - kCityTotalData.Expenses[YieldTypes.GOLD];
-  kCityTotalData.Net[YieldTypes.FAITH] = kCityTotalData.Income[YieldTypes.FAITH];
+	-- Units (TODO: Group units by promotion class and determine total maintenance cost)
+	local pUnits :table = player:GetUnits(); 	
+	for i, unit in pUnits:Members() do
+		--local unitTypeName = UnitManager.GetTypeName(unit)
+		--if "UNIT_SETTLER" == unitTypeName then
+		--end
+	end
 
-  -- Treasury
-  kCityTotalData.Treasury[YieldTypes.CULTURE] = Round( pCulture:GetCultureYield(), 0 );
-  kCityTotalData.Treasury[YieldTypes.FAITH] = Round( pReligion:GetFaithBalance(), 0 );
-  kCityTotalData.Treasury[YieldTypes.GOLD] = Round( pTreasury:GetGoldBalance(), 0 );
-  kCityTotalData.Treasury[YieldTypes.SCIENCE] = Round( pScience:GetScienceYield(), 0 );
-  kCityTotalData.Treasury["TOURISM"] = Round( kCityTotalData.Income["TOURISM"], 0 );
+	-- =================================================================
+	-- Current Deals Info (didn't wanna mess with diplomatic deal data
+	-- below, maybe later
+	-- =================================================================
+	local kCurrentDeals : table = {}
+	local kPlayers : table = PlayerManager.GetAliveMajors()
+	local iTotal = 0
 
-  -- Units (TODO: Group units by promotion class and determine total maintenance cost)
-  local pUnits :table = player:GetUnits();
-  for i, unit in pUnits:Members() do
-    --local unitTypeName = UnitManager.GetTypeName(unit)
-    --if "UNIT_SETTLER" == unitTypeName then
-    --end
-  end
+	for _, pOtherPlayer in ipairs( kPlayers ) do
+		local otherID:number = pOtherPlayer:GetID()
+		if  otherID ~= playerID then
+			
+			local pPlayerConfig	:table = PlayerConfigurations[otherID]
+			local pDeals		:table = DealManager.GetPlayerDeals( playerID, otherID )
+			
+			if pDeals ~= nil then
 
-  -- =================================================================
-  -- Current Deals Info (didn't wanna mess with diplomatic deal data
-  -- below, maybe later
-  -- =================================================================
-  local kCurrentDeals : table = {}
-  local kPlayers : table = PlayerManager.GetAliveMajors()
-  local iTotal = 0
+				for i, pDeal in ipairs( pDeals ) do
+					iTotal = iTotal + 1
 
-  for _, pOtherPlayer in ipairs( kPlayers ) do
-    local otherID:number = pOtherPlayer:GetID()
-    if otherID ~= playerID then
+					local Receiving : table = { Agreements = {}, Gold = {}, Resources = {} }
+					local Sending : table = { Agreements = {}, Gold = {}, Resources = {} }
 
-      local pPlayerConfig :table = PlayerConfigurations[otherID]
-      local pDeals :table = DealManager.GetPlayerDeals( playerID, otherID )
+					Receiving.Resources = pDeal:FindItemsByType( DealItemTypes.RESOURCES, DealItemSubTypes.NONE, otherID )
+					Receiving.Gold = pDeal:FindItemsByType( DealItemTypes.GOLD, DealItemSubTypes.NONE, otherID )
+					Receiving.Agreements = pDeal:FindItemsByType( DealItemTypes.AGREEMENTS, DealItemSubTypes.NONE, otherID )
 
-      if pDeals ~= nil then
+					Sending.Resources = pDeal:FindItemsByType( DealItemTypes.RESOURCES, DealItemSubTypes.NONE, playerID )
+					Sending.Gold = pDeal:FindItemsByType( DealItemTypes.GOLD, DealItemSubTypes.NONE, playerID )
+					Sending.Agreements = pDeal:FindItemsByType( DealItemTypes.AGREEMENTS, DealItemSubTypes.NONE, playerID )
 
-        for i, pDeal in ipairs( pDeals ) do
-          iTotal = iTotal + 1
+					kCurrentDeals[iTotal] =
+					{
+						WithCivilization = Locale.Lookup( pPlayerConfig:GetCivilizationDescription() ),
+						EndTurn = 0,
+						Receiving = {},
+						Sending = {}
+					}
 
-          local Receiving : table = { Agreements = {}, Gold = {}, Resources = {} }
-          local Sending : table = { Agreements = {}, Gold = {}, Resources = {} }
+					local iDeal = 0
 
-          Receiving.Resources = pDeal:FindItemsByType( DealItemTypes.RESOURCES, DealItemSubTypes.NONE, otherID )
-          Receiving.Gold = pDeal:FindItemsByType( DealItemTypes.GOLD, DealItemSubTypes.NONE, otherID )
-          Receiving.Agreements = pDeal:FindItemsByType( DealItemTypes.AGREEMENTS, DealItemSubTypes.NONE, otherID )
+					for pReceivingName, pReceivingGroup in pairs( Receiving ) do
+						for _, pDealItem in ipairs( pReceivingGroup ) do
 
-          Sending.Resources = pDeal:FindItemsByType( DealItemTypes.RESOURCES, DealItemSubTypes.NONE, playerID )
-          Sending.Gold = pDeal:FindItemsByType( DealItemTypes.GOLD, DealItemSubTypes.NONE, playerID )
-          Sending.Agreements = pDeal:FindItemsByType( DealItemTypes.AGREEMENTS, DealItemSubTypes.NONE, playerID )
+							iDeal = iDeal + 1
 
-          kCurrentDeals[iTotal] =
-          {
-            WithCivilization = Locale.Lookup( pPlayerConfig:GetCivilizationDescription() ),
-            EndTurn = 0,
-            Receiving = {},
-            Sending = {}
-          }
+							kCurrentDeals[iTotal].EndTurn = pDealItem:GetEndTurn()
+							kCurrentDeals[iTotal].Receiving[iDeal] = { Amount = pDealItem:GetAmount() }
 
-          local iDeal = 0
+							local deal = kCurrentDeals[iTotal].Receiving[iDeal]
 
-          for pReceivingName, pReceivingGroup in pairs( Receiving ) do
-            for _, pDealItem in ipairs( pReceivingGroup ) do
+							if pReceivingName == "Agreements" then
+								deal.Name = pDealItem:GetSubTypeNameID()
+							elseif pReceivingName == "Gold" then
+								deal.Name = deal.Amount .. " Gold Per Turn"
+								deal.Icon = "[ICON_GOLD]"
+							else
+								if deal.Amount > 1 then
+									deal.Name = pDealItem:GetValueTypeNameID() .. "(" .. deal.Amount .. ")"
+								else
+									deal.Name = pDealItem:GetValueTypeNameID()
+								end
+								deal.Icon = "[ICON_" .. pDealItem:GetValueTypeID() .. "]"
+							end
 
-              iDeal = iDeal + 1
+							deal.Name = Locale.Lookup( deal.Name )
+						end
+					end
 
-              kCurrentDeals[iTotal].EndTurn = pDealItem:GetEndTurn()
-              kCurrentDeals[iTotal].Receiving[iDeal] = { Amount = pDealItem:GetAmount() }
+					iDeal = 0
 
-              local deal = kCurrentDeals[iTotal].Receiving[iDeal]
+					for pSendingName, pSendingGroup in pairs( Sending ) do
+						for _, pDealItem in ipairs( pSendingGroup ) do
 
-              if pReceivingName == "Agreements" then
-                deal.Name = pDealItem:GetSubTypeNameID()
-              elseif pReceivingName == "Gold" then
-                deal.Name = deal.Amount .. " Gold Per Turn"
-                deal.Icon = "[ICON_GOLD]"
-              else
-                if deal.Amount > 1 then
-                  deal.Name = pDealItem:GetValueTypeNameID() .. "(" .. deal.Amount .. ")"
-                else
-                  deal.Name = pDealItem:GetValueTypeNameID()
-                end
-                deal.Icon = "[ICON_" .. pDealItem:GetValueTypeID() .. "]"
-              end
+							iDeal = iDeal + 1
 
-              deal.Name = Locale.Lookup( deal.Name )
-            end
-          end
+							kCurrentDeals[iTotal].EndTurn = pDealItem:GetEndTurn()
+							kCurrentDeals[iTotal].Sending[iDeal] = { Amount = pDealItem:GetAmount() }
+							
+							local deal = kCurrentDeals[iTotal].Sending[iDeal]
 
-          iDeal = 0
+							if pSendingName == "Agreements" then
+								deal.Name = pDealItem:GetSubTypeNameID()
+							elseif pSendingName == "Gold" then
+								deal.Name = deal.Amount .. " Gold Per Turn"
+								deal.Icon = "[ICON_GOLD]"
+							else
+								if deal.Amount > 1 then
+									deal.Name = pDealItem:GetValueTypeNameID() .. "(" .. deal.Amount .. ")"
+								else
+									deal.Name = pDealItem:GetValueTypeNameID()
+								end
+								deal.Icon = "[ICON_" .. pDealItem:GetValueTypeID() .. "]"
+							end
 
-          for pSendingName, pSendingGroup in pairs( Sending ) do
-            for _, pDealItem in ipairs( pSendingGroup ) do
+							deal.Name = Locale.Lookup( deal.Name )
+						end
+					end
+				end
+			end
+		end
+	end
 
-              iDeal = iDeal + 1
+	-- =================================================================
+	
+	
+	local kDealData	:table = {};
+	local kPlayers	:table = PlayerManager.GetAliveMajors();
+	for _, pOtherPlayer in ipairs(kPlayers) do
+		local otherID:number = pOtherPlayer:GetID();
+		if  otherID ~= playerID then			
+			
+			local pPlayerConfig	:table = PlayerConfigurations[otherID];
+			local pDeals		:table = DealManager.GetPlayerDeals(playerID, otherID);
+			
+			if pDeals ~= nil then
+				for i,pDeal in ipairs(pDeals) do
+					if pDeal:IsValid() then
+						-- Add outgoing gold deals
+						local pOutgoingDeal :table	= pDeal:FindItemsByType(DealItemTypes.GOLD, DealItemSubTypes.NONE, playerID);
+						if pOutgoingDeal ~= nil then
+							for i,pDealItem in ipairs(pOutgoingDeal) do
+								local duration		:number = pDealItem:GetDuration();
+								if duration ~= 0 then
+									local gold :number = pDealItem:GetAmount();
+									table.insert( kDealData, {
+										Type		= DealItemTypes.GOLD,
+										Amount		= gold,
+										Duration	= duration,
+										IsOutgoing	= true,
+										PlayerID	= otherID,
+										Name		= Locale.Lookup( pPlayerConfig:GetCivilizationDescription() )
+									});						
+								end
+							end
+						end
 
-              kCurrentDeals[iTotal].EndTurn = pDealItem:GetEndTurn()
-              kCurrentDeals[iTotal].Sending[iDeal] = { Amount = pDealItem:GetAmount() }
+						-- Add outgoing resource deals
+						pOutgoingDeal = pDeal:FindItemsByType(DealItemTypes.RESOURCES, DealItemSubTypes.NONE, playerID);
+						if pOutgoingDeal ~= nil then
+							for i,pDealItem in ipairs(pOutgoingDeal) do
+								local duration		:number = pDealItem:GetDuration();
+								if duration ~= 0 then
+									local amount		:number = pDealItem:GetAmount();
+									local resourceType	:number = pDealItem:GetValueType();
+									table.insert( kDealData, {
+										Type			= DealItemTypes.RESOURCES,
+										ResourceType	= resourceType,
+										Amount			= amount,
+										Duration		= duration,
+										IsOutgoing		= true,
+										PlayerID		= otherID,
+										Name			= Locale.Lookup( pPlayerConfig:GetCivilizationDescription() )
+									});
+									
+									local entryString:string = Locale.Lookup("LOC_HUD_REPORTS_ROW_DIPLOMATIC_DEALS") .. " (" .. Locale.Lookup(pPlayerConfig:GetPlayerName()) .. ")";
+									AddResourceData(kResources, resourceType, entryString, "LOC_HUD_REPORTS_TRADE_EXPORTED", -1 * amount);				
+								end
+							end
+						end
+					
+						-- Add incoming gold deals
+						local pIncomingDeal :table = pDeal:FindItemsByType(DealItemTypes.GOLD, DealItemSubTypes.NONE, otherID);
+						if pIncomingDeal ~= nil then
+							for i,pDealItem in ipairs(pIncomingDeal) do
+								local duration		:number = pDealItem:GetDuration();
+								if duration ~= 0 then
+									local gold :number = pDealItem:GetAmount()
+									table.insert( kDealData, {
+										Type		= DealItemTypes.GOLD;
+										Amount		= gold,
+										Duration	= duration,
+										IsOutgoing	= false,
+										PlayerID	= otherID,
+										Name		= Locale.Lookup( pPlayerConfig:GetCivilizationDescription() )
+									});						
+								end
+							end
+						end
 
-              local deal = kCurrentDeals[iTotal].Sending[iDeal]
+						-- Add incoming resource deals
+						pIncomingDeal = pDeal:FindItemsByType(DealItemTypes.RESOURCES, DealItemSubTypes.NONE, otherID);
+						if pIncomingDeal ~= nil then
+							for i,pDealItem in ipairs(pIncomingDeal) do
+								local duration		:number = pDealItem:GetDuration();
+								if duration ~= 0 then
+									local amount		:number = pDealItem:GetAmount();
+									local resourceType	:number = pDealItem:GetValueType();
+									table.insert( kDealData, {
+										Type			= DealItemTypes.RESOURCES,
+										ResourceType	= resourceType,
+										Amount			= amount,
+										Duration		= duration,
+										IsOutgoing		= false,
+										PlayerID		= otherID,
+										Name			= Locale.Lookup( pPlayerConfig:GetCivilizationDescription() )
+									});
+									
+									local entryString:string = Locale.Lookup("LOC_HUD_REPORTS_ROW_DIPLOMATIC_DEALS") .. " (" .. Locale.Lookup(pPlayerConfig:GetPlayerName()) .. ")";
+									AddResourceData(kResources, resourceType, entryString, "LOC_HUD_REPORTS_TRADE_IMPORTED", amount);				
+								end
+							end
+						end
+					end	
+				end							
+			end
 
-              if pSendingName == "Agreements" then
-                deal.Name = pDealItem:GetSubTypeNameID()
-              elseif pSendingName == "Gold" then
-                deal.Name = deal.Amount .. " Gold Per Turn"
-                deal.Icon = "[ICON_GOLD]"
-              else
-                if deal.Amount > 1 then
-                  deal.Name = pDealItem:GetValueTypeNameID() .. "(" .. deal.Amount .. ")"
-                else
-                  deal.Name = pDealItem:GetValueTypeNameID()
-                end
-                deal.Icon = "[ICON_" .. pDealItem:GetValueTypeID() .. "]"
-              end
+		end
+	end
 
-              deal.Name = Locale.Lookup( deal.Name )
-            end
-          end
-        end
-      end
-    end
-  end
+	-- Add resources provided by city states
+	for i, pMinorPlayer in ipairs(PlayerManager.GetAliveMinors()) do
+		local pMinorPlayerInfluence:table = pMinorPlayer:GetInfluence();		
+		if pMinorPlayerInfluence ~= nil then
+			local suzerainID:number = pMinorPlayerInfluence:GetSuzerain();
+			if suzerainID == playerID then
+				for row in GameInfo.Resources() do
+					local resourceAmount:number =  pMinorPlayer:GetResources():GetExportedResourceAmount(row.Index);
+					if resourceAmount > 0 then
+						local pMinorPlayerConfig:table = PlayerConfigurations[pMinorPlayer:GetID()];
+						local entryString:string = Locale.Lookup("LOC_HUD_REPORTS_CITY_STATE") .. " (" .. Locale.Lookup(pMinorPlayerConfig:GetPlayerName()) .. ")";
+						AddResourceData(kResources, row.Index, entryString, "LOC_CITY_STATES_SUZERAIN", resourceAmount);
+					end
+				end
+			end
+		end
+	end
 
-  -- =================================================================
+	-- Assume that resources not yet accounted for have come from Great People
+	if pResources then
+		for row in GameInfo.Resources() do
+			local internalResourceAmount:number = pResources:GetResourceAmount(row.Index);
+			if (internalResourceAmount > 0) then
+				if (kResources[row.Index] ~= nil) then
+					if (internalResourceAmount > kResources[row.Index].Total) then
+						AddResourceData(kResources, row.Index, "LOC_GOVT_FILTER_GREAT_PERSON", "-", internalResourceAmount - kResources[row.Index].Total);
+					end
+				else
+					AddResourceData(kResources, row.Index, "LOC_GOVT_FILTER_GREAT_PERSON", "-", internalResourceAmount);
+				end
+			end
+		end
+	end
 
-  local kDealData :table = {};
-  local kPlayers :table = PlayerManager.GetAliveMajors();
-  for _, pOtherPlayer in ipairs(kPlayers) do
-    local otherID:number = pOtherPlayer:GetID();
-    if otherID ~= playerID then
-
-      local pPlayerConfig :table = PlayerConfigurations[otherID];
-      local pDeals :table = DealManager.GetPlayerDeals(playerID, otherID);
-
-      if pDeals ~= nil then
-        for i,pDeal in ipairs(pDeals) do
-          if pDeal:IsValid() then
-            local pOutgoingDeal :table = pDeal:FindItemsByType(DealItemTypes.GOLD, DealItemSubTypes.NONE, playerID);
-            if pOutgoingDeal ~= nil then
-              for i,pDealItem in ipairs(pOutgoingDeal) do
-                local duration :number = pDealItem:GetDuration();
-                if duration ~= 0 then
-                  local gold :number = pDealItem:GetAmount()
-                  table.insert( kDealData, {
-                      Amount = gold,
-                      Duration = duration,
-                      Duration = pDealItem:GetEndTurn(),
-                      IsOutgoing = true,
-                      PlayerID = otherID,
-                      Name = Locale.Lookup( pPlayerConfig:GetCivilizationDescription() )
-                    });
-                end
-              end
-            end
-
-            local pIncomingDeal :table = pDeal:FindItemsByType(DealItemTypes.GOLD, DealItemSubTypes.NONE, otherID);
-
-            if pIncomingDeal ~= nil then
-              for i,pDealItem in ipairs(pIncomingDeal) do
-                local duration :number = pDealItem:GetDuration();
-                if duration ~= 0 then
-                  local gold :number = pDealItem:GetAmount()
-                  table.insert( kDealData, {
-                      Amount = gold,
-                      Duration = duration,
-                      IsOutgoing = false,
-                      PlayerID = otherID,
-                      Name = Locale.Lookup( pPlayerConfig:GetCivilizationDescription() )
-                    });
-                end
-              end
-            end
-          end
-        end
-      end
-
-    end
-  end
-
-  --print("Debug stuff: ", table.count(kDealData) );
-
-  return kCityData, kCityTotalData, kResources, kUnitData, kDealData, pCulture, kCurrentDeals
+	-- !! changed
+	--return kCityData, kCityTotalData, kResources, kUnitData, kDealData;
+	return kCityData, kCityTotalData, kResources, kUnitData, kDealData, pCulture, kCurrentDeals
 end
 
 -- ===========================================================================
--- Obtain the total resources for a given city.
+function AddResourceData( kResources:table, eResourceType:number, EntryString:string, ControlString:string, InAmount:number)
+	local kResource :table = GameInfo.Resources[eResourceType];
+
+	if kResources[eResourceType] == nil then
+		kResources[eResourceType] = {
+			EntryList	= {},
+			Icon		= "[ICON_"..kResource.ResourceType.."]",
+			IsStrategic	= kResource.ResourceClassType == "RESOURCECLASS_STRATEGIC",
+			IsLuxury	= GameInfo.Resources[eResourceType].ResourceClassType == "RESOURCECLASS_LUXURY",
+			IsBonus		= GameInfo.Resources[eResourceType].ResourceClassType == "RESOURCECLASS_BONUS",
+			Total		= 0
+		};
+	end
+
+	table.insert( kResources[eResourceType].EntryList, 
+	{
+		EntryText	= EntryString,
+		ControlText = ControlString,
+		Amount		= InAmount,					
+	});
+
+	kResources[eResourceType].Total = kResources[eResourceType].Total + InAmount;
+end
+
+-- ===========================================================================
+--	Obtain the total resources for a given city.
 -- ===========================================================================
 function GetCityResourceData( pCity:table )
 
-  -- Loop through all the plots for a given city; tallying the resource amount.
-  local kResources : table = {};
-  local cityPlots : table = Map.GetCityPlots():GetPurchasedPlots(pCity)
-  for _, plotID in ipairs(cityPlots) do
-    local plot : table = Map.GetPlotByIndex(plotID)
-    local plotX : number = plot:GetX()
-    local plotY : number = plot:GetY()
-    local eResourceType : number = plot:GetResourceType();
+	-- Loop through all the plots for a given city; tallying the resource amount.
+	local kResources : table = {};
+	local cityPlots : table = Map.GetCityPlots():GetPurchasedPlots(pCity)
+	for _, plotID in ipairs(cityPlots) do
+		local plot			: table = Map.GetPlotByIndex(plotID)
+		local plotX			: number = plot:GetX()
+		local plotY			: number = plot:GetY()
+		local eResourceType : number = plot:GetResourceType();
 
-    -- TODO: Account for trade/diplomacy resources.
-    if eResourceType ~= -1 and Players[pCity:GetOwner()]:GetResources():IsResourceExtractableAt(plot) then
-      if kResources[eResourceType] == nil then
-        kResources[eResourceType] = 1;
-      else
-        kResources[eResourceType] = kResources[eResourceType] + 1;
-      end
-    end
-  end
-  return kResources;
+		-- TODO: Account for trade/diplomacy resources.
+		if eResourceType ~= -1 and Players[pCity:GetOwner()]:GetResources():IsResourceExtractableAt(plot) then
+			if kResources[eResourceType] == nil then
+				kResources[eResourceType] = 1;
+			else
+				kResources[eResourceType] = kResources[eResourceType] + 1;
+			end
+		end
+	end
+	return kResources;
 end
 
 -- ===========================================================================
--- Obtain the yields from the worked plots
+--	Obtain the yields from the worked plots
 -- ===========================================================================
 function GetWorkedTileYieldData( pCity:table, pCulture:table )
 
-  -- Loop through all the plots for a given city; tallying the resource amount.
-  local kYields : table = {
-    YIELD_PRODUCTION= 0,
-    YIELD_FOOD = 0,
-    YIELD_GOLD = 0,
-    YIELD_FAITH = 0,
-    YIELD_SCIENCE = 0,
-    YIELD_CULTURE = 0,
-    TOURISM = 0,
-  };
-  local cityPlots : table = Map.GetCityPlots():GetPurchasedPlots(pCity);
-  local pCitizens : table = pCity:GetCitizens();
-  for _, plotID in ipairs(cityPlots) do
-    local plot : table = Map.GetPlotByIndex(plotID);
-    local x : number = plot:GetX();
-    local y : number = plot:GetY();
-    isPlotWorked = pCitizens:IsPlotWorked(x,y);
-    if isPlotWorked then
-      for row in GameInfo.Yields() do
-        kYields[row.YieldType] = kYields[row.YieldType] + plot:GetYield(row.Index);
-      end
-    end
+	-- Loop through all the plots for a given city; tallying the resource amount.
+	local kYields : table = {
+		YIELD_PRODUCTION= 0,
+		YIELD_FOOD		= 0,
+		YIELD_GOLD		= 0,
+		YIELD_FAITH		= 0,
+		YIELD_SCIENCE	= 0,
+		YIELD_CULTURE	= 0,
+		TOURISM			= 0,
+	};
+	local cityPlots : table = Map.GetCityPlots():GetPurchasedPlots(pCity);
+	local pCitizens	: table = pCity:GetCitizens();	
+	for _, plotID in ipairs(cityPlots) do		
+		local plot	: table = Map.GetPlotByIndex(plotID);
+		local x		: number = plot:GetX();
+		local y		: number = plot:GetY();
+		isPlotWorked = pCitizens:IsPlotWorked(x,y);
+		if isPlotWorked then
+			for row in GameInfo.Yields() do			
+				kYields[row.YieldType] = kYields[row.YieldType] + plot:GetYield(row.Index);				
+			end
+		end
 
-    -- Support tourism.
-    -- Not a common yield, and only exposure from game core is based off
-    -- of the plot so the sum is easily shown, but it's not possible to
-    -- show how individual buildings contribute... yet.
-    kYields["TOURISM"] = kYields["TOURISM"] + pCulture:GetTourismAt( plotID );
-  end
-  return kYields;
+		-- Support tourism.
+		-- Not a common yield, and only exposure from game core is based off
+		-- of the plot so the sum is easily shown, but it's not possible to 
+		-- show how individual buildings contribute... yet.
+		kYields["TOURISM"] = kYields["TOURISM"] + pCulture:GetTourismAt( plotID );
+	end
+	return kYields;
 end
 
+
+
 -- ===========================================================================
--- Set a group to it's proper collapse/open state
--- Set + - in group row
+--	Set a group to it's proper collapse/open state
+--	Set + - in group row
 -- ===========================================================================
 function RealizeGroup( instance:table )
-  local v :number = (instance["isCollapsed"]==false and instance.RowExpandCheck:GetSizeY() or 0);
-  instance.RowExpandCheck:SetTextureOffsetVal(0, v);
+	local v :number = (instance["isCollapsed"]==false and instance.RowExpandCheck:GetSizeY() or 0);
+	instance.RowExpandCheck:SetTextureOffsetVal(0, v);
 
-  instance.ContentStack:CalculateSize();
-  instance.CollapseScroll:CalculateSize();
+	instance.ContentStack:CalculateSize();	
+	instance.CollapseScroll:CalculateSize();
+	
+	local groupHeight	:number = instance.ContentStack:GetSizeY();
+	instance.CollapseAnim:SetBeginVal(0, -(groupHeight - instance["CollapsePadding"]));
+	instance.CollapseScroll:SetSizeY( groupHeight );				
 
-  local groupHeight :number = instance.ContentStack:GetSizeY();
-  instance.CollapseAnim:SetBeginVal(0, -(groupHeight - instance["CollapsePadding"]));
-  instance.CollapseScroll:SetSizeY( groupHeight );
-
-  instance.Top:ReprocessAnchoring();
+	instance.Top:ReprocessAnchoring();
 end
 
 -- ===========================================================================
--- Callback
--- Expand or contract a group based on its existing state.
+--	Callback
+--	Expand or contract a group based on its existing state.
 -- ===========================================================================
 function OnToggleCollapseGroup( instance:table )
-  instance["isCollapsed"] = not instance["isCollapsed"];
-  instance.CollapseAnim:Reverse();
-  RealizeGroup( instance );
+	instance["isCollapsed"] = not instance["isCollapsed"];
+	instance.CollapseAnim:Reverse();
+	RealizeGroup( instance );
 end
 
 -- ===========================================================================
--- Toggle a group expanding / collapsing
--- instance, A group instance.
+--	Toggle a group expanding / collapsing
+--	instance,	A group instance.
 -- ===========================================================================
 function OnAnimGroupCollapse( instance:table)
-  -- Helper
-  function lerp(y1:number,y2:number,x:number)
-    return y1 + (y2-y1)*x;
-  end
-  local groupHeight :number = instance.ContentStack:GetSizeY();
-  local collapseHeight:number = instance["CollapsePadding"]~=nil and instance["CollapsePadding"] or 0;
-  local startY :number = instance["isCollapsed"]==true and groupHeight or collapseHeight;
-  local endY :number = instance["isCollapsed"]==false and groupHeight or collapseHeight;
-  local progress :number = instance.CollapseAnim:GetProgress();
-  local sizeY :number = lerp(startY,endY,progress);
+		-- Helper
+	function lerp(y1:number,y2:number,x:number)
+		return y1 + (y2-y1)*x;
+	end
+	local groupHeight	:number = instance.ContentStack:GetSizeY();
+	local collapseHeight:number = instance["CollapsePadding"]~=nil and instance["CollapsePadding"] or 0;
+	local startY		:number = instance["isCollapsed"]==true  and groupHeight or collapseHeight;
+	local endY			:number = instance["isCollapsed"]==false and groupHeight or collapseHeight;
+	local progress		:number = instance.CollapseAnim:GetProgress();
+	local sizeY			:number = lerp(startY,endY,progress);
 
-  instance.CollapseAnim:SetSizeY( groupHeight );
-  instance.CollapseScroll:SetSizeY( sizeY );
-  instance.ContentStack:ReprocessAnchoring();
-  instance.Top:ReprocessAnchoring()
+	instance.CollapseAnim:SetSizeY( groupHeight );		
+	instance.CollapseScroll:SetSizeY( sizeY );	
+	instance.ContentStack:ReprocessAnchoring();	
+	instance.Top:ReprocessAnchoring()
 
-  Controls.Stack:CalculateSize();
-  Controls.Scroll:CalculateSize();
+	Controls.Stack:CalculateSize();
+	Controls.Scroll:CalculateSize();			
 end
+
 
 -- ===========================================================================
 function SetGroupCollapsePadding( instance:table, amount:number )
-  instance["CollapsePadding"] = amount;
+	instance["CollapsePadding"] = amount;
 end
+
 
 -- ===========================================================================
 function ResetTabForNewPageContent()
-  m_uiGroups = {};
-  m_simpleIM:ResetInstances();
-  m_groupIM:ResetInstances();
-  Controls.Scroll:SetScrollValue( 0 );
-  Controls.CityBuildingsCheckbox:SetHide( true )
+	m_uiGroups = {};
+	m_simpleIM:ResetInstances();
+	m_groupIM:ResetInstances();
+	Controls.Scroll:SetScrollValue( 0 );
 
-  bUnits = { group = nil, parent = nil, type = "" }
+	-- !! added
+	bUnits = { group = nil, parent = nil, type = "" }
 end
 
+
 -- ===========================================================================
--- Instantiate a new collapsable row (group) holder & wire it up.
--- ARGS: (optional) isCollapsed
--- RETURNS: New group instance
+--	Instantiate a new collapsable row (group) holder & wire it up.
+--	ARGS:	(optional) isCollapsed
+--	RETURNS: New group instance
 -- ===========================================================================
 function NewCollapsibleGroupInstance( isCollapsed:boolean )
+	if isCollapsed == nil then
+		isCollapsed = false;
+	end
+	local instance:table = m_groupIM:GetInstance();	
+	instance.ContentStack:DestroyAllChildren();
+	instance["isCollapsed"]		= isCollapsed;
+	instance["CollapsePadding"] = nil;				-- reset any prior collapse padding
 
-  if isCollapsed == nil then
-    isCollapsed = false;
-  end
+	-- !! added
+	instance["Children"] = {}
+	instance["Descend"] = false
+	-- !!
 
-  local instance:table = m_groupIM:GetInstance();
+	instance.CollapseAnim:SetToBeginning();
+	if isCollapsed == false then
+		instance.CollapseAnim:SetToEnd();
+	end
 
-  instance.ContentStack:DestroyAllChildren();
-  instance["isCollapsed"] = isCollapsed;
-  instance["CollapsePadding"] = nil; -- reset any prior collapse padding
-  instance["Children"] = {}
-  instance["Descend"] = false
+	instance.RowHeaderLabel:SetHide( true )
 
-  instance.CollapseAnim:SetToBeginning();
+	instance.RowHeaderButton:RegisterCallback( Mouse.eLClick, function() OnToggleCollapseGroup(instance); end );			
+  	instance.RowHeaderButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
 
-  if isCollapsed == false then
-    instance.CollapseAnim:SetToEnd();
-  end
+	instance.CollapseAnim:RegisterAnimCallback(               function() OnAnimGroupCollapse( instance ); end );
 
-  instance.RowHeaderLabel:SetHide( true )
+	table.insert( m_uiGroups, instance );
 
-  instance.RowHeaderButton:RegisterCallback( Mouse.eLClick, function() OnToggleCollapseGroup(instance); end );
-  instance.RowHeaderButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end );
-
-  instance.CollapseAnim:RegisterAnimCallback( function() OnAnimGroupCollapse( instance ); end );
-
-  table.insert( m_uiGroups, instance );
-
-  return instance;
+	return instance;
 end
 
+
 -- ===========================================================================
--- debug - Create a test page.
+--	debug - Create a test page.
 -- ===========================================================================
 function ViewTestPage()
 
-  ResetTabForNewPageContent();
+	ResetTabForNewPageContent();
 
-  local instance:table = NewCollapsibleGroupInstance();
-  instance.RowHeaderButton:SetText( "Test City Icon 1" );
-  instance.Top:SetID("foo");
+	local instance:table = NewCollapsibleGroupInstance();	
+	instance.RowHeaderButton:SetText( "Test City Icon 1" );
+	instance.Top:SetID("foo");
+	
+	local pHeaderInstance:table = {}
+	ContextPtr:BuildInstanceForControl( "CityIncomeHeaderInstance", pHeaderInstance, instance.ContentStack ) ;	
 
-  local pHeaderInstance:table = {}
-  ContextPtr:BuildInstanceForControl( "CityIncomeHeaderInstance", pHeaderInstance, instance.ContentStack ) ;
+	local pCityInstance:table = {};
+	ContextPtr:BuildInstanceForControl( "CityIncomeInstance", pCityInstance, instance.ContentStack ) ;
 
-  local pCityInstance:table = {};
-  ContextPtr:BuildInstanceForControl( "CityIncomeInstance", pCityInstance, instance.ContentStack ) ;
+	for i=1,3,1 do
+		local pLineItemInstance:table = {};
+		ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
+	end
 
-  for i=1,3,1 do
-    local pLineItemInstance:table = {};
-    ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
-  end
-
-  local pFooterInstance:table = {};
-  ContextPtr:BuildInstanceForControl("CityIncomeFooterInstance", pFooterInstance, instance.ContentStack );
-
-  SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
-  RealizeGroup( instance );
-
-  Controls.BottomYieldTotals:SetHide( true );
-  Controls.BottomResourceTotals:SetHide( true );
-  Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - (Controls.BottomYieldTotals:GetSizeY() + SIZE_HEIGHT_PADDING_BOTTOM_ADJUST ) );
+	local pFooterInstance:table = {};
+	ContextPtr:BuildInstanceForControl("CityIncomeFooterInstance", pFooterInstance, instance.ContentStack  );
+	
+	SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
+	RealizeGroup( instance );
+	
+	Controls.BottomYieldTotals:SetHide( true );
+	Controls.BottomResourceTotals:SetHide( true );
+	Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - (Controls.BottomYieldTotals:GetSizeY() + SIZE_HEIGHT_PADDING_BOTTOM_ADJUST ) );
 end
+
+-- !! sort features for income
 
 local sort : table = { by = "CityName", descend = true }
 
 local function sortBy( name )
 
-  if name == sort.by then
-    sort.descend = not sort.descend
-  else
-    sort.by = name
-    sort.descend = true
-  end
+	if name == sort.by then
+		sort.descend = not sort.descend
+	else
+		sort.by = name
+		sort.descend = true
+	end
 
-  ViewYieldsPage()
+	ViewYieldsPage()
 
 end
 
 local function sortFunction( t, a, b )
 
-  if sort.by == "TourismPerTurn" then
-    if sort.descend then
-      return t[b].WorkedTileYields["TOURISM"] < t[a].WorkedTileYields["TOURISM"]
-    else
-      return t[b].WorkedTileYields["TOURISM"] > t[a].WorkedTileYields["TOURISM"]
-    end
-  else
-    if sort.descend then
-      return t[b][sort.by] < t[a][sort.by]
-    else
-      return t[b][sort.by] > t[a][sort.by]
-    end
-  end
+	if sort.by == "TourismPerTurn" then
+		if sort.descend then
+			return t[b].WorkedTileYields["TOURISM"] < t[a].WorkedTileYields["TOURISM"]
+		else
+			return t[b].WorkedTileYields["TOURISM"] > t[a].WorkedTileYields["TOURISM"]
+		end
+	else
+		if sort.descend then
+			return t[b][sort.by] < t[a][sort.by]
+		else
+			return t[b][sort.by] > t[a][sort.by]
+		end
+	end
 
 end
 
 function cityincome_fields( kCityData, pCityInstance )
 
-  pCityInstance.CityName:SetText( Locale.Lookup( kCityData.CityName ) );
+	pCityInstance.CityName:SetText( Locale.Lookup( kCityData.CityName ) );
 
-  -- Current Production
-  local kCurrentProduction:table = kCityData.ProductionQueue[1];
-  pCityInstance.CurrentProduction:SetHide( kCurrentProduction == nil );
+	-- Current Production
+	local kCurrentProduction:table = kCityData.ProductionQueue[1];
+	pCityInstance.CurrentProduction:SetHide( kCurrentProduction == nil );
+	
+	if kCurrentProduction ~= nil then
+		local tooltip:string = Locale.Lookup(kCurrentProduction.Name);
+		
+		if kCurrentProduction.Description ~= nil then
+			tooltip = tooltip .. "[NEWLINE]" .. Locale.Lookup(kCurrentProduction.Description);
+		end
+	
+		pCityInstance.CurrentProduction:SetToolTipString( tooltip )
 
-  if kCurrentProduction ~= nil then
-    local tooltip:string = Locale.Lookup(kCurrentProduction.Name);
+		if kCurrentProduction.Icon then
+			pCityInstance.CityBannerBackground:SetHide( false );
+			pCityInstance.CurrentProduction:SetIcon( kCurrentProduction.Icon );
+			pCityInstance.CityProductionMeter:SetPercent( kCurrentProduction.PercentComplete );
+			pCityInstance.CityProductionNextTurn:SetPercent( kCurrentProduction.PercentCompleteNextTurn );			
+			pCityInstance.ProductionBorder:SetHide( kCurrentProduction.Type == ProductionType.DISTRICT );
+		else
+			pCityInstance.CityBannerBackground:SetHide( true );
+		end
+	end
 
-    if kCurrentProduction.Description ~= nil then
-      tooltip = tooltip .. "[NEWLINE]" .. Locale.Lookup(kCurrentProduction.Description);
-    end
+	pCityInstance.Production:SetText( toPlusMinusString(kCityData.ProductionPerTurn) );
+	pCityInstance.Food:SetText( toPlusMinusString(kCityData.FoodPerTurn) );
+	pCityInstance.Gold:SetText( toPlusMinusString(kCityData.GoldPerTurn) );
+	pCityInstance.Faith:SetText( toPlusMinusString(kCityData.FaithPerTurn) );
+	pCityInstance.Science:SetText( toPlusMinusString(kCityData.SciencePerTurn) );
+	pCityInstance.Culture:SetText( toPlusMinusString(kCityData.CulturePerTurn) );
+	pCityInstance.Tourism:SetText( toPlusMinusString(kCityData.WorkedTileYields["TOURISM"]) );
+	
+	if not Controls.CityBuildingsCheckbox:IsSelected() then
+		-- Compute tiles worked by setting to total and subtracting all the things...
+		local productionTilesWorked :number = kCityData.ProductionPerTurn;
+		local foodTilesWorked		:number = kCityData.FoodPerTurn;
+		local goldTilesWorked		:number = kCityData.GoldPerTurn;
+		local faithTilesWorked		:number = kCityData.FaithPerTurn;
+		local scienceTilesWorked	:number = kCityData.SciencePerTurn;
+		local cultureTilesWorked	:number = kCityData.CulturePerTurn;
 
-    pCityInstance.CurrentProduction:SetToolTipString( tooltip )
+		for i,kDistrict in ipairs(kCityData.BuildingsAndDistricts) do			
+			for i,kBuilding in ipairs(kDistrict.Buildings) do
+				local pLineItemInstance:table = {};
+				ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
+				pLineItemInstance.LineItemName:SetText( kBuilding.Name );
 
-    if kCurrentProduction.Icon then
-      pCityInstance.CityBannerBackground:SetHide( false );
-      pCityInstance.CurrentProduction:SetIcon( kCurrentProduction.Icon );
-      pCityInstance.CityProductionMeter:SetPercent( kCurrentProduction.PercentComplete );
-      pCityInstance.CityProductionNextTurn:SetPercent( kCurrentProduction.PercentCompleteNextTurn );
-      pCityInstance.ProductionBorder:SetHide( kCurrentProduction.Type == ProductionType.DISTRICT );
-    else
-      pCityInstance.CityBannerBackground:SetHide( true );
-    end
-  end
+				pLineItemInstance.Production:SetText( toPlusMinusNoneString(kBuilding.ProductionPerTurn) );
+				pLineItemInstance.Food:SetText( toPlusMinusNoneString(kBuilding.FoodPerTurn) );
+				pLineItemInstance.Gold:SetText( toPlusMinusNoneString(kBuilding.GoldPerTurn) );
+				pLineItemInstance.Faith:SetText( toPlusMinusNoneString(kBuilding.FaithPerTurn) );
+				pLineItemInstance.Science:SetText( toPlusMinusNoneString(kBuilding.SciencePerTurn) );
+				pLineItemInstance.Culture:SetText( toPlusMinusNoneString(kBuilding.CulturePerTurn) );
+				
+				productionTilesWorked	= productionTilesWorked - kBuilding.ProductionPerTurn;
+				foodTilesWorked			= foodTilesWorked		- kBuilding.FoodPerTurn;
+				goldTilesWorked			= goldTilesWorked		- kBuilding.GoldPerTurn;
+				faithTilesWorked		= faithTilesWorked		- kBuilding.FaithPerTurn;
+				scienceTilesWorked		= scienceTilesWorked	- kBuilding.SciencePerTurn;
+				cultureTilesWorked		= cultureTilesWorked	- kBuilding.CulturePerTurn;
+			end
+		end
 
-  pCityInstance.Production:SetText( toPlusMinusString(kCityData.ProductionPerTurn) );
-  pCityInstance.Food:SetText( toPlusMinusString(kCityData.FoodPerTurn) );
-  pCityInstance.Gold:SetText( toPlusMinusString(kCityData.GoldPerTurn) );
-  pCityInstance.Faith:SetText( toPlusMinusString(kCityData.FaithPerTurn) );
-  pCityInstance.Science:SetText( toPlusMinusString(kCityData.SciencePerTurn) );
-  pCityInstance.Culture:SetText( toPlusMinusString(kCityData.CulturePerTurn) );
-  pCityInstance.Tourism:SetText( toPlusMinusString(kCityData.WorkedTileYields["TOURISM"]) );
+		local pLineItemInstance:table = {};
+		ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
+		pLineItemInstance.LineItemName:SetText( Locale.Lookup("LOC_HUD_REPORTS_WORKED_TILES") );
+		pLineItemInstance.Production:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_PRODUCTION"]) );
+		pLineItemInstance.Food:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_FOOD"]) );
+		pLineItemInstance.Gold:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_GOLD"]) );
+		pLineItemInstance.Faith:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_FAITH"]) );
+		pLineItemInstance.Science:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_SCIENCE"]) );
+		pLineItemInstance.Culture:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_CULTURE"]) );
 
-  if not Controls.CityBuildingsCheckbox:IsSelected() then
-    -- Compute tiles worked by setting to total and subtracting all the things...
-    local productionTilesWorked :number = kCityData.ProductionPerTurn;
-    local foodTilesWorked :number = kCityData.FoodPerTurn;
-    local goldTilesWorked :number = kCityData.GoldPerTurn;
-    local faithTilesWorked :number = kCityData.FaithPerTurn;
-    local scienceTilesWorked :number = kCityData.SciencePerTurn;
-    local cultureTilesWorked :number = kCityData.CulturePerTurn;
+		local iYieldPercent = (Round(1 + (kCityData.HappinessNonFoodYieldModifier/100), 2)*.1);
+		pLineItemInstance = {};
+		ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
+		pLineItemInstance.LineItemName:SetText( Locale.Lookup("LOC_HUD_REPORTS_HEADER_AMENITIES") );
+		pLineItemInstance.Production:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_PRODUCTION"] * iYieldPercent) ) );
+		pLineItemInstance.Food:SetText( "" );
+		pLineItemInstance.Gold:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_GOLD"] * iYieldPercent)) );
+		pLineItemInstance.Faith:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_FAITH"] * iYieldPercent)) );
+		pLineItemInstance.Science:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_SCIENCE"] * iYieldPercent)) );
+		pLineItemInstance.Culture:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_CULTURE"] * iYieldPercent)) );
+	end
+		
+end
 
-    for i,kDistrict in ipairs(kCityData.BuildingsAndDistricts) do
-      for i,kBuilding in ipairs(kDistrict.Buildings) do
-        local pLineItemInstance:table = {};
-        ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
-        pLineItemInstance.LineItemName:SetText( kBuilding.Name );
+-- !! yeh
 
-        pLineItemInstance.Production:SetText( toPlusMinusNoneString(kBuilding.ProductionPerTurn) );
-        pLineItemInstance.Food:SetText( toPlusMinusNoneString(kBuilding.FoodPerTurn) );
-        pLineItemInstance.Gold:SetText( toPlusMinusNoneString(kBuilding.GoldPerTurn) );
-        pLineItemInstance.Faith:SetText( toPlusMinusNoneString(kBuilding.FaithPerTurn) );
-        pLineItemInstance.Science:SetText( toPlusMinusNoneString(kBuilding.SciencePerTurn) );
-        pLineItemInstance.Culture:SetText( toPlusMinusNoneString(kBuilding.CulturePerTurn) );
+-- ===========================================================================
+--	Tab Callback
+-- ===========================================================================
+function ViewYieldsPage()	
 
-        productionTilesWorked = productionTilesWorked - kBuilding.ProductionPerTurn;
-        foodTilesWorked = foodTilesWorked - kBuilding.FoodPerTurn;
-        goldTilesWorked = goldTilesWorked - kBuilding.GoldPerTurn;
-        faithTilesWorked = faithTilesWorked - kBuilding.FaithPerTurn;
-        scienceTilesWorked = scienceTilesWorked - kBuilding.SciencePerTurn;
-        cultureTilesWorked = cultureTilesWorked - kBuilding.CulturePerTurn;
-      end
-    end
+	ResetTabForNewPageContent();
 
-    local pLineItemInstance:table = {};
-    ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
-    pLineItemInstance.LineItemName:SetText( Locale.Lookup("LOC_HUD_REPORTS_WORKED_TILES") );
-    pLineItemInstance.Production:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_PRODUCTION"]) );
-    pLineItemInstance.Food:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_FOOD"]) );
-    pLineItemInstance.Gold:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_GOLD"]) );
-    pLineItemInstance.Faith:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_FAITH"]) );
-    pLineItemInstance.Science:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_SCIENCE"]) );
-    pLineItemInstance.Culture:SetText( toPlusMinusNoneString(kCityData.WorkedTileYields["YIELD_CULTURE"]) );
+	Controls.CityBuildingsCheckbox:SetHide( false )
 
-    local iYieldPercent = (Round(1 + (kCityData.HappinessNonFoodYieldModifier/100), 2)*.1);
-    pLineItemInstance = {};
-    ContextPtr:BuildInstanceForControl("CityIncomeLineItemInstance", pLineItemInstance, pCityInstance.LineItemStack );
-    pLineItemInstance.LineItemName:SetText( Locale.Lookup("LOC_HUD_REPORTS_HEADER_AMENITIES") );
-    pLineItemInstance.Production:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_PRODUCTION"] * iYieldPercent) ) );
-    pLineItemInstance.Food:SetText( "" );
-    pLineItemInstance.Gold:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_GOLD"] * iYieldPercent)) );
-    pLineItemInstance.Faith:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_FAITH"] * iYieldPercent)) );
-    pLineItemInstance.Science:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_SCIENCE"] * iYieldPercent)) );
-    pLineItemInstance.Culture:SetText( toPlusMinusNoneString((kCityData.WorkedTileYields["YIELD_CULTURE"] * iYieldPercent)) );
-  end
+	local pPlayer:table = Players[Game.GetLocalPlayer()];
 
+	local instance:table = nil;
+	instance = NewCollapsibleGroupInstance();
+	instance.RowHeaderButton:SetText( Locale.Lookup("LOC_HUD_REPORTS_ROW_CITY_INCOME") );
+	
+	local pHeaderInstance:table = {}
+	ContextPtr:BuildInstanceForControl( "CityIncomeHeaderInstance", pHeaderInstance, instance.ContentStack ) ;	
+
+	pHeaderInstance.CityNameButton:RegisterCallback( Mouse.eLClick, function() sortBy( "CityName" ) end )
+	pHeaderInstance.ProductionButton:RegisterCallback( Mouse.eLClick, function() sortBy( "ProductionPerTurn" ) end )
+	pHeaderInstance.FoodButton:RegisterCallback( Mouse.eLClick, function() sortBy( "FoodPerTurn" ) end )
+	pHeaderInstance.GoldButton:RegisterCallback( Mouse.eLClick, function() sortBy( "GoldPerTurn" ) end )
+	pHeaderInstance.FaithButton:RegisterCallback( Mouse.eLClick, function() sortBy( "FaithPerTurn" ) end )
+	pHeaderInstance.ScienceButton:RegisterCallback( Mouse.eLClick, function() sortBy( "SciencePerTurn" ) end )
+	pHeaderInstance.CultureButton:RegisterCallback( Mouse.eLClick, function() sortBy( "CulturePerTurn" ) end )
+	pHeaderInstance.TourismButton:RegisterCallback( Mouse.eLClick, function() sortBy( "TourismPerTurn" ) end )
+
+	local goldCityTotal		:number = 0;
+	local faithCityTotal	:number = 0;
+	local scienceCityTotal	:number = 0;
+	local cultureCityTotal	:number = 0;
+	local tourismCityTotal	:number = 0;
+	
+
+	-- ========== City Income ==========
+
+	for cityName,kCityData in spairs( m_kCityData, function( t, a, b ) return sortFunction( t, a, b ) end ) do
+		local pCityInstance:table = {};
+		ContextPtr:BuildInstanceForControl( "CityIncomeInstance", pCityInstance, instance.ContentStack ) ;
+		pCityInstance.LineItemStack:DestroyAllChildren();
+		
+		cityincome_fields( kCityData, pCityInstance )
+
+		-- Add to all cities totals
+		goldCityTotal	= goldCityTotal + kCityData.GoldPerTurn;
+		faithCityTotal	= faithCityTotal + kCityData.FaithPerTurn;
+		scienceCityTotal= scienceCityTotal + kCityData.SciencePerTurn;
+		cultureCityTotal= cultureCityTotal + kCityData.CulturePerTurn;
+		tourismCityTotal= tourismCityTotal + kCityData.WorkedTileYields["TOURISM"];
+
+		pCityInstance.LineItemStack:CalculateSize();
+		pCityInstance.Darken:SetSizeY( pCityInstance.LineItemStack:GetSizeY() + DARKEN_CITY_INCOME_AREA_ADDITIONAL_Y );
+		pCityInstance.Top:ReprocessAnchoring();
+	end
+
+	local pFooterInstance:table = {};
+	ContextPtr:BuildInstanceForControl("CityIncomeFooterInstance", pFooterInstance, instance.ContentStack  );
+	pFooterInstance.Gold:SetText( "[Icon_GOLD]"..toPlusMinusString(goldCityTotal) );
+	pFooterInstance.Faith:SetText( "[Icon_FAITH]"..toPlusMinusString(faithCityTotal) );
+	pFooterInstance.Science:SetText( "[Icon_SCIENCE]"..toPlusMinusString(scienceCityTotal) );
+	pFooterInstance.Culture:SetText( "[Icon_CULTURE]"..toPlusMinusString(cultureCityTotal) );
+	pFooterInstance.Tourism:SetText( "[Icon_TOURISM]"..toPlusMinusString(tourismCityTotal) );
+
+	SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
+	RealizeGroup( instance );
+
+
+	-- ========== Building Expenses ==========
+
+	instance = NewCollapsibleGroupInstance();
+	instance.RowHeaderButton:SetText( Locale.Lookup("LOC_HUD_REPORTS_ROW_BUILDING_EXPENSES") );
+
+	local pHeader:table = {};
+	ContextPtr:BuildInstanceForControl( "BuildingExpensesHeaderInstance", pHeader, instance.ContentStack ) ;
+
+	local iTotalBuildingMaintenance :number = 0;
+	for cityName,kCityData in pairs(m_kCityData) do
+
+		-- Adds district costs to expenses !!
+		-- don't count city center
+		-- District maintenance isn't factored into the expense screen ( but is factored into maintenance )
+		-- This helps rectify that by adding up all the districts in a city, -1 for city center
+		-- Tooltip shows districts have a -1 gpt cost, not sure if this goes up or if its different for other districts or
+		-- later eras
+
+		local iNumDistricts : number = 0
+
+		-- Can't find/figure out how to find district type, so i'll do it myself
+		-- this goes through the districts and adds the maintenance if not pillaged/being built
+		for _,kBuilding in ipairs(kCityData.BuildingsAndDistricts) do
+			if kBuilding.isBuilt then
+				for i = 1, #GameInfo.Districts do
+					if kBuilding.Name == Locale.Lookup( GameInfo.Districts[i].Name ) then
+						iNumDistricts = iNumDistricts + GameInfo.Districts[i].Maintenance
+						break
+					end
+				end
+			end
+		end
+
+		if ( iNumDistricts > 0 ) then
+			local pBuildingInstance:table = {}
+			ContextPtr:BuildInstanceForControl( "BuildingExpensesEntryInstance", pBuildingInstance, instance.ContentStack )
+			pBuildingInstance.CityName:SetText( Locale.Lookup(cityName) )
+			pBuildingInstance.BuildingName:SetText( "Districts" )
+			pBuildingInstance.Gold:SetText( "-" .. tostring( iNumDistricts ) )
+			iTotalBuildingMaintenance = iTotalBuildingMaintenance - iNumDistricts
+		end
+
+		for i,kBuilding in ipairs(kCityData.Buildings) do
+			if kBuilding.Maintenance > 0 then
+				local pBuildingInstance:table = {};
+				ContextPtr:BuildInstanceForControl( "BuildingExpensesEntryInstance", pBuildingInstance, instance.ContentStack ) ;		
+				pBuildingInstance.CityName:SetText( Locale.Lookup(cityName) );
+				pBuildingInstance.BuildingName:SetText( Locale.Lookup(kBuilding.Name) );
+				pBuildingInstance.Gold:SetText( tostring( "-" .. kBuilding.Maintenance ) );
+				iTotalBuildingMaintenance = iTotalBuildingMaintenance - kBuilding.Maintenance;
+			end
+		end
+	end
+	local pBuildingFooterInstance:table = {};		
+	ContextPtr:BuildInstanceForControl( "GoldFooterInstance", pBuildingFooterInstance, instance.ContentStack ) ;		
+	pBuildingFooterInstance.Gold:SetText("[ICON_Gold]"..tostring(iTotalBuildingMaintenance) );
+
+	SetGroupCollapsePadding(instance, pBuildingFooterInstance.Top:GetSizeY() );
+	RealizeGroup( instance );
+
+	-- ========== Diplomatic Deals Expenses ==========
+	
+	instance = NewCollapsibleGroupInstance();	
+	instance.RowHeaderButton:SetText( Locale.Lookup("LOC_HUD_REPORTS_ROW_DIPLOMATIC_DEALS") );
+
+	local pHeader:table = {};
+	ContextPtr:BuildInstanceForControl( "DealHeaderInstance", pHeader, instance.ContentStack ) ;
+
+	local iTotalDealGold :number = 0;
+
+	for i,kDeal in ipairs(m_kDealData) do
+		local pDealInstance:table = {};		
+		ContextPtr:BuildInstanceForControl( "DealEntryInstance", pDealInstance, instance.ContentStack ) ;		
+
+		pDealInstance.Civilization:SetText( kDeal.Name );
+		pDealInstance.Duration:SetText( kDeal.Duration );
+		if kDeal.IsOutgoing then
+			pDealInstance.Gold:SetText( "-"..tostring(kDeal.Amount) );
+			iTotalDealGold = iTotalDealGold - kDeal.Amount;
+		else
+			pDealInstance.Gold:SetText( "+"..tostring(kDeal.Amount) );
+			iTotalDealGold = iTotalDealGold + kDeal.Amount;
+		end
+	end
+	local pDealFooterInstance:table = {};		
+	ContextPtr:BuildInstanceForControl( "GoldFooterInstance", pDealFooterInstance, instance.ContentStack ) ;		
+	pDealFooterInstance.Gold:SetText("[ICON_Gold]"..tostring(iTotalDealGold) );
+
+	SetGroupCollapsePadding(instance, pDealFooterInstance.Top:GetSizeY() );
+	RealizeGroup( instance );
+
+	-- ========== !! Unit Expenses ==========
+
+	instance = NewCollapsibleGroupInstance();
+	instance.RowHeaderButton:SetText( Locale.Lookup( "Unit Expenses" ) );
+
+	local pHeader:table = {};
+	ContextPtr:BuildInstanceForControl( "UnitExpensesHeaderInstance", pHeader, instance.ContentStack ) ;
+
+	local iTotalUnitMaintenance : number = 0	
+	local conscript_levee : number = 0
+
+	iTotalUnitMaintenance = 0
+
+	local numSlots : number = m_kCultureData:GetNumPolicySlots()
+
+	for i = 0, numSlots - 1, 1 do
+		local iPolicyId	:number = m_kCultureData:GetSlotPolicy(i);
+		if iPolicyId ~= -1 then
+			if GameInfo.Policies[iPolicyId].PolicyType == "POLICY_CONSCRIPTION" then
+				conscript_levee = 1
+			elseif GameInfo.Policies[iPolicyId].PolicyType == "POLICY_LEVEE_EN_MASSE" then
+				conscript_levee = 2
+			end
+		end
+	end
+
+	for _, kUnitGroup in pairs( m_kUnitData["Unit_Expenses"] ) do
+		if kUnitGroup.Cost - conscript_levee > 0 then
+			local pUnitInstance:table = {}
+			ContextPtr:BuildInstanceForControl( "UnitExpensesEntryInstance", pUnitInstance, instance.ContentStack )
+			pUnitInstance.UnitName:SetText( kUnitGroup.Name )
+			pUnitInstance.Gold:SetText( "-"..tostring( kUnitGroup.Amount * ( kUnitGroup.Cost - conscript_levee ) ) )
+			iTotalUnitMaintenance = iTotalUnitMaintenance - kUnitGroup.Amount * ( kUnitGroup.Cost - conscript_levee )
+		end
+	end
+
+	local pBuildingFooterInstance : table = {};
+	ContextPtr:BuildInstanceForControl( "GoldFooterInstance", pBuildingFooterInstance, instance.ContentStack ) ;		
+	pBuildingFooterInstance.Gold:SetText( "[ICON_Gold]" .. tostring( iTotalUnitMaintenance ) );
+
+	SetGroupCollapsePadding(instance, pBuildingFooterInstance.Top:GetSizeY() );
+	RealizeGroup( instance );
+
+	-- Unit Expense END!!
+
+	-- ========== TOTALS ==========
+
+	Controls.Stack:CalculateSize();
+	Controls.Scroll:CalculateSize();
+
+	-- Totals at the bottom
+	Controls.GoldIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.GOLD] ));
+	Controls.FaithIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.FAITH] ));
+	Controls.ScienceIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.SCIENCE] ));
+	Controls.CultureIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.CULTURE] ));
+	Controls.TourismIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income["TOURISM"] ));	
+	Controls.GoldExpense:SetText( toPlusMinusNoneString( -m_kCityTotalData.Expenses[YieldTypes.GOLD] ));	-- Flip that value!
+	Controls.GoldNet:SetText( toPlusMinusNoneString( m_kCityTotalData.Net[YieldTypes.GOLD] ));
+	Controls.FaithNet:SetText( toPlusMinusNoneString( m_kCityTotalData.Net[YieldTypes.FAITH] ));
+	
+	Controls.GoldBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.GOLD] );
+	Controls.FaithBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.FAITH] );
+	Controls.ScienceBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.SCIENCE] );
+	Controls.CultureBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.CULTURE] );
+	Controls.TourismBalance:SetText( m_kCityTotalData.Treasury["TOURISM"] );
+	
+	Controls.BottomYieldTotals:SetHide( false );
+	Controls.BottomYieldTotals:SetSizeY( SIZE_HEIGHT_BOTTOM_YIELDS );
+	Controls.BottomResourceTotals:SetHide( true );
+	Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - (Controls.BottomYieldTotals:GetSizeY() + SIZE_HEIGHT_PADDING_BOTTOM_ADJUST ) );	
+end
+
+
+-- ===========================================================================
+--	Tab Callback
+-- ===========================================================================
+function ViewResourcesPage()	
+
+	ResetTabForNewPageContent();
+
+	local strategicResources:string = "";
+	local luxuryResources	:string = "";
+	local kBonuses			:table	= {};
+	local kLuxuries			:table	= {};
+	local kStrategics		:table	= {};
+	
+
+	for eResourceType,kSingleResourceData in pairs(m_kResourceData) do
+		
+		local instance:table = NewCollapsibleGroupInstance();	
+
+		local kResource :table = GameInfo.Resources[eResourceType];
+		instance.RowHeaderButton:SetText(  kSingleResourceData.Icon..Locale.Lookup( kResource.Name ) );
+
+		local pHeaderInstance:table = {};
+		ContextPtr:BuildInstanceForControl( "ResourcesHeaderInstance", pHeaderInstance, instance.ContentStack ) ;
+
+		local kResourceEntries:table = kSingleResourceData.EntryList;
+		for i,kEntry in ipairs(kResourceEntries) do
+			local pEntryInstance:table = {};
+			ContextPtr:BuildInstanceForControl( "ResourcesEntryInstance", pEntryInstance, instance.ContentStack ) ;
+			pEntryInstance.CityName:SetText( Locale.Lookup(kEntry.EntryText) );
+			pEntryInstance.Control:SetText( Locale.Lookup(kEntry.ControlText) );
+			pEntryInstance.Amount:SetText( (kEntry.Amount<=0) and tostring(kEntry.Amount) or "+"..tostring(kEntry.Amount) );
+		end
+
+		local pFooterInstance:table = {};
+		ContextPtr:BuildInstanceForControl( "ResourcesFooterInstance", pFooterInstance, instance.ContentStack ) ;
+		pFooterInstance.Amount:SetText( tostring(kSingleResourceData.Total) );		
+
+		-- Show how many of this resource are being allocated to what cities
+		local localPlayerID = Game.GetLocalPlayer();
+		local localPlayer = Players[localPlayerID];
+		local citiesProvidedTo: table = localPlayer:GetResources():GetResourceAllocationCities(GameInfo.Resources[kResource.ResourceType].Index);
+		local numCitiesProvidingTo: number = table.count(citiesProvidedTo);
+		if (numCitiesProvidingTo > 0) then
+			pFooterInstance.AmenitiesContainer:SetHide(false);
+			pFooterInstance.Amenities:SetText("[ICON_Amenities][ICON_GoingTo]"..numCitiesProvidingTo.." "..Locale.Lookup("LOC_PEDIA_CONCEPTS_PAGEGROUP_CITIES_NAME"));
+			local amenitiesTooltip: string = "";
+			local playerCities = localPlayer:GetCities();
+			for i,city in ipairs(citiesProvidedTo) do
+				local cityName = Locale.Lookup(playerCities:FindID(city.CityID):GetName());
+				if i ~=1 then
+					amenitiesTooltip = amenitiesTooltip.. "[NEWLINE]";
+				end
+				amenitiesTooltip = amenitiesTooltip.. city.AllocationAmount.." [ICON_".. kResource.ResourceType.."] [Icon_GoingTo] " ..cityName;
+			end
+			pFooterInstance.Amenities:SetToolTipString(amenitiesTooltip);
+		else
+			pFooterInstance.AmenitiesContainer:SetHide(true);
+		end
+
+		if kSingleResourceData.IsStrategic then
+			--strategicResources = strategicResources .. kSingleResourceData.Icon .. tostring( kSingleResourceData.Total );
+			table.insert(kStrategics, kSingleResourceData.Icon .. tostring( kSingleResourceData.Total ) );
+		elseif kSingleResourceData.IsLuxury then			
+			--luxuryResources = luxuryResources .. kSingleResourceData.Icon .. tostring( kSingleResourceData.Total );			
+			table.insert(kLuxuries, kSingleResourceData.Icon .. tostring( kSingleResourceData.Total ) );
+		else
+			table.insert(kBonuses, kSingleResourceData.Icon .. tostring( kSingleResourceData.Total ) );
+		end
+
+		SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
+		RealizeGroup( instance );
+	end
+	
+	m_strategicResourcesIM:ResetInstances();
+	for i,v in ipairs(kStrategics) do
+		local resourceInstance:table = m_strategicResourcesIM:GetInstance();	
+		resourceInstance.Info:SetText( v );
+	end
+	Controls.StrategicResources:CalculateSize();
+	Controls.StrategicGrid:ReprocessAnchoring();
+
+	m_bonusResourcesIM:ResetInstances();
+	for i,v in ipairs(kBonuses) do
+		local resourceInstance:table = m_bonusResourcesIM:GetInstance();	
+		resourceInstance.Info:SetText( v );
+	end
+	Controls.BonusResources:CalculateSize();
+	Controls.BonusGrid:ReprocessAnchoring();
+
+	m_luxuryResourcesIM:ResetInstances();
+	for i,v in ipairs(kLuxuries) do
+		local resourceInstance:table = m_luxuryResourcesIM:GetInstance();	
+		resourceInstance.Info:SetText( v );
+	end
+	
+	Controls.LuxuryResources:CalculateSize();
+	Controls.LuxuryResources:ReprocessAnchoring();
+	Controls.LuxuryGrid:ReprocessAnchoring();
+	
+	Controls.Stack:CalculateSize();
+	Controls.Scroll:CalculateSize();
+
+	Controls.BottomYieldTotals:SetHide( true );
+	Controls.BottomResourceTotals:SetHide( false );
+	Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - (Controls.BottomResourceTotals:GetSizeY() + SIZE_HEIGHT_PADDING_BOTTOM_ADJUST ) );	
 end
 
 -- ===========================================================================
--- Tab Callback
+--	Tab Callback
 -- ===========================================================================
-function ViewYieldsPage()
-
-  ResetTabForNewPageContent();
-
-  Controls.CityBuildingsCheckbox:SetHide( false )
-
-  local pPlayer:table = Players[Game.GetLocalPlayer()];
-
-  local instance:table = nil;
-  instance = NewCollapsibleGroupInstance();
-  instance.RowHeaderButton:SetText( Locale.Lookup("LOC_HUD_REPORTS_ROW_CITY_INCOME") );
-
-  local pHeaderInstance:table = {}
-  ContextPtr:BuildInstanceForControl( "CityIncomeHeaderInstance", pHeaderInstance, instance.ContentStack ) ;
-
-  pHeaderInstance.CityNameButton:RegisterCallback( Mouse.eLClick, function() sortBy( "CityName" ) end )
-  pHeaderInstance.ProductionButton:RegisterCallback( Mouse.eLClick, function() sortBy( "ProductionPerTurn" ) end )
-  pHeaderInstance.FoodButton:RegisterCallback( Mouse.eLClick, function() sortBy( "FoodPerTurn" ) end )
-  pHeaderInstance.GoldButton:RegisterCallback( Mouse.eLClick, function() sortBy( "GoldPerTurn" ) end )
-  pHeaderInstance.FaithButton:RegisterCallback( Mouse.eLClick, function() sortBy( "FaithPerTurn" ) end )
-  pHeaderInstance.ScienceButton:RegisterCallback( Mouse.eLClick, function() sortBy( "SciencePerTurn" ) end )
-  pHeaderInstance.CultureButton:RegisterCallback( Mouse.eLClick, function() sortBy( "CulturePerTurn" ) end )
-  pHeaderInstance.TourismButton:RegisterCallback( Mouse.eLClick, function() sortBy( "TourismPerTurn" ) end )
-
-  local goldCityTotal :number = 0;
-  local faithCityTotal :number = 0;
-  local scienceCityTotal :number = 0;
-  local cultureCityTotal :number = 0;
-  local tourismCityTotal :number = 0;
-
-  -- ========== City Income ==========
-
-  for cityName,kCityData in spairs( m_kCityData, function( t, a, b ) return sortFunction( t, a, b ) end ) do
-    local pCityInstance:table = {};
-    ContextPtr:BuildInstanceForControl( "CityIncomeInstance", pCityInstance, instance.ContentStack ) ;
-    pCityInstance.LineItemStack:DestroyAllChildren();
-
-    cityincome_fields( kCityData, pCityInstance )
-
-    -- Add to all cities totals
-    goldCityTotal = goldCityTotal + kCityData.GoldPerTurn;
-    faithCityTotal = faithCityTotal + kCityData.FaithPerTurn;
-    scienceCityTotal= scienceCityTotal + kCityData.SciencePerTurn;
-    cultureCityTotal= cultureCityTotal + kCityData.CulturePerTurn;
-    tourismCityTotal= tourismCityTotal + kCityData.WorkedTileYields["TOURISM"];
-
-    pCityInstance.LineItemStack:CalculateSize();
-    pCityInstance.Darken:SetSizeY( pCityInstance.LineItemStack:GetSizeY() + DARKEN_CITY_INCOME_AREA_ADDITIONAL_Y );
-    pCityInstance.Top:ReprocessAnchoring();
-  end
-
-  local pFooterInstance:table = {};
-  ContextPtr:BuildInstanceForControl("CityIncomeFooterInstance", pFooterInstance, instance.ContentStack );
-  pFooterInstance.Gold:SetText( "[Icon_GOLD]"..toPlusMinusString(goldCityTotal) );
-  pFooterInstance.Faith:SetText( "[Icon_FAITH]"..toPlusMinusString(faithCityTotal) );
-  pFooterInstance.Science:SetText( "[Icon_SCIENCE]"..toPlusMinusString(scienceCityTotal) );
-  pFooterInstance.Culture:SetText( "[Icon_CULTURE]"..toPlusMinusString(cultureCityTotal) );
-  pFooterInstance.Tourism:SetText( "[Icon_TOURISM]"..toPlusMinusString(tourismCityTotal) );
-
-  SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
-  RealizeGroup( instance );
-
-  -- ========== Building Expenses ==========
-
-  instance = NewCollapsibleGroupInstance();
-  instance.RowHeaderButton:SetText( Locale.Lookup("LOC_HUD_REPORTS_ROW_BUILDING_EXPENSES") );
-
-  local pHeader:table = {};
-  ContextPtr:BuildInstanceForControl( "BuildingExpensesHeaderInstance", pHeader, instance.ContentStack ) ;
-
-  local iTotalBuildingMaintenance :number = 0;
-  for cityName,kCityData in pairs(m_kCityData) do
-
-    -- Adds district costs to expenses !!
-    -- don't count city center
-    -- District maintenance isn't factored into the expense screen ( but is factored into maintenance )
-    -- This helps rectify that by adding up all the districts in a city, -1 for city center
-    -- Tooltip shows districts have a -1 gpt cost, not sure if this goes up or if its different for other districts or
-    -- later eras
-
-    local iNumDistricts : number = 0
-
-    -- Can't find/figure out how to find district type, so i'll do it myself
-    -- this goes through the districts and adds the maintenance if not pillaged/being built
-    for _,kBuilding in ipairs(kCityData.BuildingsAndDistricts) do
-      if kBuilding.isBuilt then
-        for i = 1, #GameInfo.Districts do
-          if kBuilding.Name == Locale.Lookup( GameInfo.Districts[i].Name ) then
-            iNumDistricts = iNumDistricts + GameInfo.Districts[i].Maintenance
-            break
-          end
-        end
-      end
-    end
-
-    if ( iNumDistricts > 0 ) then
-      local pBuildingInstance:table = {}
-      ContextPtr:BuildInstanceForControl( "BuildingExpensesEntryInstance", pBuildingInstance, instance.ContentStack )
-      pBuildingInstance.CityName:SetText( Locale.Lookup(cityName) )
-      pBuildingInstance.BuildingName:SetText( "Districts" )
-      pBuildingInstance.Gold:SetText( "-" .. tostring( iNumDistricts ) )
-      iTotalBuildingMaintenance = iTotalBuildingMaintenance - iNumDistricts
-    end
-
-    for i,kBuilding in ipairs(kCityData.Buildings) do
-      if kBuilding.Maintenance > 0 then
-        local pBuildingInstance:table = {};
-        ContextPtr:BuildInstanceForControl( "BuildingExpensesEntryInstance", pBuildingInstance, instance.ContentStack ) ;
-        pBuildingInstance.CityName:SetText( Locale.Lookup(cityName) );
-        pBuildingInstance.BuildingName:SetText( Locale.Lookup(kBuilding.Name) );
-        pBuildingInstance.Gold:SetText( tostring( "-" .. kBuilding.Maintenance ) );
-        iTotalBuildingMaintenance = iTotalBuildingMaintenance - kBuilding.Maintenance;
-      end
-    end
-  end
-  local pBuildingFooterInstance:table = {};
-  ContextPtr:BuildInstanceForControl( "GoldFooterInstance", pBuildingFooterInstance, instance.ContentStack ) ;
-  pBuildingFooterInstance.Gold:SetText("[ICON_Gold]"..tostring(iTotalBuildingMaintenance) );
-
-  SetGroupCollapsePadding(instance, pBuildingFooterInstance.Top:GetSizeY() );
-  RealizeGroup( instance );
-
-  -- ========== Diplomatic Deals Expenses ==========
-
-  instance = NewCollapsibleGroupInstance();
-  instance.RowHeaderButton:SetText( Locale.Lookup("LOC_HUD_REPORTS_ROW_DIPLOMATIC_DEALS") );
-
-  local pHeader:table = {};
-  ContextPtr:BuildInstanceForControl( "DealHeaderInstance", pHeader, instance.ContentStack ) ;
-
-  local iTotalDealGold :number = 0;
-
-  for i,kDeal in ipairs(m_kDealData) do
-    local pDealInstance:table = {};
-    ContextPtr:BuildInstanceForControl( "DealEntryInstance", pDealInstance, instance.ContentStack ) ;
-
-    pDealInstance.Civilization:SetText( kDeal.Name );
-    pDealInstance.Duration:SetText( kDeal.Duration );
-    if kDeal.IsOutgoing then
-      pDealInstance.Gold:SetText( "-"..tostring(kDeal.Amount) );
-      iTotalDealGold = iTotalDealGold - kDeal.Amount;
-    else
-      pDealInstance.Gold:SetText( "+"..tostring(kDeal.Amount) );
-      iTotalDealGold = iTotalDealGold + kDeal.Amount;
-    end
-  end
-  local pDealFooterInstance:table = {};
-  ContextPtr:BuildInstanceForControl( "GoldFooterInstance", pDealFooterInstance, instance.ContentStack ) ;
-  pDealFooterInstance.Gold:SetText("[ICON_Gold]"..tostring(iTotalDealGold) );
-
-  SetGroupCollapsePadding(instance, pDealFooterInstance.Top:GetSizeY() );
-  RealizeGroup( instance );
-
-  -- ========== !! Unit Expenses ==========
-
-  instance = NewCollapsibleGroupInstance();
-  instance.RowHeaderButton:SetText( Locale.Lookup( "Unit Expenses" ) );
-
-  local pHeader:table = {};
-  ContextPtr:BuildInstanceForControl( "UnitExpensesHeaderInstance", pHeader, instance.ContentStack ) ;
-
-  local iTotalUnitMaintenance : number = 0
-  local conscript_levee : number = 0
-
-  iTotalUnitMaintenance = 0
-
-  local numSlots : number = m_kCultureData:GetNumPolicySlots()
-
-  for i = 0, numSlots - 1, 1 do
-    local iPolicyId :number = m_kCultureData:GetSlotPolicy(i);
-    if iPolicyId ~= -1 then
-      if GameInfo.Policies[iPolicyId].PolicyType == "POLICY_CONSCRIPTION" then
-        conscript_levee = 1
-      elseif GameInfo.Policies[iPolicyId].PolicyType == "POLICY_LEVEE_EN_MASSE" then
-        conscript_levee = 2
-      end
-    end
-  end
-
-  for _, kUnitGroup in pairs( m_kUnitData["Unit_Expenses"] ) do
-    if kUnitGroup.Cost - conscript_levee > 0 then
-      local pUnitInstance:table = {}
-      ContextPtr:BuildInstanceForControl( "UnitExpensesEntryInstance", pUnitInstance, instance.ContentStack )
-      pUnitInstance.UnitName:SetText( kUnitGroup.Name )
-      pUnitInstance.Gold:SetText( "-"..tostring( kUnitGroup.Amount * ( kUnitGroup.Cost - conscript_levee ) ) )
-      iTotalUnitMaintenance = iTotalUnitMaintenance - kUnitGroup.Amount * ( kUnitGroup.Cost - conscript_levee )
-    end
-  end
-
-  local pBuildingFooterInstance : table = {};
-  ContextPtr:BuildInstanceForControl( "GoldFooterInstance", pBuildingFooterInstance, instance.ContentStack ) ;
-  pBuildingFooterInstance.Gold:SetText( "[ICON_Gold]" .. tostring( iTotalUnitMaintenance ) );
-
-  SetGroupCollapsePadding(instance, pBuildingFooterInstance.Top:GetSizeY() );
-  RealizeGroup( instance );
-
-  -- Unit Expense END!!
-
-  -- ========== TOTALS ==========
-
-  Controls.Stack:CalculateSize();
-  Controls.Scroll:CalculateSize();
-
-  -- Totals at the bottom
-  Controls.GoldIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.GOLD] ));
-  Controls.FaithIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.FAITH] ));
-  Controls.ScienceIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.SCIENCE] ));
-  Controls.CultureIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income[YieldTypes.CULTURE] ));
-  Controls.TourismIncome:SetText( toPlusMinusNoneString( m_kCityTotalData.Income["TOURISM"] ));
-  Controls.GoldExpense:SetText( toPlusMinusNoneString( -m_kCityTotalData.Expenses[YieldTypes.GOLD] )); -- Flip that value!
-  Controls.GoldNet:SetText( toPlusMinusNoneString( m_kCityTotalData.Net[YieldTypes.GOLD] ));
-  Controls.FaithNet:SetText( toPlusMinusNoneString( m_kCityTotalData.Net[YieldTypes.FAITH] ));
-
-  Controls.GoldBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.GOLD] );
-  Controls.FaithBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.FAITH] );
-  Controls.ScienceBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.SCIENCE] );
-  Controls.CultureBalance:SetText( m_kCityTotalData.Treasury[YieldTypes.CULTURE] );
-  Controls.TourismBalance:SetText( m_kCityTotalData.Treasury["TOURISM"] );
-
-  Controls.BottomYieldTotals:SetHide( false );
-  Controls.BottomYieldTotals:SetSizeY( SIZE_HEIGHT_BOTTOM_YIELDS );
-  Controls.BottomResourceTotals:SetHide( true );
-  Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - (Controls.BottomYieldTotals:GetSizeY() + SIZE_HEIGHT_PADDING_BOTTOM_ADJUST ) );
-end
-
--- ===========================================================================
--- Tab Callback
--- ===========================================================================
-function ViewResourcesPage()
-
-  ResetTabForNewPageContent();
-
-  local strategicResources:string = "";
-  local luxuryResources :string = "";
-
-  for eResourceType,kSingleResourceData in pairs(m_kResourceData) do
-
-    local instance:table = NewCollapsibleGroupInstance();
-
-    local kResource :table = GameInfo.Resources[eResourceType];
-    instance.RowHeaderButton:SetText( kSingleResourceData.Icon..Locale.Lookup( kResource.Name ) );
-
-    local pHeaderInstance:table = {};
-    ContextPtr:BuildInstanceForControl( "ResourcesHeaderInstance", pHeaderInstance, instance.ContentStack ) ;
-
-    local kCitiesAmount:table = kSingleResourceData.CityList;
-    for i,kCityAmount in ipairs(kCitiesAmount) do
-      local pCityInstance:table = {};
-      ContextPtr:BuildInstanceForControl( "ResourcesEntryInstance", pCityInstance, instance.ContentStack ) ;
-      pCityInstance.CityName:SetText( Locale.Lookup(kCityAmount.CityName) );
-      pCityInstance.Control:SetText("-"); --??TRON TODO:
-      pCityInstance.Amount:SetText( (kCityAmount.Amount==0) and "0" or "+"..tostring(kCityAmount.Amount) );
-    end
-
-    local pFooterInstance:table = {};
-    ContextPtr:BuildInstanceForControl( "ResourcesFooterInstance", pFooterInstance, instance.ContentStack ) ;
-    pFooterInstance.Amount:SetText( tostring(kSingleResourceData.Total) );
-
-    if kSingleResourceData.IsStrategic then
-      strategicResources = strategicResources .. kSingleResourceData.Icon .. tostring( kSingleResourceData.Total );
-    else
-      luxuryResources = luxuryResources .. kSingleResourceData.Icon .. tostring( kSingleResourceData.Total );
-    end
-
-    SetGroupCollapsePadding(instance, pFooterInstance.Top:GetSizeY() );
-    RealizeGroup( instance );
-  end
-
-  Controls.StrategicResources:SetText( strategicResources );
-  Controls.LuxuryResources:SetText( luxuryResources );
-
-  Controls.Stack:CalculateSize();
-  Controls.Scroll:CalculateSize();
-
-  Controls.BottomYieldTotals:SetHide( true );
-  Controls.BottomResourceTotals:SetHide( false );
-  Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - (Controls.BottomResourceTotals:GetSizeY() + SIZE_HEIGHT_PADDING_BOTTOM_ADJUST ) );
-end
-
--- ===========================================================================
--- Tab Callback
--- ===========================================================================
-
 function city_fields( kCityData, pCityInstance )
 
-  pCityInstance.CityName:SetText( Locale.Lookup( kCityData.CityName ) );
-  pCityInstance.Population:SetText( tostring(kCityData.Population) );
+	pCityInstance.CityName:SetText( Locale.Lookup( kCityData.CityName ) );
+	pCityInstance.Population:SetText( tostring(kCityData.Population) );
 
-  if kCityData.HousingMultiplier == 0 then
-    status = "LOC_HUD_REPORTS_STATUS_HALTED";
-  elseif kCityData.HousingMultiplier <= 0.5 then
-    status = "LOC_HUD_REPORTS_STATUS_SLOWED";
-  else
-    status = "LOC_HUD_REPORTS_STATUS_NORMAL";
-  end
+	if kCityData.HousingMultiplier == 0 then
+		status = "LOC_HUD_REPORTS_STATUS_HALTED";
+	elseif kCityData.HousingMultiplier <= 0.5 then
+		status = "LOC_HUD_REPORTS_STATUS_SLOWED";
+	else
+		status = "LOC_HUD_REPORTS_STATUS_NORMAL";
+	end
+	
+	pCityInstance.GrowthRateStatus:SetText( Locale.Lookup(status) );
 
-  pCityInstance.GrowthRateStatus:SetText( Locale.Lookup(status) );
+	pCityInstance.Housing:SetText( tostring( kCityData.Housing ) );
+	pCityInstance.Amenities:SetText( tostring(kCityData.AmenitiesNum).." / "..tostring(kCityData.AmenitiesRequiredNum) );
 
-  pCityInstance.Housing:SetText( tostring( kCityData.Housing ) );
-  pCityInstance.Amenities:SetText( tostring(kCityData.AmenitiesNum).." / "..tostring(kCityData.AmenitiesRequiredNum) );
+	local happinessText:string = Locale.Lookup( GameInfo.Happinesses[kCityData.Happiness].Name );
+	pCityInstance.CitizenHappiness:SetText( happinessText );
 
-  local happinessText:string = Locale.Lookup( GameInfo.Happinesses[kCityData.Happiness].Name );
-  pCityInstance.CitizenHappiness:SetText( happinessText );
+	local warWearyValue:number = kCityData.AmenitiesLostFromWarWeariness;
+	pCityInstance.WarWeariness:SetText( (warWearyValue==0) and "0" or "-"..tostring(warWearyValue) );
 
-  local warWearyValue:number = kCityData.AmenitiesLostFromWarWeariness;
-  pCityInstance.WarWeariness:SetText( (warWearyValue==0) and "0" or "-"..tostring(warWearyValue) );
+	pCityInstance.Status:SetText( kCityData.IsUnderSiege and Locale.Lookup("LOC_HUD_REPORTS_STATUS_UNDER_SEIGE") or Locale.Lookup("LOC_HUD_REPORTS_STATUS_NORMAL") );
 
-  pCityInstance.Status:SetText( kCityData.IsUnderSiege and Locale.Lookup("LOC_HUD_REPORTS_STATUS_UNDER_SEIGE") or Locale.Lookup("LOC_HUD_REPORTS_STATUS_NORMAL") );
-
-  pCityInstance.Strength:SetText( tostring(kCityData.Defense) );
-  pCityInstance.Damage:SetText( tostring(kCityData.Damage) );
+	pCityInstance.Strength:SetText( tostring(kCityData.Defense) );
+	pCityInstance.Damage:SetText( tostring(kCityData.Damage) );		
 
 end
 
-function ViewCityStatusPage()
+function ViewCityStatusPage()	
 
-  ResetTabForNewPageContent()
+	ResetTabForNewPageContent()
 
-  local instance:table = m_simpleIM:GetInstance()
-  instance.Top:DestroyAllChildren()
+	local instance:table = m_simpleIM:GetInstance()
+	instance.Top:DestroyAllChildren()
+	
+	instance.Children = {}
+	instance.Descend = false
+	
+	local pHeaderInstance:table = {}
+	ContextPtr:BuildInstanceForControl( "CityStatusHeaderInstance", pHeaderInstance, instance.Top )
+	
+	pHeaderInstance.CityNameButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "name", instance ) end )
+	pHeaderInstance.CityPopulationButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "pop", instance ) end )
+	pHeaderInstance.CityHousingButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "house", instance ) end )
+	pHeaderInstance.CityGrowthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "growth", instance ) end )
+	pHeaderInstance.CityAmenitiesButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "amen", instance ) end )
+	pHeaderInstance.CityHappinessButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "happy", instance ) end )
+	pHeaderInstance.CityWarButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "war", instance ) end )
+	pHeaderInstance.CityStatusButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "status", instance ) end )
+	pHeaderInstance.CityStrengthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "str", instance ) end )
+	pHeaderInstance.CityDamageButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "dam", instance ) end )
 
-  instance.Children = {}
-  instance.Descend = false
+	-- 
+	for cityName,kCityData in pairs( m_kCityData ) do
 
-  local pHeaderInstance:table = {}
-  ContextPtr:BuildInstanceForControl( "CityStatusHeaderInstance", pHeaderInstance, instance.Top )
+		local pCityInstance:table = {}
 
-  pHeaderInstance.CityNameButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "name", instance ) end )
-  pHeaderInstance.CityPopulationButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "pop", instance ) end )
-  pHeaderInstance.CityHousingButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "house", instance ) end )
-  pHeaderInstance.CityGrowthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "growth", instance ) end )
-  pHeaderInstance.CityAmenitiesButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "amen", instance ) end )
-  pHeaderInstance.CityHappinessButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "happy", instance ) end )
-  pHeaderInstance.CityWarButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "war", instance ) end )
-  pHeaderInstance.CityStatusButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "status", instance ) end )
-  pHeaderInstance.CityStrengthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "str", instance ) end )
-  pHeaderInstance.CityDamageButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_cities( "dam", instance ) end )
+		ContextPtr:BuildInstanceForControl( "CityStatusEntryInstance", pCityInstance, instance.Top )
+		table.insert( instance.Children, pCityInstance )
+		
+		city_fields( kCityData, pCityInstance )
+			
+	end
 
-  --
-  for cityName,kCityData in pairs( m_kCityData ) do
+	Controls.Stack:CalculateSize();
+	Controls.Scroll:CalculateSize();
 
-    local pCityInstance:table = {}
-
-    ContextPtr:BuildInstanceForControl( "CityStatusEntryInstance", pCityInstance, instance.Top )
-    table.insert( instance.Children, pCityInstance )
-
-    city_fields( kCityData, pCityInstance )
-
-  end
-
-  Controls.Stack:CalculateSize();
-  Controls.Scroll:CalculateSize();
-
-  Controls.BottomYieldTotals:SetHide( true );
-  Controls.BottomResourceTotals:SetHide( true );
-  Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - 88);
+	Controls.BottomYieldTotals:SetHide( true );
+	Controls.BottomResourceTotals:SetHide( true );
+	Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - 88);
 end
+
 
 function sort_cities( type, instance )
 
-  local i = 0
-
-  for _, kCityData in spairs( m_kCityData, function( t, a, b ) return city_sortFunction( instance.Descend, type, t, a, b ); end ) do
-    i = i + 1
-    local cityInstance = instance.Children[i]
-
-    city_fields( kCityData, cityInstance )
-  end
-
+	local i = 0
+	
+	for _, kCityData in spairs( m_kCityData, function( t, a, b ) return city_sortFunction( instance.Descend, type, t, a, b ); end ) do
+		i = i + 1
+		local cityInstance = instance.Children[i]
+		
+		city_fields( kCityData, cityInstance )
+	end
+	
 end
 
 function city_sortFunction( descend, type, t, a, b )
 
-  local aCity = 0
-  local bCity = 0
-
-  if type == "name" then
-    aCity = Locale.Lookup( t[a].CityName )
-    bCity = Locale.Lookup( t[b].CityName )
-  elseif type == "pop" then
-    aCity = t[a].Population
-    bCity = t[b].Population
-  elseif type == "house" then
-    aCity = t[a].Housing
-    bCity = t[b].Housing
-  elseif type == "amen" then
-    aCity = t[a].AmenitiesNum
-    bCity = t[b].AmenitiesNum
-  elseif type == "happy" then
-    aCity = t[a].Happiness
-    bCity = t[b].Happiness
-  elseif type == "growth" then
-    aCity = t[a].HousingMultiplier
-    bCity = t[b].HousingMultiplier
-  elseif type == "war" then
-    aCity = t[a].AmenitiesLostFromWarWeariness
-    bCity = t[b].AmenitiesLostFromWarWeariness
-  elseif type == "status" then
-    if t[a].IsUnderSiege == false then aCity = 10 else aCity = 20 end
-    if t[b].IsUnderSiege == false then bCity = 10 else bCity = 20 end
-  elseif type == "str" then
-    aCity = t[a].Defense
-    bCity = t[b].Defense
-  elseif type == "dam" then
-    aCity = t[a].Damage
-    bCity = t[b].Damage
-  end
-
-  if descend then return bCity > aCity else return bCity < aCity end
+	local aCity = 0
+	local bCity = 0
+	
+	if type == "name" then
+		aCity = Locale.Lookup( t[a].CityName )
+		bCity = Locale.Lookup( t[b].CityName )
+	elseif type == "pop" then
+		aCity = t[a].Population
+		bCity = t[b].Population
+	elseif type == "house" then
+		aCity = t[a].Housing
+		bCity = t[b].Housing
+	elseif type == "amen" then
+		aCity = t[a].AmenitiesNum
+		bCity = t[b].AmenitiesNum
+	elseif type == "happy" then
+		aCity = t[a].Happiness
+		bCity = t[b].Happiness
+	elseif type == "growth" then
+		aCity = t[a].HousingMultiplier
+		bCity = t[b].HousingMultiplier
+	elseif type == "war" then
+		aCity = t[a].AmenitiesLostFromWarWeariness
+		bCity = t[b].AmenitiesLostFromWarWeariness
+	elseif type == "status" then
+		if t[a].IsUnderSiege == false then aCity = 10 else aCity = 20 end
+		if t[b].IsUnderSiege == false then bCity = 10 else bCity = 20 end
+	elseif type == "str" then
+		aCity = t[a].Defense
+		bCity = t[b].Defense
+	elseif type == "dam" then
+		aCity = t[a].Damage
+		bCity = t[b].Damage
+	end
+	
+	if descend then return bCity > aCity else return bCity < aCity end
 
 end
 
 function unit_sortFunction( descend, type, t, a, b )
 
-  local aUnit = 0
-  local bUnit = 0
+	local aUnit = 0
+	local bUnit = 0
 
-  if type == "type" then
-    aUnit = UnitManager.GetTypeName( t[a] )
-    bUnit = UnitManager.GetTypeName( t[b] )
-  elseif type == "name" then
-    aUnit = Locale.Lookup( t[a]:GetName() )
-    bUnit = Locale.Lookup( t[b]:GetName() )
-  elseif type == "status" then
-    aUnit = UnitManager.GetActivityType( t[a] )
-    bUnit = UnitManager.GetActivityType( t[b] )
-  elseif type == "level" then
-    aUnit = t[a]:GetExperience():GetLevel()
-    bUnit = t[b]:GetExperience():GetLevel()
-  elseif type == "exp" then
-    aUnit = t[a]:GetExperience():GetExperiencePoints()
-    bUnit = t[b]:GetExperience():GetExperiencePoints()
-  elseif type == "health" then
-    aUnit = t[a]:GetMaxDamage() - t[a]:GetDamage()
-    bUnit = t[b]:GetMaxDamage() - t[b]:GetDamage()
-  elseif type == "move" then
-    if ( t[a]:GetFormationUnitCount() > 1 ) then
-      aUnit = t[a]:GetFormationMovesRemaining()
-    else
-      aUnit = t[a]:GetMovesRemaining()
-    end
-
-    if ( t[b]:GetFormationUnitCount() > 1 ) then
-      bUnit = t[b]:GetFormationMovesRemaining()
-    else
-      bUnit = t[b]:GetMovesRemaining()
-    end
-  elseif type == "charge" then
-    aUnit = t[a]:GetBuildCharges()
-    bUnit = t[b]:GetBuildCharges()
-  elseif type == "yield" then
-    aUnit = t[a].yields
-    bUnit = t[b].yields
-  elseif type == "route" then
-    aUnit = t[a].route
-    bUnit = t[b].route
-  elseif type == "class" then
-    aUnit = t[a]:GetGreatPerson():GetClass()
-    bUnit = t[b]:GetGreatPerson():GetClass()
-  elseif type == "strength" then
-    aUnit = t[a]:GetReligiousStrength()
-    bUnit = t[b]:GetReligiousStrength()
-  elseif type == "spread" then
-    aUnit = t[a]:GetSpreadCharges()
-    bUnit = t[b]:GetSpreadCharges()
-  elseif type == "mission" then
-    aUnit = t[a].mission
-    bUnit = t[b].mission
-  elseif type == "turns" then
-    aUnit = t[a].turns
-    bUnit = t[b].turns
-  end
-
-  if descend then return bUnit > aUnit else return bUnit < aUnit end
-
+	if type == "type" then
+		aUnit = UnitManager.GetTypeName( t[a] )
+		bUnit = UnitManager.GetTypeName( t[b] )
+	elseif type == "name" then
+		aUnit = Locale.Lookup( t[a]:GetName() )
+		bUnit = Locale.Lookup( t[b]:GetName() )
+	elseif type == "status" then
+		aUnit = UnitManager.GetActivityType( t[a] )
+		bUnit = UnitManager.GetActivityType( t[b] )
+	elseif type == "level" then
+		aUnit = t[a]:GetExperience():GetLevel()
+		bUnit = t[b]:GetExperience():GetLevel()
+	elseif type == "exp" then
+		aUnit = t[a]:GetExperience():GetExperiencePoints()
+		bUnit = t[b]:GetExperience():GetExperiencePoints()
+	elseif type == "health" then
+		aUnit = t[a]:GetMaxDamage() - t[a]:GetDamage()
+		bUnit = t[b]:GetMaxDamage() - t[b]:GetDamage()
+	elseif type == "move" then
+		if ( t[a]:GetFormationUnitCount() > 1 ) then
+			aUnit = t[a]:GetFormationMovesRemaining()
+		else
+			aUnit = t[a]:GetMovesRemaining()
+		end
+		
+		if ( t[b]:GetFormationUnitCount() > 1 ) then
+			bUnit = t[b]:GetFormationMovesRemaining()
+		else
+			bUnit = t[b]:GetMovesRemaining()
+		end
+	elseif type == "charge" then
+		aUnit = t[a]:GetBuildCharges()
+		bUnit = t[b]:GetBuildCharges()
+	elseif type == "yield" then
+		aUnit = t[a].yields
+		bUnit = t[b].yields
+	elseif type == "route" then
+		aUnit = t[a].route
+		bUnit = t[b].route
+	elseif type == "class" then
+		aUnit = t[a]:GetGreatPerson():GetClass()
+		bUnit = t[b]:GetGreatPerson():GetClass()
+	elseif type == "strength" then
+		aUnit = t[a]:GetReligiousStrength()
+		bUnit = t[b]:GetReligiousStrength()
+	elseif type == "spread" then
+		aUnit = t[a]:GetSpreadCharges()
+		bUnit = t[b]:GetSpreadCharges()
+	elseif type == "mission" then
+		aUnit = t[a].mission
+		bUnit = t[b].mission
+	elseif type == "turns" then
+		aUnit = t[a].turns
+		bUnit = t[b].turns
+	end
+	
+	if descend then return bUnit > aUnit else return bUnit < aUnit end
+	
 end
 
 function sort_units( type, group, parent )
 
-  local i = 0
-  local unit_group = m_kUnitData["Unit_Report"][group]
-
-  for _, unit in spairs( unit_group.units, function( t, a, b ) return unit_sortFunction( parent.Descend, type, t, a, b ) end ) do
-    i = i + 1
-    local unitInstance = parent.Children[i]
-
-    common_unit_fields( unit, unitInstance )
-    if unit_group.func then unit_group.func( unit, unitInstance, group, parent, type ) end
-
-    unitInstance.LookAtButton:RegisterCallback( Mouse.eLClick, function() Close(); UI.LookAtPlot( unit:GetX( ), unit:GetY( ) ); UI.SelectUnit( unit ); end )
-    unitInstance.LookAtButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound( "Main_Menu_Mouse_Over" ); end )
-  end
-
+	local i = 0
+	local unit_group = m_kUnitData["Unit_Report"][group]
+	
+	for _, unit in spairs( unit_group.units, function( t, a, b ) return unit_sortFunction( parent.Descend, type, t, a, b ) end ) do
+		i = i + 1
+		local unitInstance = parent.Children[i]
+		
+		common_unit_fields( unit, unitInstance )
+		if unit_group.func then unit_group.func( unit, unitInstance, group, parent, type ) end
+		
+		unitInstance.LookAtButton:RegisterCallback( Mouse.eLClick, function() Close(); UI.LookAtPlot( unit:GetX( ), unit:GetY( ) ); UI.SelectUnit( unit ); end )
+		unitInstance.LookAtButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound( "Main_Menu_Mouse_Over" ); end )
+	end
+	
 end
 
 function common_unit_fields( unit, unitInstance )
 
-  if unitInstance.Formation then unitInstance.Formation:SetHide( true ) end
+	if unitInstance.Formation then unitInstance.Formation:SetHide( true ) end
 
-  local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_" .. UnitManager.GetTypeName( unit ), 32 )
-  unitInstance.UnitType:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
-  unitInstance.UnitType:SetToolTipString( Locale.Lookup( GameInfo.Units[UnitManager.GetTypeName( unit )].Name ) )
+	local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_" .. UnitManager.GetTypeName( unit ), 32 )
+	unitInstance.UnitType:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
+	unitInstance.UnitType:SetToolTipString( Locale.Lookup( GameInfo.Units[UnitManager.GetTypeName( unit )].Name ) )
 
-  unitInstance.UnitName:SetText( Locale.Lookup( unit:GetName() ) )
+	unitInstance.UnitName:SetText( Locale.Lookup( unit:GetName() ) )
+			
+	if ( unit:GetFormationUnitCount() > 1 ) then
+		unitInstance.UnitMove:SetText( tostring( unit:GetFormationMovesRemaining() ) .. "/" .. tostring( unit:GetFormationMaxMoves() ) )
+		unitInstance.Formation:SetHide( false )
+	elseif unitInstance.UnitMove then
+		unitInstance.UnitMove:SetText( tostring( unit:GetMovesRemaining() ) .. "/" .. tostring( unit:GetMaxMoves() ) )
+	end
+			
+	-- adds the status icon
+	local activityType:number = UnitManager.GetActivityType( unit )
+	
+	unitInstance.UnitStatus:SetHide( false )
 
-  if ( unit:GetFormationUnitCount() > 1 ) then
-    unitInstance.UnitMove:SetText( tostring( unit:GetFormationMovesRemaining() ) .. "/" .. tostring( unit:GetFormationMaxMoves() ) )
-    unitInstance.Formation:SetHide( false )
-  elseif unitInstance.UnitMove then
-    unitInstance.UnitMove:SetText( tostring( unit:GetMovesRemaining() ) .. "/" .. tostring( unit:GetMaxMoves() ) )
-  end
-
-  -- adds the status icon
-  local activityType:number = UnitManager.GetActivityType( unit )
-
-  unitInstance.UnitStatus:SetHide( false )
-
-  if activityType == ActivityTypes.ACTIVITY_SLEEP then
-    local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_STATS_SLEEP", 22 )
-    unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
-  elseif activityType == ActivityTypes.ACTIVITY_HOLD then
-    local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_STATS_SKIP", 22 )
-    unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
-  elseif activityType ~= ActivityTypes.ACTIVITY_AWAKE and unit:GetFortifyTurns() > 0 then
-    local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_DEFENSE", 22 )
-    unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
-  else
-    -- just use a random icon for sorting purposes
-    local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_STATS_SPREADCHARGES", 22 )
-    unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
-    unitInstance.UnitStatus:SetHide( true )
-  end
-
+	if activityType == ActivityTypes.ACTIVITY_SLEEP then
+		local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_STATS_SLEEP", 22 )
+		unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
+	elseif activityType == ActivityTypes.ACTIVITY_HOLD then
+		local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_STATS_SKIP", 22 )
+		unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
+	elseif activityType ~= ActivityTypes.ACTIVITY_AWAKE and unit:GetFortifyTurns() > 0 then
+		local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_DEFENSE", 22 )
+		unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
+	else
+		-- just use a random icon for sorting purposes
+		local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas( "ICON_STATS_SPREADCHARGES", 22 )
+		unitInstance.UnitStatus:SetTexture( textureOffsetX, textureOffsetY, textureSheet )
+		unitInstance.UnitStatus:SetHide( true )
+	end
+	
 end
 
 function group_military( unit, unitInstance, group, parent, type )
 
-  local unitExp : table = unit:GetExperience()
+	local unitExp : table = unit:GetExperience()
+	
+	unitInstance.Promotion:SetHide( true )
+	unitInstance.Upgrade:SetHide( true )
+				
+	if ( unit:GetMilitaryFormation() == MilitaryFormationTypes.CORPS_FORMATION ) then
+		unitInstance.UnitName:SetText( Locale.Lookup( unit:GetName() ) .. " " .. "[ICON_Corps]" )
+	elseif ( unit:GetMilitaryFormation() == MilitaryFormationTypes.ARMY_FORMATION ) then
+		unitInstance.UnitName:SetText( Locale.Lookup( unit:GetName() ) .. " " .. "[ICON_Army]" )
+	end
+			
+	unitInstance.UnitLevel:SetText( tostring( unitExp:GetLevel() ) )
+				
+	unitInstance.UnitExp:SetText( tostring( unitExp:GetExperiencePoints() ) .. "/" .. tostring( unitExp:GetExperienceForNextLevel() ) )
+	
+	local bCanStart, tResults = UnitManager.CanStartCommand( unit, UnitCommandTypes.PROMOTE, true, true );
+	
+	if ( bCanStart and tResults ) then
+		unitInstance.Promotion:SetHide( false )
+		local tPromotions = tResults[UnitCommandResults.PROMOTIONS];
+		unitInstance.Promotion:RegisterCallback( Mouse.eLClick, function() bUnits.group = group; bUnits.parent = parent; bUnits.type = type; LuaEvents.Report_PromoteUnit( unit ); end )
+	end
 
-  unitInstance.Promotion:SetHide( true )
-  unitInstance.Upgrade:SetHide( true )
+	unitInstance.UnitHealth:SetText( tostring( unit:GetMaxDamage() - unit:GetDamage() ) .. "/" .. tostring( unit:GetMaxDamage() ) )
+			
+	local bCanStart, tResults = UnitManager.CanStartOperation( unit, UnitOperationTypes.UPGRADE, nil, true );
 
-  if ( unit:GetMilitaryFormation() == MilitaryFormationTypes.CORPS_FORMATION ) then
-    unitInstance.UnitName:SetText( Locale.Lookup( unit:GetName() ) .. " " .. "[ICON_Corps]" )
-  elseif ( unit:GetMilitaryFormation() == MilitaryFormationTypes.ARMY_FORMATION ) then
-    unitInstance.UnitName:SetText( Locale.Lookup( unit:GetName() ) .. " " .. "[ICON_Army]" )
-  end
+	if ( bCanStart ) then
+		local bCanStart, tResults = UnitManager.CanStartOperation( unit, UnitOperationTypes.UPGRADE, nil, false, true )
+					
+		unitInstance.Upgrade:SetHide( false )
+		unitInstance.Upgrade:RegisterCallback( Mouse.eLClick, function() bUnits.group = group; bUnits.parent = parent; bUnits.type = type; UnitManager.RequestOperation( unit, UnitOperationTypes.UPGRADE ); end )
+		local upgradeUnitName = GameInfo.Units[tResults[UnitOperationResults.UNIT_TYPE]].Name;
+		local toolTipString	= Locale.Lookup( "LOC_UNITOPERATION_UPGRADE_DESCRIPTION" );
+		toolTipString = toolTipString .. " " .. Locale.Lookup(upgradeUnitName);
+		local upgradeCost = unit:GetUpgradeCost();
+					
+		if (upgradeCost ~= nil) then
+			toolTipString = toolTipString .. ": " .. upgradeCost .. " " .. Locale.Lookup("LOC_TOP_PANEL_GOLD");
+		end
 
-  unitInstance.UnitLevel:SetText( tostring( unitExp:GetLevel() ) )
-
-  unitInstance.UnitExp:SetText( tostring( unitExp:GetExperiencePoints() ) .. "/" .. tostring( unitExp:GetExperienceForNextLevel() ) )
-
-  local bCanStart, tResults = UnitManager.CanStartCommand( unit, UnitCommandTypes.PROMOTE, true, true );
-
-  if ( bCanStart and tResults ) then
-    unitInstance.Promotion:SetHide( false )
-    local tPromotions = tResults[UnitCommandResults.PROMOTIONS];
-    unitInstance.Promotion:RegisterCallback( Mouse.eLClick, function() bUnits.group = group; bUnits.parent = parent; bUnits.type = type; LuaEvents.Report_PromoteUnit( unit ); end )
-  end
-
-  unitInstance.UnitHealth:SetText( tostring( unit:GetMaxDamage() - unit:GetDamage() ) .. "/" .. tostring( unit:GetMaxDamage() ) )
-
-  local bCanStart, tResults = UnitManager.CanStartOperation( unit, UnitOperationTypes.UPGRADE, nil, true );
-
-  if ( bCanStart ) then
-    local bCanStart, tResults = UnitManager.CanStartOperation( unit, UnitOperationTypes.UPGRADE, nil, false, true )
-
-    unitInstance.Upgrade:SetHide( false )
-    unitInstance.Upgrade:RegisterCallback( Mouse.eLClick, function() bUnits.group = group; bUnits.parent = parent; bUnits.type = type; UnitManager.RequestOperation( unit, UnitOperationTypes.UPGRADE ); end )
-    local upgradeUnitName = GameInfo.Units[tResults[UnitOperationResults.UNIT_TYPE]].Name;
-    local toolTipString = Locale.Lookup( "LOC_UNITOPERATION_UPGRADE_DESCRIPTION" );
-    toolTipString = toolTipString .. " " .. Locale.Lookup(upgradeUnitName);
-    local upgradeCost = unit:GetUpgradeCost();
-
-    if (upgradeCost ~= nil) then
-      toolTipString = toolTipString .. ": " .. upgradeCost .. " " .. Locale.Lookup("LOC_TOP_PANEL_GOLD");
-    end
-
-    toolTipString = Locale.Lookup( "LOC_UNITOPERATION_UPGRADE_INFO", upgradeUnitName, upgradeCost );
-
-    if (tResults[UnitOperationResults.FAILURE_REASONS] ~= nil) then
-      -- Add the reason(s) to the tool tip
-      for i,v in ipairs(tResults[UnitOperationResults.FAILURE_REASONS]) do
-        toolTipString = toolTipString .. "[NEWLINE]" .. "[COLOR:Red]" .. Locale.Lookup(v) .. "[ENDCOLOR]";
-      end
-    end
-
-    unitInstance.Upgrade:SetToolTipString( toolTipString )
-  end
-
+		toolTipString = Locale.Lookup( "LOC_UNITOPERATION_UPGRADE_INFO", upgradeUnitName, upgradeCost );
+					
+		if (tResults[UnitOperationResults.FAILURE_REASONS] ~= nil) then
+			-- Add the reason(s) to the tool tip
+			for i,v in ipairs(tResults[UnitOperationResults.FAILURE_REASONS]) do
+				toolTipString = toolTipString .. "[NEWLINE]" .. "[COLOR:Red]" .. Locale.Lookup(v) .. "[ENDCOLOR]";
+			end
+		end
+						
+		unitInstance.Upgrade:SetToolTipString( toolTipString )
+	end
+	
 end
 
 function group_civilian( unit, unitInstance, group, parent, type )
 
-  unitInstance.UnitCharges:SetText( tostring( unit:GetBuildCharges() ) )
-
+	unitInstance.UnitCharges:SetText( tostring( unit:GetBuildCharges() ) )
+	
 end
 
 function group_great( unit, unitInstance, group, parent, type )
 
-  unitInstance.UnitClass:SetText( Locale.Lookup( GameInfo.GreatPersonClasses[unit:GetGreatPerson():GetClass()].Name ) )
+	unitInstance.UnitClass:SetText( Locale.Lookup( GameInfo.GreatPersonClasses[unit:GetGreatPerson():GetClass()].Name ) )
 
 end
 
 function group_religious( unit, unitInstance, group, parent, type )
 
-  unitInstance.UnitSpreads:SetText( unit:GetSpreadCharges() )
-  unitInstance.UnitStrength:SetText( unit:GetReligiousStrength() )
+	unitInstance.UnitSpreads:SetText( unit:GetSpreadCharges() )
+	unitInstance.UnitStrength:SetText( unit:GetReligiousStrength() )
 
 end
 
 function group_spy( unit, unitInstance, group, parent, type )
 
-  local operationType : number = unit:GetSpyOperation();
+	local operationType : number = unit:GetSpyOperation();
+	
+	unitInstance.UnitOperation:SetText( "None" )
+	unitInstance.UnitTurns:SetText( "0" )
+	unit.mission = "None"
+	unit.turns = 0
 
-  unitInstance.UnitOperation:SetText( "None" )
-  unitInstance.UnitTurns:SetText( "0" )
-  unit.mission = "None"
-  unit.turns = 0
+	if ( operationType ~= -1 ) then
+		-- Mission Name
+		local operationInfo:table = GameInfo.UnitOperations[operationType];
+		unitInstance.UnitOperation:SetText( Locale.Lookup( operationInfo.Description ) )
 
-  if ( operationType ~= -1 ) then
-    -- Mission Name
-    local operationInfo:table = GameInfo.UnitOperations[operationType];
-    unitInstance.UnitOperation:SetText( Locale.Lookup( operationInfo.Description ) )
-
-    -- Turns Remaining
-    unitInstance.UnitTurns:SetText( Locale.Lookup( "LOC_UNITPANEL_ESPIONAGE_MORE_TURNS", unit:GetSpyOperationEndTurn() - Game.GetCurrentGameTurn() ) )
-
-    unit.mission = Locale.Lookup( operationInfo.Description )
-    unit.turns = unit:GetSpyOperationEndTurn() - Game.GetCurrentGameTurn()
-  end
+		-- Turns Remaining
+		unitInstance.UnitTurns:SetText( Locale.Lookup( "LOC_UNITPANEL_ESPIONAGE_MORE_TURNS", unit:GetSpyOperationEndTurn() - Game.GetCurrentGameTurn() ) )
+		
+		unit.mission = Locale.Lookup( operationInfo.Description )
+		unit.turns = unit:GetSpyOperationEndTurn() - Game.GetCurrentGameTurn()
+	end
 
 end
 
 function group_trader( unit, unitInstance, group, parent, type )
 
-  local owningPlayer:table = Players[unit:GetOwner()];
-  local cities:table = owningPlayer:GetCities();
-  local yieldtype : table = { ["YIELD_FOOD"] = "[ICON_Food]",
-    ["YIELD_PRODUCTION"] = "[ICON_Production]",
-    ["YIELD_GOLD"] = "[ICON_Gold]",
-    ["YIELD_SCIENCE"] = "[ICON_Science]",
-    ["YIELD_CULTURE"] = "[ICON_Culture]",
-    ["YIELD_FAITH"] = "[ICON_Faith]"
-  }
-  local yields : string = ""
+	local owningPlayer:table = Players[unit:GetOwner()];
+	local cities:table = owningPlayer:GetCities();
+	local yieldtype : table = { ["YIELD_FOOD"] = "[ICON_Food]",
+								["YIELD_PRODUCTION"] = "[ICON_Production]",
+								["YIELD_GOLD"] = "[ICON_Gold]",
+								["YIELD_SCIENCE"] = "[ICON_Science]",
+								["YIELD_CULTURE"] = "[ICON_Culture]",
+								["YIELD_FAITH"] = "[ICON_Faith]"
+										  }
+	local yields : string = ""
+	
+	unitInstance.UnitYields:SetText( "No Yields" )
+	unitInstance.UnitRoute:SetText( "No Route" )
+	unit.yields = "No Yields"
+	unit.route = "No Route"
 
-  unitInstance.UnitYields:SetText( "No Yields" )
-  unitInstance.UnitRoute:SetText( "No Route" )
-  unit.yields = "No Yields"
-  unit.route = "No Route"
+	for _, city in cities:Members() do
+		local outgoingRoutes:table = city:GetTrade():GetOutgoingRoutes();
+	
+		for i,route in ipairs(outgoingRoutes) do
+			if unit:GetID() == route.TraderUnitID then
+				-- Find origin city
+				local originCity:table = cities:FindID(route.OriginCityID);
 
-  for _, city in cities:Members() do
-    local outgoingRoutes:table = city:GetTrade():GetOutgoingRoutes();
+				-- Find destination city
+				local destinationPlayer:table = Players[route.DestinationCityPlayer];
+				local destinationCities:table = destinationPlayer:GetCities();
+				local destinationCity:table = destinationCities:FindID(route.DestinationCityID);
 
-    for i,route in ipairs(outgoingRoutes) do
-      if unit:GetID() == route.TraderUnitID then
-        -- Find origin city
-        local originCity:table = cities:FindID(route.OriginCityID);
+				-- Set origin to destination name
+				if originCity and destinationCity then
+					unitInstance.UnitRoute:SetText( Locale.Lookup("LOC_HUD_UNIT_PANEL_TRADE_ROUTE_NAME", originCity:GetName(), destinationCity:GetName()) )
+					unit.route = Locale.Lookup("LOC_HUD_UNIT_PANEL_TRADE_ROUTE_NAME", originCity:GetName(), destinationCity:GetName())
+				end
 
-        -- Find destination city
-        local destinationPlayer:table = Players[route.DestinationCityPlayer];
-        local destinationCities:table = destinationPlayer:GetCities();
-        local destinationCity:table = destinationCities:FindID(route.DestinationCityID);
-
-        -- Set origin to destination name
-        if originCity and destinationCity then
-          unitInstance.UnitRoute:SetText( Locale.Lookup("LOC_HUD_UNIT_PANEL_TRADE_ROUTE_NAME", originCity:GetName(), destinationCity:GetName()) )
-          unit.route = Locale.Lookup("LOC_HUD_UNIT_PANEL_TRADE_ROUTE_NAME", originCity:GetName(), destinationCity:GetName())
-        end
-
-        for j, yieldInfo in pairs( route.OriginYields ) do
-          if yieldInfo.Amount > 0 then
-            local yieldDetails:table = GameInfo.Yields[yieldInfo.YieldIndex];
-            yields = yields .. yieldtype[yieldDetails.YieldType] .. "+" .. yieldInfo.Amount
-            unitInstance.UnitYields:SetText( yields )
-            unit.yields = yields
-          end
-        end
-      end
-    end
-  end
-
+				for j, yieldInfo in pairs( route.OriginYields ) do
+					if yieldInfo.Amount > 0 then
+						local yieldDetails:table = GameInfo.Yields[yieldInfo.YieldIndex];
+						yields = yields .. yieldtype[yieldDetails.YieldType] .. "+" .. yieldInfo.Amount
+						unitInstance.UnitYields:SetText( yields )
+						unit.yields = yields
+					end
+				end
+			end
+		end
+	end
+	
 end
 
 -- ===========================================================================
--- !! Start of Deals Report Page
+--	!! Start of Deals Report Page
 -- ===========================================================================
 function ViewDealsPage()
 
-  ResetTabForNewPageContent();
+	ResetTabForNewPageContent();
+	
+	for j, pDeal in spairs( m_kCurrentDeals, function( t, a, b ) return t[b].EndTurn > t[a].EndTurn end ) do
+		local ending = pDeal.EndTurn - Game.GetCurrentGameTurn()
+		local turns = "turns"
+		if ending == 1 then turns = "turn" end
 
-  for j, pDeal in spairs( m_kCurrentDeals, function( t, a, b ) return t[b].EndTurn > t[a].EndTurn end ) do
-    local ending = pDeal.EndTurn - Game.GetCurrentGameTurn()
-    local turns = "turns"
-    if ending == 1 then turns = "turn" end
+		local instance : table = NewCollapsibleGroupInstance()
 
-    local instance : table = NewCollapsibleGroupInstance()
+		instance.RowHeaderButton:SetText( "Deal With " .. pDeal.WithCivilization )
+		instance.RowHeaderLabel:SetText( "Ends in " .. ending .. " " .. turns .. " (" .. pDeal.EndTurn .. ")" )
+		instance.RowHeaderLabel:SetHide( false )
 
-    instance.RowHeaderButton:SetText( "Deal With " .. pDeal.WithCivilization )
-    instance.RowHeaderLabel:SetText( "Ends in " .. ending .. " " .. turns .. " (" .. pDeal.EndTurn .. ")" )
-    instance.RowHeaderLabel:SetHide( false )
+		local dealHeaderInstance : table = {}
+		ContextPtr:BuildInstanceForControl( "DealsHeader", dealHeaderInstance, instance.ContentStack )
 
-    local dealHeaderInstance : table = {}
-    ContextPtr:BuildInstanceForControl( "DealsHeader", dealHeaderInstance, instance.ContentStack )
+		local iSlots = #pDeal.Sending
 
-    local iSlots = #pDeal.Sending
+		if iSlots < #pDeal.Receiving then iSlots = #pDeal.Receiving end
 
-    if iSlots < #pDeal.Receiving then iSlots = #pDeal.Receiving end
+		for i = 1, iSlots do
+			local dealInstance : table = {}
+			ContextPtr:BuildInstanceForControl( "DealsInstance", dealInstance, instance.ContentStack )
+			table.insert( instance.Children, dealInstance )
+		end
 
-    for i = 1, iSlots do
-      local dealInstance : table = {}
-      ContextPtr:BuildInstanceForControl( "DealsInstance", dealInstance, instance.ContentStack )
-      table.insert( instance.Children, dealInstance )
-    end
+		for i, pDealItem in pairs( pDeal.Sending ) do
+			if pDealItem.Icon then
+				instance.Children[i].Outgoing:SetText( pDealItem.Icon .. " " .. pDealItem.Name )
+			else
+				instance.Children[i].Outgoing:SetText( pDealItem.Name )
+			end
+		end
 
-    for i, pDealItem in pairs( pDeal.Sending ) do
-      if pDealItem.Icon then
-        instance.Children[i].Outgoing:SetText( pDealItem.Icon .. " " .. pDealItem.Name )
-      else
-        instance.Children[i].Outgoing:SetText( pDealItem.Name )
-      end
-    end
-
-    for i, pDealItem in pairs( pDeal.Receiving ) do
-      if pDealItem.Icon then
-        instance.Children[i].Incoming:SetText( pDealItem.Icon .. " " .. pDealItem.Name )
-      else
-        instance.Children[i].Incoming:SetText( pDealItem.Name )
-      end
-    end
-
-    local pFooterInstance:table = {}
-    ContextPtr:BuildInstanceForControl( "DealsFooterInstance", pFooterInstance, instance.ContentStack )
-    pFooterInstance.Outgoing:SetText( "Total: " .. #pDeal.Sending )
-    pFooterInstance.Incoming:SetText( "Total: " .. #pDeal.Receiving )
-
-    SetGroupCollapsePadding( instance, pFooterInstance.Top:GetSizeY() )
-    RealizeGroup( instance );
-  end
-
-  Controls.Stack:CalculateSize();
-  Controls.Scroll:CalculateSize();
-
-  Controls.BottomYieldTotals:SetHide( true )
-  Controls.BottomResourceTotals:SetHide( true )
-  Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - 88 )
+		for i, pDealItem in pairs( pDeal.Receiving ) do
+			if pDealItem.Icon then
+				instance.Children[i].Incoming:SetText( pDealItem.Icon .. " " .. pDealItem.Name )
+			else
+				instance.Children[i].Incoming:SetText( pDealItem.Name )
+			end
+		end
+	
+		local pFooterInstance:table = {}
+		ContextPtr:BuildInstanceForControl( "DealsFooterInstance", pFooterInstance, instance.ContentStack )
+		pFooterInstance.Outgoing:SetText( "Total: " .. #pDeal.Sending )
+		pFooterInstance.Incoming:SetText( "Total: " .. #pDeal.Receiving )
+	
+		SetGroupCollapsePadding( instance, pFooterInstance.Top:GetSizeY() )
+		RealizeGroup( instance );
+	end
+	
+	Controls.Stack:CalculateSize();
+	Controls.Scroll:CalculateSize();
+	
+	Controls.BottomYieldTotals:SetHide( true )
+	Controls.BottomResourceTotals:SetHide( true )
+	Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - 88 )
 
 end
 
 -- ===========================================================================
--- !! Start of Unit Report Page
+--	!! Start of Unit Report Page
 -- ===========================================================================
 function ViewUnitsPage()
 
-  ResetTabForNewPageContent();
+	ResetTabForNewPageContent();
+	
+	for iUnitGroup, kUnitGroup in spairs( m_kUnitData["Unit_Report"], function( t, a, b ) return t[b].ID > t[a].ID end ) do
+		local instance : table = NewCollapsibleGroupInstance()
+		
+		instance.RowHeaderButton:SetText( kUnitGroup.Name )
+		
+		local pHeaderInstance:table = {}
+		ContextPtr:BuildInstanceForControl( kUnitGroup.Header, pHeaderInstance, instance.ContentStack )
 
-  for iUnitGroup, kUnitGroup in spairs( m_kUnitData["Unit_Report"], function( t, a, b ) return t[b].ID > t[a].ID end ) do
-    local instance : table = NewCollapsibleGroupInstance()
+		if pHeaderInstance.UnitTypeButton then pHeaderInstance.UnitTypeButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "type", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitNameButton then pHeaderInstance.UnitNameButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "name", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitStatusButton then pHeaderInstance.UnitStatusButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "status", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitLevelButton then pHeaderInstance.UnitLevelButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "level", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitExpButton then pHeaderInstance.UnitExpButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "exp", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitHealthButton then pHeaderInstance.UnitHealthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "health", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitMoveButton then pHeaderInstance.UnitMoveButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "move", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitChargeButton then pHeaderInstance.UnitChargeButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "charge", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitYieldButton then pHeaderInstance.UnitYieldButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "yield", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitRouteButton then pHeaderInstance.UnitRouteButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "route", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitClassButton then pHeaderInstance.UnitClassButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "class", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitStrengthButton then pHeaderInstance.UnitStrengthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "strength", iUnitGroup, instance ) end ) end
+		if pHeaderInstance.UnitSpreadButton then pHeaderInstance.UnitSpreadButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "spread", iUnitGroup, instance ) end ) end
 
-    instance.RowHeaderButton:SetText( kUnitGroup.Name )
+		for i, unit in ipairs( kUnitGroup.units ) do			
+			local unitInstance:table = {}
+			table.insert( instance.Children, unitInstance )
+			
+			ContextPtr:BuildInstanceForControl( kUnitGroup.Entry, unitInstance, instance.ContentStack )
+			
+			common_unit_fields( unit, unitInstance )
+			
+			if kUnitGroup.func then kUnitGroup.func( unit, unitInstance, iUnitGroup, instance ) end
+			
+			-- allows you to select a unit and zoom to them
+			unitInstance.LookAtButton:RegisterCallback( Mouse.eLClick, function() Close(); UI.LookAtPlot( unit:GetX( ), unit:GetY( ) ); UI.SelectUnit( unit ); end )
+			unitInstance.LookAtButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound( "Main_Menu_Mouse_Over" ); end )
+		end
+	
+		local pFooterInstance:table = {}
+		ContextPtr:BuildInstanceForControl( "UnitsFooterInstance", pFooterInstance, instance.ContentStack )
+		pFooterInstance.Amount:SetText( tostring( #kUnitGroup.units ) )
+	
+		SetGroupCollapsePadding( instance, pFooterInstance.Top:GetSizeY() )
+		RealizeGroup( instance )
+	end
 
-    local pHeaderInstance:table = {}
-    ContextPtr:BuildInstanceForControl( kUnitGroup.Header, pHeaderInstance, instance.ContentStack )
-
-    if pHeaderInstance.UnitTypeButton then pHeaderInstance.UnitTypeButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "type", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitNameButton then pHeaderInstance.UnitNameButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "name", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitStatusButton then pHeaderInstance.UnitStatusButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "status", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitLevelButton then pHeaderInstance.UnitLevelButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "level", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitExpButton then pHeaderInstance.UnitExpButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "exp", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitHealthButton then pHeaderInstance.UnitHealthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "health", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitMoveButton then pHeaderInstance.UnitMoveButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "move", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitChargeButton then pHeaderInstance.UnitChargeButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "charge", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitYieldButton then pHeaderInstance.UnitYieldButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "yield", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitRouteButton then pHeaderInstance.UnitRouteButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "route", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitClassButton then pHeaderInstance.UnitClassButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "class", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitStrengthButton then pHeaderInstance.UnitStrengthButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "strength", iUnitGroup, instance ) end ) end
-    if pHeaderInstance.UnitSpreadButton then pHeaderInstance.UnitSpreadButton:RegisterCallback( Mouse.eLClick, function() instance.Descend = not instance.Descend; sort_units( "spread", iUnitGroup, instance ) end ) end
-
-    for i, unit in ipairs( kUnitGroup.units ) do
-      local unitInstance:table = {}
-      table.insert( instance.Children, unitInstance )
-
-      ContextPtr:BuildInstanceForControl( kUnitGroup.Entry, unitInstance, instance.ContentStack )
-
-      common_unit_fields( unit, unitInstance )
-
-      if kUnitGroup.func then kUnitGroup.func( unit, unitInstance, iUnitGroup, instance ) end
-
-      -- allows you to select a unit and zoom to them
-      unitInstance.LookAtButton:RegisterCallback( Mouse.eLClick, function() Close(); UI.LookAtPlot( unit:GetX( ), unit:GetY( ) ); UI.SelectUnit( unit ); end )
-      unitInstance.LookAtButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound( "Main_Menu_Mouse_Over" ); end )
-    end
-
-    local pFooterInstance:table = {}
-    ContextPtr:BuildInstanceForControl( "UnitsFooterInstance", pFooterInstance, instance.ContentStack )
-    pFooterInstance.Amount:SetText( tostring( #kUnitGroup.units ) )
-
-    SetGroupCollapsePadding( instance, pFooterInstance.Top:GetSizeY() )
-    RealizeGroup( instance )
-  end
-
-  Controls.Stack:CalculateSize();
-  Controls.Scroll:CalculateSize();
-
-  Controls.BottomYieldTotals:SetHide( true )
-  Controls.BottomResourceTotals:SetHide( true )
-  Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - 88 )
+	Controls.Stack:CalculateSize();
+	Controls.Scroll:CalculateSize();
+	
+	Controls.BottomYieldTotals:SetHide( true )
+	Controls.BottomResourceTotals:SetHide( true )
+	Controls.Scroll:SetSizeY( Controls.Main:GetSizeY() - 88 )
+	
 
 end
 
 -- ===========================================================================
--- !! End of Unit Report Page
+--	!! End of Unit Report Page
 -- ===========================================================================
 
 -- ===========================================================================
 --
 -- ===========================================================================
 function AddTabSection( name:string, populateCallback:ifunction )
-  local kTab :table = m_tabIM:GetInstance();
-  kTab.Button[DATA_FIELD_SELECTION] = kTab.Selection;
+	local kTab		:table				= m_tabIM:GetInstance();	
+	kTab.Button[DATA_FIELD_SELECTION]	= kTab.Selection;
 
-  local callback :ifunction = function()
-    if m_tabs.prevSelectedControl ~= nil then
-      m_tabs.prevSelectedControl[DATA_FIELD_SELECTION]:SetHide(true);
-    end
-    kTab.Selection:SetHide(false);
-    populateCallback();
-  end
+	local callback	:ifunction	= function()
+		if m_tabs.prevSelectedControl ~= nil then
+			m_tabs.prevSelectedControl[DATA_FIELD_SELECTION]:SetHide(true);
+		end
+		kTab.Selection:SetHide(false);
+		populateCallback();
+	end
 
-  kTab.Button:GetTextControl():SetText( Locale.Lookup(name) );
-  kTab.Button:SetSizeToText( 40, 20 );
-  kTab.Button:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
+	kTab.Button:GetTextControl():SetText( Locale.Lookup(name) );
+	kTab.Button:SetSizeToText( 40, 20 );
+    kTab.Button:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
 
-  m_tabs.AddTab( kTab.Button, callback );
+	m_tabs.AddTab( kTab.Button, callback );
 end
 
+
 -- ===========================================================================
--- UI Callback
+--	UI Callback
 -- ===========================================================================
 function OnInputHandler( pInputStruct:table )
-  local uiMsg :number = pInputStruct:GetMessageType();
-  if uiMsg == KeyEvents.KeyUp then
-    local uiKey = pInputStruct:GetKey();
-    if uiKey == Keys.VK_ESCAPE then
-      if ContextPtr:IsHidden()==false then
-        Close();
-        return true;
-      end
-    end
-  end
-  return false;
+	local uiMsg :number = pInputStruct:GetMessageType();
+	if uiMsg == KeyEvents.KeyUp then 
+		local uiKey = pInputStruct:GetKey();
+		if uiKey == Keys.VK_ESCAPE then
+			if ContextPtr:IsHidden()==false then
+				Close();
+				return true;
+			end
+		end		
+	end
+	return false;
 end
 
+
 -- ===========================================================================
--- UI Event
+--	UI Event
 -- ===========================================================================
 function OnInit( isReload:boolean )
-  if isReload then
-    if ContextPtr:IsHidden()==false then
-      Open();
-    end
-  end
-  m_tabs.AddAnimDeco(Controls.TabAnim, Controls.TabArrow);
+	if isReload then		
+		if ContextPtr:IsHidden()==false then
+			Open();
+		end
+	end
+	m_tabs.AddAnimDeco(Controls.TabAnim, Controls.TabArrow);	
 end
+
 
 -- ===========================================================================
 function Resize()
-  local topPanelSizeY:number = 30;
+	local topPanelSizeY:number = 30;
 
-  if m_debugFullHeight then
-    x,y = UIManager:GetScreenSizeVal();
-    Controls.Main:SetSizeY( y - topPanelSizeY );
-    Controls.Main:SetOffsetY( topPanelSizeY * 0.5 );
-  end
+	if m_debugFullHeight then
+		x,y = UIManager:GetScreenSizeVal();
+		Controls.Main:SetSizeY( y - topPanelSizeY );
+		Controls.Main:SetOffsetY( topPanelSizeY * 0.5 );
+	end
 end
 
 -- ===========================================================================
@@ -1663,45 +1877,45 @@ end
 -- ===========================================================================
 
 function OnToggleCityBuildings()
-  local isChecked = Controls.CityBuildingsCheckbox:IsSelected();
-  Controls.CityBuildingsCheckbox:SetSelected( not isChecked );
-  ViewYieldsPage()
+	local isChecked = Controls.CityBuildingsCheckbox:IsSelected();
+	Controls.CityBuildingsCheckbox:SetSelected( not isChecked );
+	ViewYieldsPage()
 end
 
 function Initialize()
 
-  Resize();
+	Resize();
 
-  m_tabs = CreateTabs( Controls.TabContainer, 42, 34, 0xFF331D05 );
-  --AddTabSection( "Test", ViewTestPage ); --TRONSTER debug
-  --AddTabSection( "Test2", ViewTestPage ); --TRONSTER debug
-  AddTabSection( "LOC_HUD_REPORTS_TAB_YIELDS", ViewYieldsPage );
-  AddTabSection( "LOC_HUD_REPORTS_TAB_RESOURCES", ViewResourcesPage );
-  AddTabSection( "LOC_HUD_REPORTS_TAB_CITY_STATUS", ViewCityStatusPage );
-  AddTabSection( "Current Deals", ViewDealsPage );
-  AddTabSection( "Units", ViewUnitsPage );
+	m_tabs = CreateTabs( Controls.TabContainer, 42, 34, 0xFF331D05 );
+	--AddTabSection( "Test",								ViewTestPage );			--TRONSTER debug
+	--AddTabSection( "Test2",								ViewTestPage );			--TRONSTER debug
+	AddTabSection( "LOC_HUD_REPORTS_TAB_YIELDS",		ViewYieldsPage );
+	AddTabSection( "LOC_HUD_REPORTS_TAB_RESOURCES",		ViewResourcesPage );
+	AddTabSection( "LOC_HUD_REPORTS_TAB_CITY_STATUS",	ViewCityStatusPage );
+	AddTabSection( "Current Deals",						ViewDealsPage );
+	AddTabSection( "Units",								ViewUnitsPage );
 
-  m_tabs.SameSizedTabs(50);
-  m_tabs.CenterAlignTabs(-10);
+	m_tabs.SameSizedTabs(50);
+	m_tabs.CenterAlignTabs(-10);
 
-  -- UI Callbacks
-  ContextPtr:SetInitHandler( OnInit );
-  ContextPtr:SetInputHandler( OnInputHandler, true );
-  ContextPtr:SetRefreshHandler( function() if bUnits.group then m_kCityData, m_kCityTotalData, m_kResourceData, m_kUnitData, m_kDealData, m_kCultureData, m_kCurrentDeals = GetData(); sort_units( bUnits.type, bUnits.group, bUnits.parent ); end; end )
+	-- UI Callbacks
+	ContextPtr:SetInitHandler( OnInit );
+	ContextPtr:SetInputHandler( OnInputHandler, true );
+	ContextPtr:SetRefreshHandler( function() if bUnits.group then m_kCityData, m_kCityTotalData, m_kResourceData, m_kUnitData, m_kDealData, m_kCultureData, m_kCurrentDeals = GetData(); sort_units( bUnits.type, bUnits.group, bUnits.parent ); end; end )
+	
+	Events.UnitPromoted.Add( function() LuaEvents.UnitPanel_HideUnitPromotion(); ContextPtr:RequestRefresh() end )
+	Events.UnitUpgraded.Add( function() ContextPtr:RequestRefresh() end )
 
-  Events.UnitPromoted.Add( function() LuaEvents.UnitPanel_HideUnitPromotion(); ContextPtr:RequestRefresh() end )
-  Events.UnitUpgraded.Add( function() ContextPtr:RequestRefresh() end )
+	Controls.CloseButton:RegisterCallback( Mouse.eLClick, OnCloseButton );
+	Controls.CloseButton:RegisterCallback(	Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
+	Controls.CollapseAll:RegisterCallback( Mouse.eLClick, OnCollapseAllButton );
+	Controls.CollapseAll:RegisterCallback(	Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
 
-  Controls.CloseButton:RegisterCallback( Mouse.eLClick, OnCloseButton );
-  Controls.CloseButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
-  Controls.CollapseAll:RegisterCallback( Mouse.eLClick, OnCollapseAllButton );
-  Controls.CollapseAll:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
-
-  Controls.CityBuildingsCheckbox:RegisterCallback( Mouse.eLClick, OnToggleCityBuildings )
-  Controls.CityBuildingsCheckbox:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end )
-
-  -- Events
-  LuaEvents.TopPanel_OpenReportsScreen.Add( OnTopOpenReportsScreen );
-  LuaEvents.TopPanel_CloseReportsScreen.Add( OnTopCloseReportsScreen );
+	Controls.CityBuildingsCheckbox:RegisterCallback( Mouse.eLClick, OnToggleCityBuildings )
+	Controls.CityBuildingsCheckbox:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end )
+	
+	-- Events
+	LuaEvents.TopPanel_OpenReportsScreen.Add( OnTopOpenReportsScreen );
+	LuaEvents.TopPanel_CloseReportsScreen.Add( OnTopCloseReportsScreen );
 end
 Initialize();

--- a/URS/ReportScreen.xml
+++ b/URS/ReportScreen.xml
@@ -1,1407 +1,1418 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Context xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="..\..\..\..\..\CivTech\Libs\ForgeUI\ForgeUI_Assets\Controls.xsd">
 
-  <Container Style="FullScreenVignetteConsumer" />
+	<Container Style="FullScreenVignetteConsumer" />
 
-  <Box            ID="Main"           Anchor="C,C"                  Size="1024,759"           Color="11,27,40,255">
-    <Grid                             Anchor="C,C"                  Size="parent+9,parent+9"  Style="WindowFrameTopOnly" />
-    <Button       ID="CloseButton"    Anchor="R,T"  Offset="-3,-1"  Size="44,44"                                      Texture="Controls_CloseLarge"  />
-    <Image                            Anchor="C,T"                  Size="parent,44"          Color="61,112,154,255"  Texture="Controls_Gradient_HalfRadial"  />
-    <GridButton   ID="CollapseAll"                  Offset="48,13"  SizeToText="80,12"        Style="RoundedButton"   String="LOC_HUD_REPORTS_COLLAPSE_ALL"  Hidden="0" />
-    <GridButton   ID="CityBuildingsCheckbox"  Style="CheckBoxControl" SizeToText="80,12" String="Hide City Buildings" Offset="220,15" Hidden="1"/>
-    <Label                            Anchor="C,T"  Offset="0,16"                             Style="FontFlair20"     String="{LOC_HUD_REPORTS_TITLE:upper}" FontStyle="Glow" Color0="133,205,235,255" Color1="203,215,225,100" Color2="254,254,254,255" SmallCaps="28" SmallCapsType="EveryWord" />
-    <Grid                             Anchor="C,T"  Offset="0,44"   Size="parent-6,8"         Style="Divider3Grid" />
-    
-    
-    <!-- ================================================================== -->
-    <!--  Tab Header                                                        -->
-    <!-- ================================================================== -->
-    <Container    ID="TabArea"        Anchor="C,T"  Offset="0,44"   Size="parent,42" >
-      <Image                          Anchor="C,T"  Offset="0,4"    Size="parent-8,22"        Color="0,0,0,255" Texture="Controls_GradientSmall" />
-      <Container  ID="TabContainer"                 Offset="0,0"    Size="parent,34" />
-      <Grid                           Anchor="C,B"  Offset="0,0"    Size="parent-6,8"         Style="Divider3Grid" />
-    </Container>
-    <Container                        Anchor="C,T"  Offset="0,44"   Size="parent,36">
-      <SlideAnim  ID="TabAnim"        Begin="0,0" End="0,0" Cycle="Once" Speed="3.5" Function="OutQuint" Size="67,68">
-        <Image    ID="TabArrow"       Texture="Controls_TabSelectArrow" Size="42,11"/>
-      </SlideAnim>
-    </Container>
+	<Box						ID="Main"						Anchor="C,C"									Size="1024,759"						Color="11,27,40,255">
+		<Grid															Anchor="C,C"									Size="parent+9,parent+9"	Style="WindowFrameTopOnly" />
+		<Button				ID="CloseButton"		Anchor="R,T"	Offset="-3,-1"	Size="44,44"																			Texture="Controls_CloseLarge"  />
+		<Image														Anchor="C,T"									Size="parent,44"					Color="61,112,154,255"	Texture="Controls_Gradient_HalfRadial"  />
+		<GridButton		ID="CollapseAll"									Offset="48,13"	SizeToText="80,12"				Style="RoundedButton"		String="LOC_HUD_REPORTS_COLLAPSE_ALL"  Hidden="0" />
+		<GridButton   ID="CityBuildingsCheckbox"  Style="CheckBoxControl" SizeToText="80,12" String="Hide City Buildings" Offset="220,15" Hidden="1"/>
+		<Label														Anchor="C,T"	Offset="0,16"															Style="FontFlair20"			String="{LOC_HUD_REPORTS_TITLE:upper}" FontStyle="Glow" Color0="133,205,235,255" Color1="203,215,225,100" Color2="254,254,254,255" SmallCaps="28" SmallCapsType="EveryWord" />
+		<Grid															Anchor="C,T"	Offset="0,44"		Size="parent-6,8"					Style="Divider3Grid" />
+		
+		
+		<!-- ==================================================================	-->
+		<!--	Tab Header																												-->
+		<!-- ==================================================================	-->
+		<Container		ID="TabArea"				Anchor="C,T"	Offset="0,44"		Size="parent,42" >
+			<Image													Anchor="C,T"	Offset="0,4"		Size="parent-8,22"				Color="0,0,0,255" Texture="Controls_GradientSmall" />
+			<Container	ID="TabContainer"									Offset="0,0"		Size="parent,34" />
+			<Grid														Anchor="C,B"	Offset="0,0"		Size="parent-6,8"					Style="Divider3Grid" />
+		</Container>
+		<Container												Anchor="C,T"	Offset="0,44"		Size="parent,36">
+			<SlideAnim	ID="TabAnim"				Begin="0,0" End="0,0" Cycle="Once" Speed="3.5" Function="OutQuint" Size="67,68">
+				<Image		ID="TabArrow"				Texture="Controls_TabSelectArrow" Size="42,11"/>
+			</SlideAnim>
+		</Container>
 
-    <ScrollPanel  ID="Scroll"                       Offset="4,84"   Size="parent-8,parent-188"        Vertical="1" AutoScrollBar="1" >
-      <Stack      ID="Stack"          Anchor="L,T"  Offset="0,1"    StackPadding="4" />
-      <ScrollBar                      Anchor="R,C"  Offset="2,0"    Size="11,parent" AnchorSide="I,I"         Style="ScrollVerticalBarAlt" />
-    </ScrollPanel>
-    <Image                            Anchor="C,T"  Offset="0,83"   Size="parent-8,22"        Color="0,0,0,255" Texture="Controls_GradientSmall" />
+		<ScrollPanel	ID="Scroll"												Offset="4,84"		Size="parent-8,parent-188"				Vertical="1" AutoScrollBar="1" >
+			<Stack			ID="Stack"					Anchor="L,T"	Offset="0,1"		StackPadding="4" />
+			<ScrollBar											Anchor="R,C"	Offset="2,0"		Size="11,parent" AnchorSide="I,I"					Style="ScrollVerticalBarAlt" />
+		</ScrollPanel>
+		<Image														Anchor="C,T"	Offset="0,83"		Size="parent-8,22"				Color="0,0,0,255" Texture="Controls_GradientSmall" />
 
-    <Container    ID="BottomYieldTotals"    Anchor="C,B"  Offset="0,0"    Size="parent-6,103" >
-      <Grid                           Anchor="C,T"  Offset="0,0"    Size="parent,8"         Style="Divider3Grid" />
-      <Image                          Anchor="C,B"  Offset="0,10"   Size="parent-26,150" Texture="Controls_Gradient" Color="255,255,255,32">
-        <Grid                         Anchor="C,B"  Offset="0,-4"   Size="parent+20,8" Style="DividerGrid" Color="47,63,76,255" />
-        <Box                          Anchor="L,B"  Offset="-4,2"   Size="2,parent-32"  Color="46,70,95,128" />
-        <Box                          Anchor="R,B"  Offset="-4,2"   Size="2,parent-32"  Color="46,70,95,128" />
-      </Image>
-      <Grid                                         Offset="280,10" Size="195,80" Texture="Controls_ItemContainer" SliceCorner="8,8" SliceTextureSize="16,16" >
-        <Label                                      Offset="4,-26"  Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_TOTAL_INCOME_PER_TURN" />
-        <Label                                      Offset="4,0"    Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_TOTAL_EXPENSES_PER_TURN" />
-        <Label                                      Offset="4,26"   Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_NET_PER_TURN" />
+		<Container		ID="BottomYieldTotals"		Anchor="C,B"	Offset="0,0"		Size="parent-6,103" >
+			<Grid														Anchor="C,T"	Offset="0,0"		Size="parent,8"					Style="Divider3Grid" />
+			<Image													Anchor="C,B"	Offset="0,10"		Size="parent-26,150" Texture="Controls_Gradient" Color="255,255,255,32">
+				<Grid													Anchor="C,B"	Offset="0,-4"		Size="parent+20,8" Style="DividerGrid" Color="47,63,76,255" />
+				<Box													Anchor="L,B"	Offset="-4,2"		Size="2,parent-32"	Color="46,70,95,128" />
+				<Box													Anchor="R,B"	Offset="-4,2"		Size="2,parent-32"	Color="46,70,95,128" />
+			</Image>
+			<Grid																					Offset="280,10"	Size="195,80" Texture="Controls_ItemContainer" SliceCorner="8,8" SliceTextureSize="16,16" >
+				<Label																			Offset="4,-26"	Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_TOTAL_INCOME_PER_TURN" />
+				<Label																			Offset="4,0"		Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_TOTAL_EXPENSES_PER_TURN" />
+				<Label																			Offset="4,26"		Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_NET_PER_TURN" />
+			</Grid>
+			<Grid																					Offset="280,93"	Size="195,30" Texture="Controls_ItemContainer" SliceCorner="8,8" SliceTextureSize="16,16" >
+				<Label																			Offset="4,0"		Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_TREASURY" />
+			</Grid>
+
+			<Grid																					Offset="480,6"	Size="522,31"		SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
+			<Grid																					Offset="480,35"	Size="522,31"		SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
+			<Grid																					Offset="480,64"	Size="212,31"		SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
+			<Container																		Offset="485,12"	Size="500,50">
+				<Stack				StackGrowth="Right">
+					<Container																										Size="100,20">
+						<Label		ID="GoldIncome"							Style="ReportValueText"			String="G"	Color="Gold" />
+					</Container>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20">
+						<Label		ID="FaithIncome"						Style="ReportValueText"			String="F"	Color="Faith" />
+					</Container>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20">
+						<Label		ID="ScienceIncome"					Style="ReportValueText"			String="S"	Color="Science" />
+					</Container>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20">
+						<Label		ID="CultureIncome"					Style="ReportValueText"			String="C"	Color="Culture" />
+					</Container>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20">
+						<Label		ID="TourismIncome"					Style="ReportValueText"			String=""	Color="Tourism" />
+					</Container>
+				</Stack>
+				<Stack				StackGrowth="Right"		Offset="0,29">
+					<Container																										Size="100,20">
+						<Label		ID="GoldExpense"							Style="ReportValueText"			String="G"	Color="Gold" />
+					</Container>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20"/>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20"/>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20"/>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20"/>
+				</Stack>
+				<Stack				StackGrowth="Right"		Offset="0,58">
+					<Container																										Size="100,20">
+						<Label		ID="GoldNet"					Style="ReportEndValueText"	String="G"	ColorSet="ResGoldLabelCS" />
+					</Container>
+					<Box															Anchor="C,C"								Size="2,18"	Color="46,70,95,255" />
+					<Container																										Size="100,20">
+						<Label		ID="FaithNet"					Style="ReportEndValueText"	String="F"	ColorSet="ResFaithLabelCS" />
+					</Container>
+					<Container Size="6,1" />
+					<Grid																					 Offset="0,-4"	Size="94,29"	Style="YieldBacking" Color="24,156,216,150">
+						<Label													Anchor="L,C" Offset="-9,0"								String="[ICON_ScienceLarge]"/>
+						<Label		ID="ScienceBalance"		Anchor="C,C"															Style="ReportEndTotalText" ColorSet="ResScienceLabelCS" FontStyle="Stroke" String="0"/>
+					</Grid>
+					<Container Size="9,1" />
+					<Grid																					 Offset="0,-4"	Size="94,30"	Style="YieldBacking" Color="254,42,237,100">
+						<Label													Anchor="L,C" Offset="-9,0"								String="[ICON_CultureLarge]"/>
+						<Label		ID="CultureBalance"		Anchor="C,C"															Style="ReportEndTotalText" ColorSet="ResCultureLabelCS" FontStyle="Stroke" String="0"/>
+					</Grid>
+					<Container Size="9,1" />
+					<Grid																					 Offset="0,-4"	Size="94,30"	Style="YieldBacking" Color="181,116,102,150" >
+						<Label													Anchor="L,C" Offset="-9,0"								String="[ICON_TourismLarge]"/>
+						<Label		ID="TourismBalance"		Anchor="C,C"															Style="ReportEndTotalText" ColorSet="ResTourismLabelCS" String="0"	/>
+					</Grid>
+				</Stack>
+
+				<Stack																					 Offset="-4,85"	  StackGrowth="Right" Padding="4">
+					<Grid																													Size="101,26"	Style="YieldBacking" Color="185,176,70,150">
+						<Label													Anchor="L,C" Offset="-9,0"								String="[ICON_GoldLarge]"/>
+						<Label		ID="GoldBalance"			Anchor="C,C"															Style="ReportEndTotalText" ColorSet="ResGoldLabelCS" String="0"	/>
+					</Grid>
+					<Grid																													Size="101,26"	Style="YieldBacking" Color="99,114,159,200"	>
+						<Label													Anchor="L,C" Offset="-9,0"								String="[ICON_FaithLarge]"/>
+						<Label		ID="FaithBalance"			Anchor="C,C"															Style="ReportEndTotalText" ColorSet="ResFaithLabelCS" String="0" />
+					</Grid>
+				</Stack>
+				</Container>	
+		</Container>
+
+		<Container		ID="BottomResourceTotals"	Anchor="C,B"	Offset="0,0"		Size="parent-6,100" >
+			<Grid																	Anchor="C,T"	Offset="0,0"		Size="parent,8"							Style="Divider3Grid" />
+			<Image																Anchor="C,B"	Offset="0,2"		Size="parent,parent"				Texture="Controls_Gradient" Color="255,255,255,32">
+				<Grid			ID="StrategicGrid"											Offset="5,10"		Size="parent-515,40"				Style="SubContainer4"				Color="36,50,62,255" InnerPadding="2,2">
+					<Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_STRATEGICS" />
+					<Stack	ID="StrategicResources"		Anchor="L,C"	Offset="150,-9"	WrapWidth="340"	WrapGrowth="Down"	StackGrowth="Right" />
+				</Grid>				
+				<Grid			ID="BonusGrid"													Offset="510,10"	Size="parent-515,40"				Style="SubContainer4"				Color="36,50,62,255" InnerPadding="2,2">
+					<Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_BONUSES" />
+					<Stack	ID="BonusResources"				Anchor="L,C"	Offset="150,-9"	WrapWidth="340"	WrapGrowth="Down"	StackGrowth="Right" />
+				</Grid>
+				<Grid			ID="LuxuryGrid"													Offset="5,55"		Size="parent-10,40"					Style="SubContainer4"				Color="36,50,62,255" InnerPadding="2,2">
+					<Label																					Offset="5,0"																Style="ReportResourceText"	String="LOC_HUD_REPORTS_LUXURIES" />
+					<Stack	ID="LuxuryResources"			Anchor="L,C"	Offset="150,-9"	WrapWidth="840"	WrapGrowth="Down"	StackGrowth="Right" />
+				</Grid>
+			</Image>
+		</Container>
+		
+	</Box>
+
+
+
+	<!-- ==================================================================	-->
+	<!--	Instances																													-->
+	<!-- ==================================================================	-->
+	<Instance					Name="TabInstance">
+		<GridButton			ID="Button"																				Size="50,34" Style="TabButton" FontSize="14" TextOffset="0,2">
+			<AlphaAnim		ID="Selection"											Offset="-2,0"	Size="parent+3,parent" Speed="4" AlphaBegin="0" AlphaEnd="1" Cycle="Once" Function="Root" Hidden="1" >
+				<GridButton																										Size="parent,parent" Style="TabButtonSelected" ConsumeMouseButton="0" ConsumeMouseOver="1" />
+			</AlphaAnim>
+		</GridButton>
+	</Instance>
+
+	<!-- Non-Collapsable Rows -->
+	<Instance					Name="SimpleInstance">
+		<Stack					ID="Top"	StackGrowth="Down" />
+	</Instance>
+
+	<!-- Collapsable Row(s) area -->
+	<Instance						Name="GroupInstance">
+		<Container				ID="Top"																					Size="1003,10"	AutoSize="V">
+			<GridButton			ID="RowHeaderButton"								Offset="0,0"	Size="parent,30"		Style="RowButton"		String="$RowHeaderButton" >
+				<Label ID="RowHeaderLabel" Anchor="R,C" Offset="50,0" Style="RowButton" String="Ends in ## turns (###)" Hidden="1" />
+			</GridButton>
+			<Image					ID="RowExpandCheck"		Anchor="R,T"	Offset="5,5"	Size="22,22"				Texture="Controls_ExpandButton" />
+			<ScrollPanel		ID="CollapseScroll"									Offset="0,31"	Size="parent,20"		StackGrowth="Bottom" FullClip="1" >
+				<SlideAnim		ID="CollapseAnim"			Start="0,0"	EndOffset="0,0" Speed="4" Cycle="Once" Stopped="1">
+					<Stack			ID="ContentStack"										Offset="0,0"	StackGrowth="Bottom" />
+				</SlideAnim>
+			</ScrollPanel>
+		</Container>
+	</Instance>
+
+	
+	<!-- CITY INCOME -->
+	<Instance					Name="CityIncomeHeaderInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22" >
+			<Image																						Offset="4,0"	Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="232,parent">
+					<GridButton		ID="CityNameButton"  Size="232,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_CITY" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="33,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="ProductionButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_PRODUCTION" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="FoodButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_FOOD" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="GoldButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_GOLD" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="FaithButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_FAITH" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="ScienceButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_SCIENCE" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="CultureButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_CULTURE" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="TourismButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label							Anchor="C,C"						Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_TOURISM" />
+					</GridButton>
+				</Container>
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance					Name="CityIncomeInstance">
+		<Grid						ID="Top"														Offset="0,-1"	Size="1003,100"		SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255" AutoSize="V" >
+			<Stack																						Offset="8,6"	StackGrowth="Right">
+				<Box																													Size="2,40"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="232,40" />
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="33,40" />
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="100,40">
+					<Label		ID="Production"				Style="ReportValueText"			String="P"  Color="Production" />
+				</Container>
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="100,40">
+					<Label		ID="Food"							Style="ReportValueText"			String="F"	Color="Food" />
+				</Container>
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="100,40">
+					<Label		ID="Gold"							Style="ReportValueText"			String="G"	Color="Gold" />
+				</Container>
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="100,40">
+					<Label		ID="Faith"						Style="ReportValueText"			String="F"	Color="Faith" />
+				</Container>
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="100,40">
+					<Label		ID="Science"					Style="ReportValueText"			String="S"	Color="Science" />
+				</Container>
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="100,40">
+					<Label		ID="Culture"					Style="ReportValueText"			String="C"	Color="Culture" />
+				</Container>
+				<Box																													Size="2,40"	Color="46,70,95,255" />
+				<Container																										Size="100,40">
+					<Label		ID="Tourism"					Style="ReportValueText"			String=""	Color="Tourism" />
+				</Container>
+				<Box																											Offset="1,0"	Size="2,40"	Color="46,70,95,128" />
+			</Stack>
+			<Label					ID="CityName"																Offset="11,15"	Style="ReportCityName"	String="$CityName$" />
+			<Stack					ID="LineItemStack"													Offset="8,39"		StackGrowth="Bottom" />
+			<Box						ID="Darken"										Anchor="C,T"	Offset="0,39"		Size="parent-8,10"			Color="0,15,30,60"  />
+			<Grid						ID="CityBannerBackground"			Anchor="L,T"  Offset="245,4"	Size="40,34"						Color="255,255,255,150" SliceStart="10,0" SliceTextureSize="40,34" SliceCorner="25,17" Texture="Banner_BannerBacking">
+				<Image				ID="CityProductionProgress"		Anchor="R,C"	Offset="0,0"		Size="14,32"	TextureOffset="14,0" Texture="Banner_ProductionMeter" >
+					<TextureBar ID="CityProductionNextTurn"		Anchor="L,C"									Size="14,32"  Direction="Up" Texture="Banner_ProductionMeter" />
+					<TextureBar ID="CityProductionMeter"			Anchor="L,C"									Size="14,32"  Direction="Up" Texture="Banner_ProductionMeter" />
+				</Image>
+				<Image				ID="ProductionBorder"					Anchor="L,C"	Offset="-5,0"		Size="40,40" Texture="Controls_CircleRim40" />
+				<Image				ID="CurrentProduction"				Anchor="L,C"	Offset="-5,0"		Size="40,40" Texture="Controls_CircleRim40" />
+			</Grid>
+		</Grid>
+	</Instance>
+
+	<Instance					Name="CityIncomeLineItemInstance">
+		<Container			ID="Top"														Offset="0,0"	Size="1003,20" >			
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="232,parent">
+					<Label		ID="LineItemName"			Style="ReportRowStart"			String="District" Offset="36,0" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="33,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,20">
+					<Label		ID="Production"				Style="ReportValueText"			String="P"  Color="Production" />
+				</Container>
+				<Box																													Size="2,20"	Color="46,70,95,255" />
+				<Container																										Size="100,20">
+					<Label		ID="Food"							Style="ReportValueText"			String="F"	Color="Food" />
+				</Container>
+				<Box																													Size="2,20"	Color="46,70,95,255" />
+				<Container																										Size="100,20">
+					<Label		ID="Gold"							Style="ReportValueText"			String="G"	Color="Gold" />
+				</Container>
+				<Box																													Size="2,20"	Color="46,70,95,255" />
+				<Container																										Size="100,20">
+					<Label		ID="Faith"						Style="ReportValueText"			String="F"	Color="Faith" />
+				</Container>
+				<Box																													Size="2,20"	Color="46,70,95,255" />
+				<Container																										Size="100,20">
+					<Label		ID="Science"					Style="ReportValueText"			String="S"	Color="Science" />
+				</Container>
+				<Box																													Size="2,20"	Color="46,70,95,255" />
+				<Container																										Size="100,20">
+					<Label		ID="Culture"					Style="ReportValueText"			String="C"	Color="Culture" />
+				</Container>
+				<Box																													Size="2,20"	Color="46,70,95,255" />
+				<Container																										Size="100,20">
+					<Label		ID="Tourism"					Style="ReportValueText"			String=""	Color="Tourism" />
+				</Container>
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>			
+		</Container>
+	</Instance>
+
+	<Instance					Name="CityIncomeFooterInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,30">
+			<Image																						Offset="4,0"	Size="parent-24,22" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,22"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="232,22"/>
+				<Container																										Size="239,22" >
+					<Label						Anchor="R,C"								Offset="5,1"	Style="ReportTotalText"			String="LOC_HUD_REPORTS_TOTALS"  />
+				</Container>
+				<Box																													Size="2,22"	Color="46,70,95,255" />
+				<Container																										Size="100,22">
+					<Image		Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Gold,150" />
+					<Label		ID="Gold"														Style="ReportHeaderText"		String="[ICON_Gold]0" Color="Gold"  />
+				</Container>
+				<Box																													Size="2,22"	Color="46,70,95,255" />
+				<Container																										Size="100,22">
+					<Image		Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Faith,150" />
+					<Label		ID="Faith"													Style="ReportHeaderText"		String="[ICON_Faith]0" Color="Faith"  />
+				</Container>
+				<Box																													Size="2,22"	Color="46,70,95,255" />
+				<Container																										Size="100,22">
+					<Image		Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Science,150" />
+					<Label		ID="Science"												Style="ReportHeaderText"		String="[ICON_Science]0" Color="Science"  />
+				</Container>
+				<Box																													Size="2,22"	Color="46,70,95,255" />
+				<Container																										Size="100,22">
+					<Image		Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Culture,150" />
+					<Label		ID="Culture"												Style="ReportHeaderText"		String="[ICON_Culture]0" Color="Culture"  />
+				</Container>
+				<Box																													Size="2,22"	Color="46,70,95,255" />
+				<Container																										Size="100,22">
+					<Image		Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Tourism,150" />
+					<Label		ID="Tourism"												Style="ReportHeaderText"		String="[ICON_Tourism]0" Color="Tourism"  />
+				</Container>
+				<Box																						Offset="1,0"	Size="2,22"	Color="46,70,95,128" />				
+			</Stack>
+			<Grid					Style="DividerGrid" Offset="-10,22" Size="parent,8" Color="47,63,76,255" />
+		</Container>
+	</Instance>
+
+
+	<!-- BUILDING EXPENSE -->
+
+	<Instance					Name="BuildingExpensesHeaderInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-432,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="232,parent">
+					<Label													Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_CITY" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="237,parent">
+					<Label													Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_BUILDING" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<Label													Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_GOLD" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance						Name="BuildingExpensesEntryInstance">
+		<Container				ID="Top"													Offset="8,0" Size="1003,32">
+			<Grid																							Offset="-8,-1"	Size="590,parent"		SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
+			<Stack	StackGrowth="Right" >
+				<Box															Anchor="C,C"								Size="2,22"	Color="46,70,95,128" />				
+				<Container																			Offset="1,0"	Size="232,parent">
+					<Label			ID="CityName"				Style="ReportValueLeftName"	String="LOC_HUD_REPORTS_HEADER_CITY" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,255" />
+				<Container																										Size="237,parent">
+					<Label			ID="BuildingName"		Style="ReportValueLeftName"	String="LOC_HUD_REPORTS_HEADER_BUILDING" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<Label			ID="Gold"						Style="ReportValueText"	String="LOC_HUD_REPORTS_HEADER_GOLD"  Color="Gold" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance					Name="GoldFooterInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,30">
+			<Image																						Offset="4,0"	Size="parent-24,22" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,22"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="232,22"/>
+				<Container																										Size="239,22" >
+					<Label						Anchor="R,C"								Offset="5,1"	Style="ReportTotalText"			String="LOC_HUD_REPORTS_TOTALS"  />
+				</Container>
+				<Box																													Size="2,22"	Color="46,70,95,255" />
+				<Container																										Size="100,22">
+					<Image		Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Gold,150" />
+					<Label		ID="Gold"														Style="ReportHeaderText"		String="[ICON_Gold]0" Color="Gold"  />
+				</Container>
+				<Box																													Size="2,22"	Color="46,70,95,55" />
+				<Container																										Size="100,22" />
+				<Box																													Size="2,22"	Color="46,70,95,55" />
+				<Container																										Size="100,22" />
+				<Box																													Size="2,22"	Color="46,70,95,55" />
+				<Container																										Size="100,22" />
+				<Box																													Size="2,22"	Color="46,70,95,55" />
+				<Container																										Size="100,22" />
+				<Box																						Offset="1,0"	Size="2,22"	Color="46,70,95,128" />
+			</Stack>
+			<Grid					Style="DividerGrid" Offset="-10,22" Size="parent,8" Color="47,63,76,255" />
+		</Container>
+	</Instance>
+
+	<!-- UNIT EXPENSE -->
+
+	<Instance					Name="UnitExpensesHeaderInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-432,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="2,0"	Size="470,parent">
+					<Label													Style="ReportHeaderText"		String="Unit" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				
+				<Container																										Size="100,parent">
+					<Label													Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_GOLD" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance						Name="UnitExpensesEntryInstance">
+		<Container				ID="Top"													Offset="8,0" Size="1003,32">
+			<Grid																							Offset="-8,-1"	Size="590,parent"		SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
+			<Stack	StackGrowth="Right" >
+				<Box															Anchor="C,C"								Size="2,22"	Color="46,70,95,128" />				
+				<Container																			Offset="2,0"	Size="470,parent">
+					<Label			ID="UnitName"				Style="ReportValueText"	String="UnitName" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,255" />
+				
+				<Container																										Size="100,parent">
+					<Label			ID="Gold"						Style="ReportValueText"	String="0"  Color="Gold" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<!-- DEALS -->
+
+	<Instance					Name="DealHeaderInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-432,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="369,parent">
+					<Label													Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_CIVILIZATION" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<Label													Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_DURATION" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<Label													Style="ReportHeaderText"		String="LOC_HUD_REPORTS_HEADER_GOLD" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+
+	<Instance						Name="DealEntryInstance">
+		<Container				ID="Top"													Offset="8,0" Size="1003,32">
+			<Grid																							Offset="-8,-1"	Size="590,parent"		SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
+			<Stack	StackGrowth="Right" >
+				<Box															Anchor="C,C"								Size="2,22"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="369,parent">
+					<Label			ID="Civilization"		Style="ReportValueLeftName"	String="LOC_HUD_REPORTS_HEADER_CITY" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<Label			ID="Duration"				Style="ReportValueLeftName"	String="LOC_HUD_REPORTS_HEADER_BUILDING" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<Label			ID="Gold"						Style="ReportValueText"	String="LOC_HUD_REPORTS_HEADER_GOLD"  Color="Gold" />
+				</Container>
+				<Box															Anchor="C,C"								Size="2,19"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																													Size="2,parent"	Color="46,70,95,55" />
+				<Container																										Size="100,parent" />
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+
+
+	<!-- RESOURCES  -->
+
+	<Instance					Name="ResourcesHeaderInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="577,parent">
+					<Label																											Style="ReportHeaderText"	String="LOC_HUD_REPORTS_SOURCES"  />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="200,parent">
+					<Label																											Style="ReportValueText"	String="LOC_HUD_REPORTS_CONTROL" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="200,parent">
+					<Label																											Style="ReportValueText"	String="LOC_HUD_REPORTS_AMOUNT" />
+				</Container>
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance					Name="ResourcesEntryInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="577,parent">
+					<Label				ID="CityName"																	Style="ReportValueText"	String="$CityName$" Align="Left" Anchor="L,C" Offset="10,0" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="200,parent">
+					<Label				ID="Control"																	Style="ReportValueText"	String="$Control$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="200,parent">
+					<Label				ID="Amount"																		Style="ReportValueText"	String="$Amount$" />
+				</Container>
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance							Name="ResourcesFooterInstance">
+		<Container					ID="Top"												Offset="8,0" Size="1003,30">
+			<Image																						Offset="4,0"	Size="parent-24,parent-2" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+      <Grid             ID="AmenitiesContainer" Style="SubContainerSmall"  Size="48,24" Anchor="L,C" Offset="5,1" AutoSizePadding="3,0">
+        <Label          ID="Amenities"	Anchor="C,C"	Style="ReportTotalText"			String="[ICON_Amenities] 3 Cities"/>
       </Grid>
-      <Grid                                         Offset="280,93" Size="195,30" Texture="Controls_ItemContainer" SliceCorner="8,8" SliceTextureSize="16,16" >
-        <Label                                      Offset="4,0"    Style="ReportBottomLabelText" String="LOC_HUD_REPORTS_TREASURY" />
-      </Grid>
-
-      <Grid                                         Offset="480,6"  Size="522,31"   SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
-      <Grid                                         Offset="480,35" Size="522,31"   SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
-      <Grid                                         Offset="480,64" Size="212,31"   SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
-      <Container                                    Offset="485,12" Size="500,50">
-        <Stack        StackGrowth="Right">
-          <Container                                                    Size="100,20">
-            <Label    ID="GoldIncome"             Style="ReportValueText"     String="G"  Color="Gold" />
-          </Container>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20">
-            <Label    ID="FaithIncome"            Style="ReportValueText"     String="F"  Color="Faith" />
-          </Container>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20">
-            <Label    ID="ScienceIncome"          Style="ReportValueText"     String="S"  Color="Science" />
-          </Container>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20">
-            <Label    ID="CultureIncome"          Style="ReportValueText"     String="C"  Color="Culture" />
-          </Container>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20">
-            <Label    ID="TourismIncome"          Style="ReportValueText"     String="" Color="Tourism" />
-          </Container>
-        </Stack>
-        <Stack        StackGrowth="Right"   Offset="0,29">
-          <Container                                                    Size="100,20">
-            <Label    ID="GoldExpense"              Style="ReportValueText"     String="G"  Color="Gold" />
-          </Container>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20"/>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20"/>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20"/>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20"/>
-        </Stack>
-        <Stack        StackGrowth="Right"   Offset="0,58">
-          <Container                                                    Size="100,20">
-            <Label    ID="GoldNet"          Style="ReportEndValueText"  String="G"  ColorSet="ResGoldLabelCS" />
-          </Container>
-          <Box                              Anchor="C,C"                Size="2,18" Color="46,70,95,255" />
-          <Container                                                    Size="100,20">
-            <Label    ID="FaithNet"         Style="ReportEndValueText"  String="F"  ColorSet="ResFaithLabelCS" />
-          </Container>
-          <Container Size="6,1" />
-          <Grid                                          Offset="0,-4"  Size="94,29"  Style="YieldBacking" Color="24,156,216,150">
-            <Label                          Anchor="L,C" Offset="-9,0"                String="[ICON_ScienceLarge]"/>
-            <Label    ID="ScienceBalance"   Anchor="C,C"                              Style="ReportEndTotalText" ColorSet="ResScienceLabelCS" FontStyle="Stroke" String="0"/>
-          </Grid>
-          <Container Size="9,1" />
-          <Grid                                          Offset="0,-4"  Size="94,30"  Style="YieldBacking" Color="254,42,237,100">
-            <Label                          Anchor="L,C" Offset="-9,0"                String="[ICON_CultureLarge]"/>
-            <Label    ID="CultureBalance"   Anchor="C,C"                              Style="ReportEndTotalText" ColorSet="ResCultureLabelCS" FontStyle="Stroke" String="0"/>
-          </Grid>
-          <Container Size="9,1" />
-          <Grid                                          Offset="0,-4"  Size="94,30"  Style="YieldBacking" Color="181,116,102,150" >
-            <Label                          Anchor="L,C" Offset="-9,0"                String="[ICON_TourismLarge]"/>
-            <Label    ID="TourismBalance"   Anchor="C,C"                              Style="ReportEndTotalText" ColorSet="ResTourismLabelCS" String="0"  />
-          </Grid>
-        </Stack>
-
-        <Stack                                           Offset="-4,85"   StackGrowth="Right" Padding="4">
-          <Grid                                                         Size="101,26" Style="YieldBacking" Color="185,176,70,150">
-            <Label                          Anchor="L,C" Offset="-9,0"                String="[ICON_GoldLarge]"/>
-            <Label    ID="GoldBalance"      Anchor="C,C"                              Style="ReportEndTotalText" ColorSet="ResGoldLabelCS" String="0" />
-          </Grid>
-          <Grid                                                         Size="101,26" Style="YieldBacking" Color="99,114,159,200" >
-            <Label                          Anchor="L,C" Offset="-9,0"                String="[ICON_FaithLarge]"/>
-            <Label    ID="FaithBalance"     Anchor="C,C"                              Style="ReportEndTotalText" ColorSet="ResFaithLabelCS" String="0" />
-          </Grid>
-        </Stack>
-        </Container>  
-    </Container>
-
-    <Container    ID="BottomResourceTotals" Anchor="C,B"  Offset="0,0"    Size="parent-6,70" >
-      <Grid                                 Anchor="C,T"  Offset="0,0"    Size="parent,8"         Style="Divider3Grid" />
-      <Image                                Anchor="C,B"  Offset="0,10"   Size="parent-26,parent" Texture="Controls_Gradient" Color="255,255,255,32">
-
-        <Label                              Anchor="R,T"  Offset="500,20" Style="ReportEndTotalText" String="LOC_HUD_REPORTS_STRATEGICS" />
-        <Label                              Anchor="R,T"  Offset="500,45" Style="ReportEndTotalText" String="LOC_HUD_REPORTS_LUXURIES_AND_BONUSES" />
-        <Label    ID="StrategicResources"   Anchor="L,T"  Offset="500,20" Style="ReportEndTotalText" String="foo" />
-        <Label    ID="LuxuryResources"      Anchor="L,T"  Offset="500,45" Style="ReportEndTotalText" String="bar" />
-
-
-        <Grid                         Anchor="C,B"  Offset="0,-4"   Size="parent+20,8" Style="DividerGrid" Color="47,63,76,255" />
-        <Box                          Anchor="L,B"  Offset="-4,2"   Size="2,parent-18"  Color="46,70,95,128" />
-        <Box                          Anchor="R,B"  Offset="-4,2"   Size="2,parent-18"  Color="46,70,95,128" />
-      </Image>
-    </Container>
-    
-  </Box>
-
-
-
-  <!-- ================================================================== -->
-  <!--  Instances                                                         -->
-  <!-- ================================================================== -->
-  <Instance         Name="TabInstance">
-    <GridButton     ID="Button"                                       Size="50,34" Style="TabButton" FontSize="14" TextOffset="0,2">
-      <AlphaAnim    ID="Selection"                      Offset="-2,0" Size="parent+3,parent" Speed="4" AlphaBegin="0" AlphaEnd="1" Cycle="Once" Function="Root" Hidden="1" >
-        <GridButton                                                   Size="parent,parent" Style="TabButtonSelected" ConsumeMouseButton="0" ConsumeMouseOver="1" />
-      </AlphaAnim>
-    </GridButton>
-  </Instance>
-
-  <Instance         Name="SimpleInstance">
-    <Stack          ID="Top"  StackGrowth="Down" />
-  </Instance>
-
-  <!-- Collapsable -->
-  <Instance           Name="GroupInstance">
-    <Container        ID="Top"                                          Size="1003,10"  AutoSize="V">
-      <GridButton     ID="RowHeaderButton"                Offset="0,0"  Size="parent,30"    Style="RowButton"   String="$RowHeaderButton" >
-        <Label ID="RowHeaderLabel" Anchor="R,C" Offset="50,0" Style="RowButton" String="Ends in ## turns (###)" Hidden="1" />
-      </GridButton>
-      <Image          ID="RowExpandCheck"   Anchor="R,T"  Offset="5,5"  Size="22,22"        Texture="Controls_ExpandButton" />
-      <ScrollPanel    ID="CollapseScroll"                 Offset="0,31" Size="parent,20"    StackGrowth="Bottom" FullClip="1" >
-        <SlideAnim    ID="CollapseAnim"     Start="0,0" EndOffset="0,0" Speed="4" Cycle="Once" Stopped="1">
-          <Stack      ID="ContentStack"                   Offset="0,0"  StackGrowth="Bottom" />
-        </SlideAnim>
-      </ScrollPanel>
-    </Container>
-  </Instance>
-
-  
-  <!-- CITY INCOME -->
-  
-  <Instance         Name="CityIncomeHeaderInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22" >
-      <Image                                            Offset="4,0"  Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="232,parent">
-          <GridButton   ID="CityNameButton"  Size="232,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_CITY" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="33,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="ProductionButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_PRODUCTION" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="FoodButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_FOOD" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="GoldButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_GOLD" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="FaithButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_FAITH" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="ScienceButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_SCIENCE" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="CultureButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_CULTURE" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="TourismButton"  Size="100,26" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label              Anchor="C,C"            Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_TOURISM" />
-          </GridButton>
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance         Name="CityIncomeInstance">
-    <Grid           ID="Top"                            Offset="0,-1" Size="1003,100"   SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255" AutoSize="V" >
-      <Stack                                            Offset="8,6"  StackGrowth="Right">
-        <Box                                                          Size="2,40" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="232,40" />
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="33,40" />
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="100,40">
-          <Label    ID="Production"       Style="ReportValueText"     String="P"  Color="Production" />
-        </Container>
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="100,40">
-          <Label    ID="Food"             Style="ReportValueText"     String="F"  Color="Food" />
-        </Container>
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="100,40">
-          <Label    ID="Gold"             Style="ReportValueText"     String="G"  Color="Gold" />
-        </Container>
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="100,40">
-          <Label    ID="Faith"            Style="ReportValueText"     String="F"  Color="Faith" />
-        </Container>
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="100,40">
-          <Label    ID="Science"          Style="ReportValueText"     String="S"  Color="Science" />
-        </Container>
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="100,40">
-          <Label    ID="Culture"          Style="ReportValueText"     String="C"  Color="Culture" />
-        </Container>
-        <Box                                                          Size="2,40" Color="46,70,95,255" />
-        <Container                                                    Size="100,40">
-          <Label    ID="Tourism"          Style="ReportValueText"     String="" Color="Tourism" />
-        </Container>
-        <Box                                                      Offset="1,0"  Size="2,40" Color="46,70,95,128" />
-      </Stack>
-      <Label          ID="CityName"                               Offset="11,15"  Style="ReportCityName"  String="$CityName$" />
-      <Stack          ID="LineItemStack"                          Offset="8,39"   StackGrowth="Bottom" />
-      <Box            ID="Darken"                   Anchor="C,T"  Offset="0,39"   Size="parent-8,10"      Color="0,15,30,60"  />
-      <Grid           ID="CityBannerBackground"     Anchor="L,T"  Offset="245,4"  Size="40,34"            Color="255,255,255,150" SliceStart="10,0" SliceTextureSize="40,34" SliceCorner="25,17" Texture="Banner_BannerBacking">
-        <Image        ID="CityProductionProgress"   Anchor="R,C"  Offset="0,0"    Size="14,32"  TextureOffset="14,0" Texture="Banner_ProductionMeter" >
-          <TextureBar ID="CityProductionNextTurn"   Anchor="L,C"                  Size="14,32"  Direction="Up" Texture="Banner_ProductionMeter" />
-          <TextureBar ID="CityProductionMeter"      Anchor="L,C"                  Size="14,32"  Direction="Up" Texture="Banner_ProductionMeter" />
-        </Image>
-        <Image        ID="ProductionBorder"         Anchor="L,C"  Offset="-5,0"   Size="40,40" Texture="Controls_CircleRim40" />
-        <Image        ID="CurrentProduction"        Anchor="L,C"  Offset="-5,0"   Size="40,40" Texture="Controls_CircleRim40" />
-      </Grid>
-    </Grid>
-  </Instance>
-
-  <Instance         Name="CityIncomeLineItemInstance">
-    <Container      ID="Top"                            Offset="0,0"  Size="1003,20" >      
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="232,parent">
-          <Label    ID="LineItemName"     Style="ReportRowStart"      String="District" Offset="36,0" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="33,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,20">
-          <Label    ID="Production"       Style="ReportValueText"     String="P"  Color="Production" />
-        </Container>
-        <Box                                                          Size="2,20" Color="46,70,95,255" />
-        <Container                                                    Size="100,20">
-          <Label    ID="Food"             Style="ReportValueText"     String="F"  Color="Food" />
-        </Container>
-        <Box                                                          Size="2,20" Color="46,70,95,255" />
-        <Container                                                    Size="100,20">
-          <Label    ID="Gold"             Style="ReportValueText"     String="G"  Color="Gold" />
-        </Container>
-        <Box                                                          Size="2,20" Color="46,70,95,255" />
-        <Container                                                    Size="100,20">
-          <Label    ID="Faith"            Style="ReportValueText"     String="F"  Color="Faith" />
-        </Container>
-        <Box                                                          Size="2,20" Color="46,70,95,255" />
-        <Container                                                    Size="100,20">
-          <Label    ID="Science"          Style="ReportValueText"     String="S"  Color="Science" />
-        </Container>
-        <Box                                                          Size="2,20" Color="46,70,95,255" />
-        <Container                                                    Size="100,20">
-          <Label    ID="Culture"          Style="ReportValueText"     String="C"  Color="Culture" />
-        </Container>
-        <Box                                                          Size="2,20" Color="46,70,95,255" />
-        <Container                                                    Size="100,20">
-          <Label    ID="Tourism"          Style="ReportValueText"     String="" Color="Tourism" />
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>      
-    </Container>
-  </Instance>
-
-  <Instance         Name="CityIncomeFooterInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,30">
-      <Image                                            Offset="4,0"  Size="parent-24,22" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,22" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="232,22"/>
-        <Container                                                    Size="239,22" >
-          <Label            Anchor="R,C"                Offset="5,1"  Style="ReportTotalText"     String="LOC_HUD_REPORTS_TOTALS"  />
-        </Container>
-        <Box                                                          Size="2,22" Color="46,70,95,255" />
-        <Container                                                    Size="100,22">
-          <Image    Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Gold,150" />
-          <Label    ID="Gold"                           Style="ReportHeaderText"    String="[ICON_Gold]0" Color="Gold"  />
-        </Container>
-        <Box                                                          Size="2,22" Color="46,70,95,255" />
-        <Container                                                    Size="100,22">
-          <Image    Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Faith,150" />
-          <Label    ID="Faith"                          Style="ReportHeaderText"    String="[ICON_Faith]0" Color="Faith"  />
-        </Container>
-        <Box                                                          Size="2,22" Color="46,70,95,255" />
-        <Container                                                    Size="100,22">
-          <Image    Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Science,150" />
-          <Label    ID="Science"                        Style="ReportHeaderText"    String="[ICON_Science]0" Color="Science"  />
-        </Container>
-        <Box                                                          Size="2,22" Color="46,70,95,255" />
-        <Container                                                    Size="100,22">
-          <Image    Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Culture,150" />
-          <Label    ID="Culture"                        Style="ReportHeaderText"    String="[ICON_Culture]0" Color="Culture"  />
-        </Container>
-        <Box                                                          Size="2,22" Color="46,70,95,255" />
-        <Container                                                    Size="100,22">
-          <Image    Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Tourism,150" />
-          <Label    ID="Tourism"                        Style="ReportHeaderText"    String="[ICON_Tourism]0" Color="Tourism"  />
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,22" Color="46,70,95,128" />       
-      </Stack>
-      <Grid         Style="DividerGrid" Offset="-10,22" Size="parent,8" Color="47,63,76,255" />
-    </Container>
-  </Instance>
-
-
-  <!-- BUILDING EXPENSE -->
-
-  <Instance         Name="BuildingExpensesHeaderInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-432,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="232,parent">
-          <Label                          Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_CITY" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="237,parent">
-          <Label                          Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_BUILDING" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <Label                          Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_GOLD" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance           Name="BuildingExpensesEntryInstance">
-    <Container        ID="Top"                          Offset="8,0" Size="1003,32">
-      <Grid                                             Offset="-8,-1"  Size="590,parent"   SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
-      <Stack  StackGrowth="Right" >
-        <Box                              Anchor="C,C"                Size="2,22" Color="46,70,95,128" />       
-        <Container                                      Offset="1,0"  Size="232,parent">
-          <Label      ID="CityName"       Style="ReportValueLeftName" String="LOC_HUD_REPORTS_HEADER_CITY" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,255" />
-        <Container                                                    Size="237,parent">
-          <Label      ID="BuildingName"   Style="ReportValueLeftName" String="LOC_HUD_REPORTS_HEADER_BUILDING" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <Label      ID="Gold"           Style="ReportValueText" String="LOC_HUD_REPORTS_HEADER_GOLD"  Color="Gold" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance         Name="GoldFooterInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,30">
-      <Image                                            Offset="4,0"  Size="parent-24,22" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,22" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="232,22"/>
-        <Container                                                    Size="239,22" >
-          <Label            Anchor="R,C"                Offset="5,1"  Style="ReportTotalText"     String="LOC_HUD_REPORTS_TOTALS"  />
-        </Container>
-        <Box                                                          Size="2,22" Color="46,70,95,255" />
-        <Container                                                    Size="100,22">
-          <Image    Size="parent,24" Offset="0,-2" Texture="Controls_GradientSmall" FlipY="1" Color="Gold,150" />
-          <Label    ID="Gold"                           Style="ReportHeaderText"    String="[ICON_Gold]0" Color="Gold"  />
-        </Container>
-        <Box                                                          Size="2,22" Color="46,70,95,55" />
-        <Container                                                    Size="100,22" />
-        <Box                                                          Size="2,22" Color="46,70,95,55" />
-        <Container                                                    Size="100,22" />
-        <Box                                                          Size="2,22" Color="46,70,95,55" />
-        <Container                                                    Size="100,22" />
-        <Box                                                          Size="2,22" Color="46,70,95,55" />
-        <Container                                                    Size="100,22" />
-        <Box                                            Offset="1,0"  Size="2,22" Color="46,70,95,128" />
-      </Stack>
-      <Grid         Style="DividerGrid" Offset="-10,22" Size="parent,8" Color="47,63,76,255" />
-    </Container>
-  </Instance>
-
-  <!-- UNIT EXPENSE -->
-
-  <Instance         Name="UnitExpensesHeaderInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-432,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="2,0"  Size="470,parent">
-          <Label                          Style="ReportHeaderText"    String="Unit" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        
-        <Container                                                    Size="100,parent">
-          <Label                          Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_GOLD" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance           Name="UnitExpensesEntryInstance">
-    <Container        ID="Top"                          Offset="8,0" Size="1003,32">
-      <Grid                                             Offset="-8,-1"  Size="590,parent"   SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
-      <Stack  StackGrowth="Right" >
-        <Box                              Anchor="C,C"                Size="2,22" Color="46,70,95,128" />       
-        <Container                                      Offset="2,0"  Size="470,parent">
-          <Label      ID="UnitName"       Style="ReportValueText" String="UnitName" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,255" />
-        
-        <Container                                                    Size="100,parent">
-          <Label      ID="Gold"           Style="ReportValueText" String="0"  Color="Gold" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <!-- DEALS -->
-
-  <Instance         Name="DealHeaderInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-432,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="369,parent">
-          <Label                          Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_CIVILIZATION" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <Label                          Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_DURATION" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <Label                          Style="ReportHeaderText"    String="LOC_HUD_REPORTS_HEADER_GOLD" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-
-  <Instance           Name="DealEntryInstance">
-    <Container        ID="Top"                          Offset="8,0" Size="1003,32">
-      <Grid                                             Offset="-8,-1"  Size="590,parent"   SliceCorner="16,16" SliceSize="1,1" SliceTextureSize="32,32" Texture="Controls_LineItem" Color="200,199,212,255"  />
-      <Stack  StackGrowth="Right" >
-        <Box                              Anchor="C,C"                Size="2,22" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="369,parent">
-          <Label      ID="Civilization"   Style="ReportValueLeftName" String="LOC_HUD_REPORTS_HEADER_CITY" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <Label      ID="Duration"       Style="ReportValueLeftName" String="LOC_HUD_REPORTS_HEADER_BUILDING" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <Label      ID="Gold"           Style="ReportValueText" String="LOC_HUD_REPORTS_HEADER_GOLD"  Color="Gold" />
-        </Container>
-        <Box                              Anchor="C,C"                Size="2,19" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                                          Size="2,parent" Color="46,70,95,55" />
-        <Container                                                    Size="100,parent" />
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-
-
-  <!-- RESOURCES  -->
-
-  <Instance         Name="ResourcesHeaderInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="577,parent">
-          <Label                                                      Style="ReportHeaderText"  String="LOC_HUD_REPORTS_SOURCES"  />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="200,parent">
-          <Label                                                      Style="ReportValueText" String="LOC_HUD_REPORTS_CONTROL" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="200,parent">
-          <Label                                                      Style="ReportValueText" String="LOC_HUD_REPORTS_AMOUNT" />
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance         Name="ResourcesEntryInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="577,parent">
-          <Label        ID="CityName"                                 Style="ReportValueText" String="$CityName$" Align="Left" Anchor="L,C" Offset="10,0" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="200,parent">
-          <Label        ID="Control"                                  Style="ReportValueText" String="$Control$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="200,parent">
-          <Label        ID="Amount"                                   Style="ReportValueText" String="$Amount$" />
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance         Name="ResourcesFooterInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,30">
-      <Image                                            Offset="4,0"  Size="parent-24,parent-2" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,26" Color="46,70,95,128" />
-        <Container                                                    Size="780,26">
-          <Label            Anchor="R,C"                Offset="5,1"  Style="ReportTotalText"     String="LOC_HUD_REPORTS_TOTALS"  />
-        </Container>
-        <Box                                                          Size="2,26" Color="46,70,95,255" />
-        <Container                                                    Size="200,26">
-          <Label        ID="Amount"                                   Style="ReportTotalText" String="$Amount$" />
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,26" Color="46,70,95,128" />
-      </Stack>
-      <Grid                        Style="DividerGrid"  Offset="-10,22" Size="parent,8" Color="47,63,76,255" />
-    </Container>
-  </Instance>
-
-
-
-  <!-- CITY STATUS -->
-
-  <Instance         Name="CityStatusHeaderInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-15,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="136,parent">
-          <GridButton   ID="CityNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_CITY" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <GridButton   ID="CityPopulationButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_POPULATION" />
-          </GridButton
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="80,parent">
-          <GridButton   ID="CityHousingButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_HOUSING" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="120,parent">
-          <GridButton   ID="CityGrowthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_GROWTH_RATE_STATUS" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="80,parent">
-          <GridButton   ID="CityAmenitiesButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_AMENITIES" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="110,parent">
-          <GridButton   ID="CityHappinessButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_CITIZEN_HAPPINESS" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="110,parent">
-          <GridButton   ID="CityWarButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_WAR_WEARINESS" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="80,parent">
-          <GridButton   ID="CityStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_STATUS" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="78,parent">
-          <GridButton   ID="CityStrengthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_STRENGTH" />
-          </GridButton>
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="78,parent">
-          <GridButton   ID="CityDamageButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label                          Style="ReportHeaderSmallText"   String="LOC_HUD_REPORTS_HEADER_DAMAGE" />
-          </GridButton>
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance         Name="CityStatusEntryInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-15,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="136,parent">
-          <Label        ID="CityName"                                 Style="ReportValueText" String="$CityName$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="100,parent">
-          <Label        ID="Population"                               Style="ReportValueText" String="$Population$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="80,parent">
-          <Label        ID="Housing"                                  Style="ReportValueText" String="$Housing$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="120,parent">
-          <Label        ID="GrowthRateStatus"                         Style="ReportValueText" String="$GrowthRateStatus$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="80,parent">
-          <Label        ID="Amenities"                                Style="ReportValueText" String="$Amenities$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="110,parent">
-          <Label        ID="CitizenHappiness"                         Style="ReportValueText" String="$CitizenHappiness$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="110,parent">
-          <Label        ID="WarWeariness"                             Style="ReportValueText" String="$WarWeariness$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="80,parent">
-          <Label        ID="Status"                                   Style="ReportValueText" String="$Status$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="78,parent">
-          <Label        ID="Strength"                                 Style="ReportValueText" String="$Strength$" />
-        </Container>
-        <Box                                                          Size="2,parent" Color="46,70,95,255" />
-        <Container                                                    Size="78,parent">
-          <Label        ID="Damage"                                   Style="ReportValueText" String="$Damage$" />
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance         Name="UnitStatusHeaderInstance">
-    <Container      ID="Top"                            Offset="8,0" Size="1003,22">
-      <Image                                            Offset="4,0"  Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
-      <Stack  StackGrowth="Right" >
-        <Box                                                          Size="2,parent" Color="46,70,95,128" />
-        <Container                                      Offset="1,0"  Size="236,parent">
-          <Label                          Style="ReportHeaderSmallText"   String="Name" />
-        </Container>
-        <Container                                                    Size="22,parent">
-          <Label                          Style="ReportHeaderSmallText"   String="Status" />
-        </Container>
-        <Container                                                    Size="100,parent">
-          <Label                          Style="ReportHeaderSmallText"   String="Level" />
-        </Container>
-        <Container                                                    Size="125,parent">
-          <Label                          Style="ReportHeaderSmallText"   String="Experience" />
-        </Container>
-        <Container                                                    Size="100,parent">
-          <Label                          Style="ReportHeaderSmallText"   String="Health" />
-        </Container>
-        <Container                                                    Size="100,parent">
-          <Label                          Style="ReportHeaderSmallText"   String="Movement" />
-        </Container>        
-        <Container                                                    Size="298,parent">
-          <Label                          Style="ReportHeaderSmallText"   String="" />
-        </Container>
-        <Box                                            Offset="1,0"  Size="2,parent" Color="46,70,95,128" />
-      </Stack>
-    </Container>
-  </Instance>
-  
-  <!-- ================================================================== -->
-  <!-- Unit Report Screen -->
-  <!-- ================================================================== -->
-  
-  <Instance Name="UnitsMilitaryHeaderInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,22">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128" />
-
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Type"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <GridButton   ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Name"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Status"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <GridButton   ID="UnitLevelButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Level"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <GridButton   ID="UnitExpButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Experience"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <GridButton   ID="UnitHealthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Health"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <GridButton   ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Movement"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="174,parent">
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-  
-  <Instance Name="UnitsCivilianHeaderInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,22">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128" />
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Type"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <GridButton   ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Name"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Status"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <GridButton   ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Movement"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <GridButton   ID="UnitChargeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Charges"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="401,parent">
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsTraderHeaderInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,22">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128" />
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Type"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <GridButton   ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Name"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Status"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="300,parent">
-          <GridButton   ID="UnitRouteButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-          <Label Style="ReportHeaderSmallText" String="Route"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="300,parent">
-          <GridButton   ID="UnitYieldButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Yields"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="26,parent">
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsGreatPeopleHeaderInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,22">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128" />
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Type"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <GridButton   ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Name"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Status"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <GridButton   ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Movement"/>
-          </GridButton>
-        </Container>
-
-        <Container Offset="1,0" Size="250,parent">
-          <GridButton   ID="UnitClassButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Class"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="251,parent">
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsReligiousHeaderInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,22">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128" />
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Type"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <GridButton   ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Name"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Status"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <GridButton   ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Movement"/>
-          </GridButton>
-        </Container>
-
-        <Container Offset="1,0" Size="100,parent">
-          <GridButton   ID="UnitStrengthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Strength"/>
-          </GridButton>
-        </Container>
-
-        <Container Offset="1,0" Size="100,parent">
-          <GridButton   ID="UnitSpreadButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Spreads"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="300,parent">
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsSpyHeaderInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,22">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128" />
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Type"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <GridButton   ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Name"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <GridButton   ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Status"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <GridButton   ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Movement"/>
-          </GridButton>
-        </Container>
-
-        <Container Offset="1,0" Size="200,parent">
-          <GridButton   ID="UnitMissionButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Mission"/>
-          </GridButton>
-        </Container>
-
-        <Container Offset="1,0" Size="200,parent">
-          <GridButton   ID="UnitTurnsButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
-            <Label Style="ReportHeaderSmallText" String="Turns Left"/>
-          </GridButton>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-  
-  <Instance Name="UnitsMilitaryEntryInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,44">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right" >
-        <Box Size="2,parent" Color="46,70,95,128"/>
-
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitType" Anchor="C,C" Size="32,32"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <Label ID="UnitLevel" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <Label ID="UnitExp" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-          <Button ID="Promotion" Hidden="1" Anchor="R,C" Size="32,32" StateOffsetIncrement="0,0" Offset="10,0">
-            <Image Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="Promotion Available" Icon="ICON_PROMOTION"/>
-          </Button>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <Label ID="UnitHealth" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-          <Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <Button ID="Upgrade" Hidden="1" Anchor="R,C" Size="32,32" StateOffsetIncrement="0,0" Offset="10,0">
-            <Image Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" Icon="ICON_UNITCOMMAND_UPGRADE"/>
-          </Button>
-        </Container>
-        
-        <Container Offset="1,0" Size="73,parent">
-          <Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-  
-  <Instance Name="UnitsCivilianEntryInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,44">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right" >
-        <Box Size="2,parent" Color="46,70,95,128"/>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitType" Anchor="C,C" Size="32,32"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-          <Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <Label ID="UnitCharges" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="401,parent">
-          <Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsTraderEntryInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,44">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right" >
-        <Box Size="2,parent" Color="46,70,95,128"/>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitType" Anchor="C,C" Size="32,32"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
-        </Container>
-
-        <Container Offset="1,0" Size="300,parent">
-          <Label ID="UnitRoute" Style="ReportValueText" String="No Route" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-
-        <Container Offset="1,0" Size="300,parent">
-          <Label ID="UnitYields" Style="ReportValueText" String="No Yields" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="26,parent">
-          <Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
-        </Container>        
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsGreatPeopleEntryInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,44">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right" >
-        <Box Size="2,parent" Color="46,70,95,128"/>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitType" Anchor="C,C" Size="32,32"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-          <Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
-        </Container>
-
-        <Container Offset="1,0" Size="250,parent">
-          <Label ID="UnitClass" Style="ReportValueText" String="Great Person" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="251,parent">
-          <Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsReligiousEntryInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,44">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right" >
-        <Box Size="2,parent" Color="46,70,95,128"/>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitType" Anchor="C,C" Size="32,32"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-          <Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
-        </Container>
-
-        <Container Offset="1,0" Size="100,parent">
-          <Label ID="UnitStrength" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-
-        <Container Offset="1,0" Size="100,parent">
-          <Label ID="UnitSpreads" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="300,parent">
-          <Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="UnitsSpyEntryInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,44">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right" >
-        <Box Size="2,parent" Color="46,70,95,128"/>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitType" Anchor="C,C" Size="32,32"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="250,parent">
-          <Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="50,parent">
-          <Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="125,parent">
-          <Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
-          <Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
-        </Container>
-
-        <Container Offset="1,0" Size="200,parent">
-          <Label ID="UnitOperation" Style="ReportValueText" String="None" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-
-        <Container Offset="1,0" Size="200,parent">
-          <Label ID="UnitTurns" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
-        </Container>
-        
-        <Container Offset="1,0" Size="100,parent">
-          <Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-  
-  <Instance Name="UnitsFooterInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,30">
-      <Image Offset="4,0" Size="parent-24,parent-2" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,26"  Color="46,70,95,128"/>
-        <Container Size="780,26">
-          <Label Anchor="R,C" Offset="5,1" Style="ReportTotalText" String="Number of Units"/>
-        </Container>
-        <Box Size="2,26" Color="46,70,95,255"/>
-        <Container Size="200,26">
-          <Label ID="Amount" Style="ReportTotalText" String="$Amount$"/>
-        </Container>
-        <Box Offset="1,0" Size="2,26" Color="46,70,95,128"/>
-      </Stack>
-      <Grid Style="DividerGrid" Offset="-10,22" Size="parent+4,8" Color="47,63,76,255"/>
-    </Container>
-  </Instance>
-
-  <Instance Name="DealsHeader">
-    <Container ID="Top" Offset="8,0" Size="1003,25">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128" />
-
-        <Container Offset="1,0" Size="500,parent">
-          <Label Style="ReportHeaderText" Anchor="C,C" Color="255,255,255,255" String="Outgoing"/>
-        </Container>
-
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-
-        <Container Offset="1,0" Size="477,parent">
-            <Label Style="ReportHeaderText" Anchor="C,C" Color="255,255,255,255" String="Incoming"/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-  
-  <Instance Name="DealsInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,30">
-      <Stack StackGrowth="Right" >
-        <Box Size="2,parent" Color="46,70,95,128"/>
-        
-        <Container Offset="1,0" Size="500,parent">
-          <Label ID="Outgoing" Style="ReportValueText" Anchor="C,C" String=""/>
-        </Container>
-
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-
-        <Container Offset="1,0" Size="477,parent">
-            <Label ID="Incoming" Style="ReportValueText" Anchor="C,C" String=""/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-    </Container>
-  </Instance>
-
-  <Instance Name="DealsFooterInstance">
-    <Container ID="Top" Offset="8,0" Size="1003,30">
-      <Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="0" Color="39,89,137,125"/>
-      <Stack StackGrowth="Right">
-        <Box Size="2,parent" Color="46,70,95,128"/>
-        
-        <Container Offset="1,0" Size="500,parent">
-          <Label ID="Outgoing" Style="ReportHeaderSmallText" Anchor="C,C" Offset="0,-3" String="Total: 0"/>
-        </Container>
-
-        <Box Offset="1,0" Size="2,parent-5" Color="46,70,95,128"/>
-
-        <Container Offset="1,0" Size="477,parent">
-            <Label ID="Incoming" Style="ReportHeaderSmallText" Anchor="C,C" Offset="0,-3" String="Total: 0"/>
-        </Container>
-        
-        <Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
-      </Stack>
-      <Grid Style="DividerGrid" Offset="-10,22" Size="parent+4,8" Color="47,63,76,255"/>
-    </Container>
-  </Instance>
-  
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,26"	Color="46,70,95,128" />
+				<Container																										Size="780,26">
+					<Label													Anchor="R,C"	Offset="5,1"	Style="ReportTotalText"			String="LOC_HUD_REPORTS_TOTALS"  />
+				</Container>
+				<Box																													Size="2,26"	Color="46,70,95,255" />
+				<Container																										Size="200,26">
+					<Label				ID="Amount"																		Style="ReportTotalText"	String="$Amount$" />
+				</Container>
+				<Box																						Offset="1,0"	Size="2,26"	Color="46,70,95,128" />
+			</Stack>
+			<Grid												 Style="DividerGrid"	Offset="-10,22" Size="parent,8" Color="47,63,76,255" />
+		</Container>
+	</Instance>
+
+	<!-- Resource-->
+	<Instance					Name="ResourceAmountInstance">
+      <Label					ID="Info" Style="ReportResourceText" String="00" />
+	</Instance>
+
+
+
+
+	<!-- CITY STATUS -->
+
+	<Instance					Name="CityStatusHeaderInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-15,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="136,parent">
+					<GridButton		ID="CityNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_CITY" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<GridButton		ID="CityPopulationButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_POPULATION" />
+					</GridButton
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="80,parent">
+					<GridButton		ID="CityHousingButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_HOUSING" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="120,parent">
+					<GridButton		ID="CityGrowthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_GROWTH_RATE_STATUS" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="80,parent">
+					<GridButton		ID="CityAmenitiesButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_AMENITIES" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="110,parent">
+					<GridButton		ID="CityHappinessButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_CITIZEN_HAPPINESS" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="110,parent">
+					<GridButton		ID="CityWarButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_WAR_WEARINESS" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="80,parent">
+					<GridButton		ID="CityStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_STATUS" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="78,parent">
+					<GridButton		ID="CityStrengthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_STRENGTH" />
+					</GridButton>
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="78,parent">
+					<GridButton		ID="CityDamageButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label													Style="ReportHeaderSmallText"		String="LOC_HUD_REPORTS_HEADER_DAMAGE" />
+					</GridButton>
+				</Container>
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance					Name="CityStatusEntryInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-15,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="136,parent">
+					<Label				ID="CityName"																	Style="ReportValueText"	String="$CityName$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="100,parent">
+					<Label				ID="Population"																Style="ReportValueText"	String="$Population$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="80,parent">
+					<Label				ID="Housing"																	Style="ReportValueText"	String="$Housing$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="120,parent">
+					<Label				ID="GrowthRateStatus"													Style="ReportValueText"	String="$GrowthRateStatus$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="80,parent">
+					<Label				ID="Amenities"																Style="ReportValueText"	String="$Amenities$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="110,parent">
+					<Label				ID="CitizenHappiness"													Style="ReportValueText"	String="$CitizenHappiness$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="110,parent">
+					<Label				ID="WarWeariness"															Style="ReportValueText"	String="$WarWeariness$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="80,parent">
+					<Label				ID="Status"																		Style="ReportValueText"	String="$Status$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="78,parent">
+					<Label				ID="Strength"																	Style="ReportValueText"	String="$Strength$" />
+				</Container>
+				<Box																													Size="2,parent"	Color="46,70,95,255" />
+				<Container																										Size="78,parent">
+					<Label				ID="Damage"																		Style="ReportValueText"	String="$Damage$" />
+				</Container>
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance					Name="UnitStatusHeaderInstance">
+		<Container			ID="Top"														Offset="8,0" Size="1003,22">
+			<Image																						Offset="4,0"	Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125" />
+			<Stack	StackGrowth="Right" >
+				<Box																													Size="2,parent"	Color="46,70,95,128" />
+				<Container																			Offset="1,0"	Size="236,parent">
+					<Label													Style="ReportHeaderSmallText"		String="Name" />
+				</Container>
+				<Container																										Size="22,parent">
+					<Label													Style="ReportHeaderSmallText"		String="Status" />
+				</Container>
+				<Container																										Size="100,parent">
+					<Label													Style="ReportHeaderSmallText"		String="Level" />
+				</Container>
+				<Container																										Size="125,parent">
+					<Label													Style="ReportHeaderSmallText"		String="Experience" />
+				</Container>
+				<Container																										Size="100,parent">
+					<Label													Style="ReportHeaderSmallText"		String="Health" />
+				</Container>
+				<Container																										Size="100,parent">
+					<Label													Style="ReportHeaderSmallText"		String="Movement" />
+				</Container>				
+				<Container																										Size="298,parent">
+					<Label													Style="ReportHeaderSmallText"		String="" />
+				</Container>
+				<Box																						Offset="1,0"	Size="2,parent"	Color="46,70,95,128" />
+			</Stack>
+		</Container>
+	</Instance>
+	
+	<!-- ==================================================================	-->
+	<!-- Unit Report Screen	-->
+	<!-- ==================================================================	-->
+	
+	<Instance Name="UnitsMilitaryHeaderInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,22">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128" />
+
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Type"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<GridButton		ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Name"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Status"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<GridButton		ID="UnitLevelButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Level"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<GridButton		ID="UnitExpButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Experience"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<GridButton		ID="UnitHealthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Health"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<GridButton		ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Movement"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="174,parent">
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+	
+	<Instance Name="UnitsCivilianHeaderInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,22">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128" />
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Type"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<GridButton		ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Name"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Status"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<GridButton		ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Movement"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<GridButton		ID="UnitChargeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Charges"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="401,parent">
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsTraderHeaderInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,22">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128" />
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Type"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<GridButton		ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Name"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Status"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="300,parent">
+					<GridButton		ID="UnitRouteButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+					<Label Style="ReportHeaderSmallText" String="Route"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="300,parent">
+					<GridButton		ID="UnitYieldButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Yields"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="26,parent">
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsGreatPeopleHeaderInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,22">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128" />
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Type"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<GridButton		ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Name"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Status"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<GridButton		ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Movement"/>
+					</GridButton>
+				</Container>
+
+				<Container Offset="1,0" Size="250,parent">
+					<GridButton		ID="UnitClassButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Class"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="251,parent">
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsReligiousHeaderInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,22">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128" />
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Type"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<GridButton		ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Name"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Status"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<GridButton		ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Movement"/>
+					</GridButton>
+				</Container>
+
+				<Container Offset="1,0" Size="100,parent">
+					<GridButton		ID="UnitStrengthButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Strength"/>
+					</GridButton>
+				</Container>
+
+				<Container Offset="1,0" Size="100,parent">
+					<GridButton		ID="UnitSpreadButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Spreads"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="300,parent">
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsSpyHeaderInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,22">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128" />
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitTypeButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Type"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<GridButton		ID="UnitNameButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Name"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<GridButton		ID="UnitStatusButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Status"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<GridButton		ID="UnitMoveButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Movement"/>
+					</GridButton>
+				</Container>
+
+				<Container Offset="1,0" Size="200,parent">
+					<GridButton		ID="UnitMissionButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Mission"/>
+					</GridButton>
+				</Container>
+
+				<Container Offset="1,0" Size="200,parent">
+					<GridButton		ID="UnitTurnsButton"  Size="parent,parent" Style="ButtonLightWeightSquareGrid" Anchor="C,C">
+						<Label Style="ReportHeaderSmallText" String="Turns Left"/>
+					</GridButton>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+	
+	<Instance Name="UnitsMilitaryEntryInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,44">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right" >
+				<Box Size="2,parent" Color="46,70,95,128"/>
+
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitType" Anchor="C,C" Size="32,32"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<Label ID="UnitLevel" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<Label ID="UnitExp" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+					<Button ID="Promotion" Hidden="1" Anchor="R,C" Size="32,32" StateOffsetIncrement="0,0" Offset="10,0">
+						<Image Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="Promotion Available" Icon="ICON_PROMOTION"/>
+					</Button>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<Label ID="UnitHealth" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+					<Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<Button ID="Upgrade" Hidden="1" Anchor="R,C" Size="32,32" StateOffsetIncrement="0,0" Offset="10,0">
+						<Image Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" Icon="ICON_UNITCOMMAND_UPGRADE"/>
+					</Button>
+				</Container>
+				
+				<Container Offset="1,0" Size="73,parent">
+					<Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+	
+	<Instance Name="UnitsCivilianEntryInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,44">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right" >
+				<Box Size="2,parent" Color="46,70,95,128"/>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitType" Anchor="C,C" Size="32,32"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+					<Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<Label ID="UnitCharges" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="401,parent">
+					<Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsTraderEntryInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,44">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right" >
+				<Box Size="2,parent" Color="46,70,95,128"/>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitType" Anchor="C,C" Size="32,32"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
+				</Container>
+
+				<Container Offset="1,0" Size="300,parent">
+					<Label ID="UnitRoute" Style="ReportValueText" String="No Route" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+
+				<Container Offset="1,0" Size="300,parent">
+					<Label ID="UnitYields" Style="ReportValueText" String="No Yields" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="26,parent">
+					<Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
+				</Container>				
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsGreatPeopleEntryInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,44">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right" >
+				<Box Size="2,parent" Color="46,70,95,128"/>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitType" Anchor="C,C" Size="32,32"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+					<Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
+				</Container>
+
+				<Container Offset="1,0" Size="250,parent">
+					<Label ID="UnitClass" Style="ReportValueText" String="Great Person" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="251,parent">
+					<Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsReligiousEntryInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,44">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right" >
+				<Box Size="2,parent" Color="46,70,95,128"/>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitType" Anchor="C,C" Size="32,32"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+					<Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
+				</Container>
+
+				<Container Offset="1,0" Size="100,parent">
+					<Label ID="UnitStrength" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+
+				<Container Offset="1,0" Size="100,parent">
+					<Label ID="UnitSpreads" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="300,parent">
+					<Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="UnitsSpyEntryInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,44">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right" >
+				<Box Size="2,parent" Color="46,70,95,128"/>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitType" Anchor="C,C" Size="32,32"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="250,parent">
+					<Label ID="UnitName" Style="ReportValueText" String="$UnitName$" Align="Center" Anchor="C,C" Offset="0,0" Color="Science"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="50,parent">
+					<Image ID="UnitStatus" Anchor="C,C" Size="22,22"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="125,parent">
+					<Label ID="UnitMove" Style="ReportValueText" String="0/0" Align="Center" Anchor="C,C" Offset="0,0"/>
+					<Image ID="Formation" Hidden="1" Offset="0,-1" Texture="Stats32" Size="32,32" Anchor="R,C" ToolTip="In Formation" Icon="ICON_UNITCOMMAND_ENTER_FORMATION"/>
+				</Container>
+
+				<Container Offset="1,0" Size="200,parent">
+					<Label ID="UnitOperation" Style="ReportValueText" String="None" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+
+				<Container Offset="1,0" Size="200,parent">
+					<Label ID="UnitTurns" Style="ReportValueText" String="0" Align="Center" Anchor="C,C" Offset="0,0"/>
+				</Container>
+				
+				<Container Offset="1,0" Size="100,parent">
+					<Button ID="LookAtButton" Anchor="R,C" Size="23,31" Texture="Controls_ShowMe" StateOffsetIncrement="0,0" Offset="10,0" ToolTip="View this unit on the map."/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+	
+	<Instance Name="UnitsFooterInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,30">
+			<Image Offset="4,0"	Size="parent-24,parent-2" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,26"	Color="46,70,95,128"/>
+				<Container Size="780,26">
+					<Label Anchor="R,C" Offset="5,1" Style="ReportTotalText" String="Number of Units"/>
+				</Container>
+				<Box Size="2,26" Color="46,70,95,255"/>
+				<Container Size="200,26">
+					<Label ID="Amount" Style="ReportTotalText" String="$Amount$"/>
+				</Container>
+				<Box Offset="1,0" Size="2,26" Color="46,70,95,128"/>
+			</Stack>
+			<Grid Style="DividerGrid" Offset="-10,22" Size="parent+4,8" Color="47,63,76,255"/>
+		</Container>
+	</Instance>
+
+	<Instance Name="DealsHeader">
+		<Container ID="Top" Offset="8,0" Size="1003,25">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="1" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128" />
+
+				<Container Offset="1,0" Size="500,parent">
+					<Label Style="ReportHeaderText" Anchor="C,C" Color="255,255,255,255" String="Outgoing"/>
+				</Container>
+
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+
+				<Container Offset="1,0" Size="477,parent">
+						<Label Style="ReportHeaderText" Anchor="C,C" Color="255,255,255,255" String="Incoming"/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+	
+	<Instance Name="DealsInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,30">
+			<Stack StackGrowth="Right" >
+				<Box Size="2,parent" Color="46,70,95,128"/>
+				
+				<Container Offset="1,0" Size="500,parent">
+					<Label ID="Outgoing" Style="ReportValueText" Anchor="C,C" String=""/>
+				</Container>
+
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+
+				<Container Offset="1,0" Size="477,parent">
+						<Label ID="Incoming" Style="ReportValueText" Anchor="C,C" String=""/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance Name="DealsFooterInstance">
+		<Container ID="Top" Offset="8,0" Size="1003,30">
+			<Image Offset="4,0" Size="parent-24,parent" Texture="Controls_GradientSmall" FlipY="0" Color="39,89,137,125"/>
+			<Stack StackGrowth="Right">
+				<Box Size="2,parent" Color="46,70,95,128"/>
+				
+				<Container Offset="1,0" Size="500,parent">
+					<Label ID="Outgoing" Style="ReportHeaderSmallText" Anchor="C,C" Offset="0,-3" String="Total: 0"/>
+				</Container>
+
+				<Box Offset="1,0" Size="2,parent-5" Color="46,70,95,128"/>
+
+				<Container Offset="1,0" Size="477,parent">
+						<Label ID="Incoming" Style="ReportHeaderSmallText" Anchor="C,C" Offset="0,-3" String="Total: 0"/>
+				</Container>
+				
+				<Box Offset="1,0" Size="2,parent" Color="46,70,95,128"/>
+			</Stack>
+			<Grid Style="DividerGrid" Offset="-10,22" Size="parent+4,8" Color="47,63,76,255"/>
+		</Container>
+	</Instance>
+
 </Context>

--- a/URS/UnitPromotionPopup.lua
+++ b/URS/UnitPromotionPopup.lua
@@ -1,537 +1,538 @@
 -- ===========================================================================
--- Popups when a Tech or Civic are completed
+--	Popups when a Tech or Civic are completed
 -- ===========================================================================
 include("Civ6Common");
 include("InstanceManager");
+	
+-- ===========================================================================
+--	CONSTANTS / MEMBERS
+-- ===========================================================================
+local m_PromotionListInstanceMgr:table	= InstanceManager:new( "PromotionSelectionInstance",	"PromotionSelection",	Controls.PromotionScrollPanel );
+local m_CompletedPromotionListInstanceMgr:table	= InstanceManager:new( "CompletedPromotionSelectionInstance",	"PromotionSelection",	Controls.PromotionScrollPanel );
+local m_kLineIM					:table	= InstanceManager:new( "LineImageInstance", 			"LineImage",			Controls.PromotionScrollPanel );
+
+local m_uiNodes				:table = {};
+local SIZE_NODE_X				:number = 150;			-- Item node dimensions
+local SIZE_NODE_Y				:number = 146;
+local SIZE_NODE_X_HALF			:number = 75;			-- Item node dimensions
+local SIZE_NODE_Y_HALF			:number = 75;
+local SIZE_PATH					:number = 40;
+local SIZE_PATH_HALF			:number = 20;
+local SIZE_ROW_Y				:number = 106;
+local SIZE_COLUMN_X				:number = 212;
+local LINE_BEFORE_CURVE			:number = 20;		-- MIN-MAX 40-(SIZE_NODE_Y/3)
+local SIZE_BORDER_X				:number = 50;
+local SIZE_BORDER_Y				:number = 60;
+-- ===========================================================================
+--	FUNCTIONS
+-- ===========================================================================
 
 -- ===========================================================================
--- CONSTANTS / MEMBERS
--- ===========================================================================
-local m_PromotionListInstanceMgr:table = InstanceManager:new( "PromotionSelectionInstance", "PromotionSelection", Controls.PromotionScrollPanel );
-local m_CompletedPromotionListInstanceMgr:table = InstanceManager:new( "CompletedPromotionSelectionInstance", "PromotionSelection", Controls.PromotionScrollPanel );
-local m_kLineIM :table = InstanceManager:new( "LineImageInstance", "LineImage", Controls.PromotionScrollPanel );
-
-local m_uiNodes :table = {};
-local SIZE_NODE_X :number = 150; -- Item node dimensions
-local SIZE_NODE_Y :number = 146;
-local SIZE_NODE_X_HALF :number = 75; -- Item node dimensions
-local SIZE_NODE_Y_HALF :number = 75;
-local SIZE_PATH :number = 40;
-local SIZE_PATH_HALF :number = 20;
-local SIZE_ROW_Y :number = 106;
-local SIZE_COLUMN_X :number = 212;
-local LINE_BEFORE_CURVE :number = 20; -- MIN-MAX 40-(SIZE_NODE_Y/3)
-local SIZE_BORDER_X :number = 50;
-local SIZE_BORDER_Y :number = 60;
--- ===========================================================================
--- FUNCTIONS
--- ===========================================================================
 
 -- ===========================================================================
-
--- ===========================================================================
--- Closes the immediate popup, will raise more if queued.
+--	Closes the immediate popup, will raise more if queued.
 -- ===========================================================================
 function Close()
-  UIManager:DequeuePopup( ContextPtr );
+	UIManager:DequeuePopup( ContextPtr );
 end
 
 -- ===========================================================================
--- UI Callback
+--	UI Callback
 -- ===========================================================================
 function OnClose()
-  Close();
+	Close();
 end
 
 -- ===========================================================================
--- UI Event
+--	UI Event
 -- ===========================================================================
 function OnInit( isReload:boolean )
-  if isReload then
-    LuaEvents.GameDebug_GetValues(RELOAD_CACHE_ID);
-  end
+	if isReload then		
+		LuaEvents.GameDebug_GetValues(RELOAD_CACHE_ID);		
+	end
 end
 
 ------------------------------------------------------------------------------------------------
 function OnLocalPlayerTurnEnd()
-  if(GameConfiguration.IsHotseat()) then
-    Close();
-  end
+	if(GameConfiguration.IsHotseat()) then
+		Close();
+	end
 end
 
 function OnPromoteUnit(ePromotion)
-  local pSelectedUnit = UI.GetHeadSelectedUnit();
-  if (pSelectedUnit ~= nil) then
-    local tParameters = {};
-    tParameters[UnitCommandTypes.PARAM_PROMOTION_TYPE] = ePromotion;
-    UnitManager.RequestCommand( pSelectedUnit, UnitCommandTypes.PROMOTE, tParameters );
-  end
+	local pSelectedUnit = UI.GetHeadSelectedUnit();
+	if (pSelectedUnit ~= nil) then
+		local tParameters = {};
+		tParameters[UnitCommandTypes.PARAM_PROMOTION_TYPE] = ePromotion;
+		UnitManager.RequestCommand( pSelectedUnit, UnitCommandTypes.PROMOTE, tParameters );
+	end
 end
 
 function OnPromoteUnitPopup()
-  local pUnit:table = UI.GetHeadSelectedUnit();
+	local pUnit:table	= UI.GetHeadSelectedUnit();
 
-  local bCanStart, tResults = UnitManager.CanStartCommand( pUnit, UnitCommandTypes.PROMOTE, true, true);
-  local tPromotions = tResults[UnitCommandResults.PROMOTIONS];
+	local bCanStart, tResults = UnitManager.CanStartCommand( pUnit, UnitCommandTypes.PROMOTE, true, true);
+	local tPromotions		= tResults[UnitCommandResults.PROMOTIONS];
 
-  local unitExperience = pUnit:GetExperience();
-  local currentPromotionList :table = unitExperience:GetPromotions();
-  local promotionClass = GameInfo.Units[pUnit:GetUnitType()].PromotionClass;
+	local unitExperience = pUnit:GetExperience();
+	local currentPromotionList :table = unitExperience:GetPromotions();
+	local promotionClass = GameInfo.Units[pUnit:GetUnitType()].PromotionClass;
 
-  local strengthString:string = "";
-  local experienceString:string = "";
-  if pUnit:GetCombat() > 0 then
-    strengthString = strengthString .. "[ICON_Strength]" ..pUnit:GetCombat()
-  end
-  if pUnit:GetRangedCombat() > 0 then
-    strengthString = strengthString .. "[ICON_Ranged]" ..pUnit:GetRangedCombat()
-  end
-  if pUnit:GetBombardCombat() > 0 then
-    strengthString = strengthString .. "[ICON_Bombard]" ..pUnit:GetBombardCombat()
-  end
-  if pUnit:GetAntiAirCombat() > 0 then
-    strengthString = strengthString .. "[ICON_AntiAir_Large]" ..pUnit:GetAntiAirCombat()
-  end
-  if pUnit:GetReligiousStrength() > 0 then
-    strengthString = strengthString .. "[ICON_Religion]" ..pUnit:GetReligiousStrength()
-  end
-  if pUnit:GetMaxMoves() > 0 then
-    strengthString = strengthString .. "[ICON_Movement]" ..pUnit:GetMaxMoves()
-  end
+	local strengthString:string = "";
+	local experienceString:string = "";
+	if pUnit:GetCombat() > 0 then
+		strengthString = strengthString .. "[ICON_Strength]" ..pUnit:GetCombat()
+	end
+	if pUnit:GetRangedCombat() > 0 then
+		strengthString = strengthString .. "[ICON_Ranged]" ..pUnit:GetRangedCombat()
+	end
+	if pUnit:GetBombardCombat() > 0 then
+		strengthString = strengthString .. "[ICON_Bombard]" ..pUnit:GetBombardCombat()
+	end
+	if pUnit:GetAntiAirCombat() > 0 then
+		strengthString = strengthString .. "[ICON_AntiAir_Large]" ..pUnit:GetAntiAirCombat()
+	end
+	if pUnit:GetReligiousStrength() > 0 then
+		strengthString = strengthString .. "[ICON_Religion]" ..pUnit:GetReligiousStrength()
+	end
+	if pUnit:GetMaxMoves() > 0 then
+		strengthString = strengthString .. "[ICON_Movement]" ..pUnit:GetMaxMoves()
+	end
 
-  experienceString = Locale.Lookup("LOC_HUD_UNIT_PANEL_XP") .. " " .. unitExperience:GetExperiencePoints();
+	experienceString = Locale.Lookup("LOC_HUD_UNIT_PANEL_XP") .. " " .. unitExperience:GetExperiencePoints();
 
-  Controls.StrMoveLabel:SetText(Locale.Lookup(strengthString));
-  Controls.ExperienceLabel:SetText(Locale.Lookup(experienceString));
+	Controls.StrMoveLabel:SetText(Locale.Lookup(strengthString));
+	Controls.ExperienceLabel:SetText(Locale.Lookup(experienceString));
 
-  m_PromotionListInstanceMgr:ResetInstances();
-  m_CompletedPromotionListInstanceMgr:ResetInstances();
-  m_kLineIM:ResetInstances();
-  m_uiNodes = {};
-  local hasPromotion:boolean;
+	m_PromotionListInstanceMgr:ResetInstances();
+	m_CompletedPromotionListInstanceMgr:ResetInstances();
+	m_kLineIM:ResetInstances();
+	m_uiNodes = {};
+	local hasPromotion:boolean;
 
-  for row in GameInfo.UnitPromotions() do
+	for row in GameInfo.UnitPromotions() do
 
-    if row.PromotionClass == promotionClass then
-      m_uiNodes[row.UnitPromotionType] = row;
-    end
-  end
+		if row.PromotionClass == promotionClass then
+			m_uiNodes[row.UnitPromotionType] = row;
+		end
+	end
 
-  local numUnlocks = 0;
-  for _, i in pairs(m_uiNodes) do
-    for row in GameInfo.UnitPromotionPrereqs() do
-      hasPromotion = false;
-      numUnlocks = 0
+	local numUnlocks = 0;
+	for _, i in pairs(m_uiNodes) do
+		for row in GameInfo.UnitPromotionPrereqs() do
+			hasPromotion = false;
+			numUnlocks = 0
+			
+			if row.PrereqUnitPromotion == i.UnitPromotionType then
+				local previousRow	:number = i.Level;
+				local previousColumn:number = i.Column;
+				local currentRow:number = m_uiNodes[row.UnitPromotion].Level;
+				local currentColumn:number = m_uiNodes[row.UnitPromotion].Column;
+			
+				for _, promotion in pairs(currentPromotionList) do
+					if row.UnitPromotion == GameInfo.UnitPromotions[promotion].UnitPromotionType or i.UnitPromotionType == GameInfo.UnitPromotions[promotion].UnitPromotionType then
+						numUnlocks = numUnlocks+1;
+					end
+				end
+				hasPromotion = numUnlocks >= 2;
 
-      if row.PrereqUnitPromotion == i.UnitPromotionType then
-        local previousRow :number = i.Level;
-        local previousColumn:number = i.Column;
-        local currentRow:number = m_uiNodes[row.UnitPromotion].Level;
-        local currentColumn:number = m_uiNodes[row.UnitPromotion].Column;
+				if (currentColumn > previousColumn or currentColumn < previousColumn) and  (currentRow > previousRow or currentRow < previousRow) then
+					local inst	:table = m_kLineIM:GetInstance();
+					local line1	:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line2:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line3:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line4:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line5:table = inst.LineImage;
 
-        for _, promotion in pairs(currentPromotionList) do
-          if row.UnitPromotion == GameInfo.UnitPromotions[promotion].UnitPromotionType or i.UnitPromotionType == GameInfo.UnitPromotions[promotion].UnitPromotionType then
-            numUnlocks = numUnlocks+1;
-          end
-        end
-        hasPromotion = numUnlocks >= 2;
+					local PrereqX = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+					local MyX = previousColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+					local PrereqY = (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
+					local MyY = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
+					local CurveY = PrereqY + LINE_BEFORE_CURVE;
 
-        if (currentColumn > previousColumn or currentColumn < previousColumn) and (currentRow > previousRow or currentRow < previousRow) then
-          local inst :table = m_kLineIM:GetInstance();
-          local line1 :table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line2:table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line3:table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line4:table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line5:table = inst.LineImage;
+					line1:SetOffsetVal(MyX, PrereqY);
+					line1:SetSizeVal(SIZE_PATH, CurveY - PrereqY-SIZE_PATH_HALF);
 
-          local PrereqX = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
-          local MyX = previousColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
-          local PrereqY = (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
-          local MyY = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
-          local CurveY = PrereqY + LINE_BEFORE_CURVE;
+					line2:SetOffsetVal(MyX, CurveY-SIZE_PATH_HALF);
+					line2:SetSizeVal(SIZE_PATH, SIZE_PATH);
 
-          line1:SetOffsetVal(MyX, PrereqY);
-          line1:SetSizeVal(SIZE_PATH, CurveY - PrereqY-SIZE_PATH_HALF);
+					line3:SetOffsetVal(math.min(PrereqX, MyX)+SIZE_PATH, CurveY-SIZE_PATH_HALF);
+					line3:SetSizeVal(math.abs(PrereqX - MyX)-SIZE_PATH, SIZE_PATH);
 
-          line2:SetOffsetVal(MyX, CurveY-SIZE_PATH_HALF);
-          line2:SetSizeVal(SIZE_PATH, SIZE_PATH);
+					line4:SetOffsetVal(PrereqX, CurveY-SIZE_PATH_HALF);
+					line4:SetSizeVal(SIZE_PATH, SIZE_PATH);
 
-          line3:SetOffsetVal(math.min(PrereqX, MyX)+SIZE_PATH, CurveY-SIZE_PATH_HALF);
-          line3:SetSizeVal(math.abs(PrereqX - MyX)-SIZE_PATH, SIZE_PATH);
+					line5:SetOffsetVal(PrereqX, CurveY + SIZE_PATH_HALF);
+					line5:SetSizeVal(SIZE_PATH, MyY - CurveY - SIZE_PATH_HALF);
+					
+					if hasPromotion then
+						line1:SetTexture("Controls_TreePathNS");
+						line3:SetTexture("Controls_TreePathEW");
+						line5:SetTexture("Controls_TreePathNS");
 
-          line4:SetOffsetVal(PrereqX, CurveY-SIZE_PATH_HALF);
-          line4:SetSizeVal(SIZE_PATH, SIZE_PATH);
+						if( PrereqX < MyX) then
+							line2:SetTexture("Controls_TreePathEN");
+							line4:SetTexture("Controls_TreePathNE");
+						else
+							line2:SetTexture("Controls_TreePathSE");
+							line4:SetTexture("Controls_TreePathES");
+						end
 
-          line5:SetOffsetVal(PrereqX, CurveY + SIZE_PATH_HALF);
-          line5:SetSizeVal(SIZE_PATH, MyY - CurveY - SIZE_PATH_HALF);
+						line1:SetColor(0xFF71A2BF);
+						line2:SetColor(0xFF71A2BF);
+						line3:SetColor(0xFF71A2BF);
+						line4:SetColor(0xFF71A2BF);
+						line5:SetColor(0xFF71A2BF);
+					else
+						line1:SetTexture("Controls_TreePathDashNS");
+						line3:SetTexture("Controls_TreePathDashEW");
+						line5:SetTexture("Controls_TreePathDashNS");
 
-          if hasPromotion then
-            line1:SetTexture("Controls_TreePathNS");
-            line3:SetTexture("Controls_TreePathEW");
-            line5:SetTexture("Controls_TreePathNS");
+						if( PrereqX < MyX) then
+							line2:SetTexture("Controls_TreePathDashEN");
+							line4:SetTexture("Controls_TreePathDashNE");
+						else
+							line2:SetTexture("Controls_TreePathDashSE");
+							line4:SetTexture("Controls_TreePathDashES");
+						end
 
-            if( PrereqX < MyX) then
-              line2:SetTexture("Controls_TreePathEN");
-              line4:SetTexture("Controls_TreePathNE");
-            else
-              line2:SetTexture("Controls_TreePathSE");
-              line4:SetTexture("Controls_TreePathES");
-            end
+						--line1:SetColor(63,83,100,255);
+						--line2:SetColor(63,83,100,255);
+						--line3:SetColor(63,83,100,255);
+						--line4:SetColor(63,83,100,255);
+						--line5:SetColor(63,83,100,255);
+					end
+				else
+					local inst:table = m_kLineIM:GetInstance();
+					local line:table = inst.LineImage;
+					if(currentColumn > previousColumn or currentColumn < previousColumn) then
+						local startX:number= (math.min(previousColumn,currentColumn))*SIZE_NODE_X + SIZE_BORDER_X;
+						local endX :number = (math.max(previousColumn,currentColumn)-1)*SIZE_NODE_X + SIZE_BORDER_X;
+						local yVal:number = (currentRow-1)*SIZE_NODE_Y + SIZE_NODE_Y_HALF;
+						
+						line:SetOffsetVal(startX, yVal);				
+						line:SetSizeVal( endX - startX, SIZE_PATH);
+						if hasPromotion then
+							line:SetTexture("Controls_TreePathEW");
+							line:SetColor(0xFF71A2BF);
+						else
+							line:SetTexture("Controls_TreePathDashEW");
+							--line:SetColor(63,83,100,255);
+						end
+					else
+						local startY:number= (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
+						local endY :number = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
+						local XVal:number = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+						
+						line:SetOffsetVal(XVal, startY);				
+						line:SetSizeVal(SIZE_PATH,  endY - startY);
+						if hasPromotion then
+							line:SetTexture("Controls_TreePathNS");
+							line:SetColor(0xFF71A2BF);
+						else
+							line:SetTexture("Controls_TreePathDashNS");
+							--line:SetColor(63,83,100,255);
+						end
+					end
+				end
+			end
+		end
+	end
 
-            line1:SetColor(0xFF71A2BF);
-            line2:SetColor(0xFF71A2BF);
-            line3:SetColor(0xFF71A2BF);
-            line4:SetColor(0xFF71A2BF);
-            line5:SetColor(0xFF71A2BF);
-          else
-            line1:SetTexture("Controls_TreePathDashNS");
-            line3:SetTexture("Controls_TreePathDashEW");
-            line5:SetTexture("Controls_TreePathDashNS");
+	for row in GameInfo.UnitPromotions() do
+		hasPromotion = false;
+		for i, promotion in pairs(currentPromotionList) do
+			if row == GameInfo.UnitPromotions[promotion] then
+				hasPromotion = true;
+			end
+		end
 
-            if( PrereqX < MyX) then
-              line2:SetTexture("Controls_TreePathDashEN");
-              line4:SetTexture("Controls_TreePathDashNE");
-            else
-              line2:SetTexture("Controls_TreePathDashSE");
-              line4:SetTexture("Controls_TreePathDashES");
-            end
+		if row.PromotionClass == promotionClass then
+			local promotionInstance;
+			local promotionDefinition = row;
+			m_uiNodes[row.UnitPromotionType] = row;
+			
+			if hasPromotion then
+				promotionInstance = m_CompletedPromotionListInstanceMgr:GetInstance();
+			else
+				promotionInstance = m_PromotionListInstanceMgr:GetInstance();
+			end
 
-            --line1:SetColor(63,83,100,255);
-            --line2:SetColor(63,83,100,255);
-            --line3:SetColor(63,83,100,255);
-            --line4:SetColor(63,83,100,255);
-            --line5:SetColor(63,83,100,255);
-          end
-        else
-          local inst:table = m_kLineIM:GetInstance();
-          local line:table = inst.LineImage;
-          if(currentColumn > previousColumn or currentColumn < previousColumn) then
-            local startX:number= (math.min(previousColumn,currentColumn))*SIZE_NODE_X + SIZE_BORDER_X;
-            local endX :number = (math.max(previousColumn,currentColumn)-1)*SIZE_NODE_X + SIZE_BORDER_X;
-            local yVal:number = (currentRow-1)*SIZE_NODE_Y + SIZE_NODE_Y_HALF;
+			promotionInstance.PromotionSelection:SetOffsetVal((row.Column-1)*SIZE_NODE_X + SIZE_BORDER_X, (row.Level-1)*SIZE_NODE_Y + SIZE_BORDER_Y);
+			if (promotionDefinition ~= nil) then
+				promotionInstance.PromotionName:SetText(Locale.ToUpper(promotionDefinition.Name));
+				promotionInstance.PromotionDescription:SetText(Locale.Lookup(promotionDefinition.Description));
+				local iconName = "ICON_" .. promotionDefinition.UnitPromotionType;
+				local textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas(iconName,32);
+				if (textureOffsetX ~= nil) then
+					promotionInstance.PromotionIcon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+				end
+			end
 
-            line:SetOffsetVal(startX, yVal);
-            line:SetSizeVal( endX - startX, SIZE_PATH);
-            if hasPromotion then
-              line:SetTexture("Controls_TreePathEW");
-              line:SetColor(0xFF71A2BF);
-            else
-              line:SetTexture("Controls_TreePathDashEW");
-              --line:SetColor(63,83,100,255);
-            end
-          else
-            local startY:number= (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
-            local endY :number = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
-            local XVal:number = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+			local bAvailable:boolean = false;
+			-- are they available to be clicked?
+			for i, item in pairs(tPromotions) do
+				if(item == row.Index) then
+					bAvailable = true;
+					local ePromotion = item;
+					promotionInstance.PromotionSlot:RegisterCallback( Mouse.eLClick, OnPromoteUnit );
+					promotionInstance.PromotionSlot:SetVoid1( ePromotion );
+				end
+			end
 
-            line:SetOffsetVal(XVal, startY);
-            line:SetSizeVal(SIZE_PATH, endY - startY);
-            if hasPromotion then
-              line:SetTexture("Controls_TreePathNS");
-              line:SetColor(0xFF71A2BF);
-            else
-              line:SetTexture("Controls_TreePathDashNS");
-              --line:SetColor(63,83,100,255);
-            end
-          end
-        end
-      end
-    end
-  end
+			if bAvailable then
+				promotionInstance.PromotionSlot:SetDisabled(false);
+			else
+				promotionInstance.PromotionSlot:SetDisabled(true);
+			end
+		end
+	end
 
-  for row in GameInfo.UnitPromotions() do
-    hasPromotion = false;
-    for i, promotion in pairs(currentPromotionList) do
-      if row == GameInfo.UnitPromotions[promotion] then
-        hasPromotion = true;
-      end
-    end
-
-    if row.PromotionClass == promotionClass then
-      local promotionInstance;
-      local promotionDefinition = row;
-      m_uiNodes[row.UnitPromotionType] = row;
-
-      if hasPromotion then
-        promotionInstance = m_CompletedPromotionListInstanceMgr:GetInstance();
-      else
-        promotionInstance = m_PromotionListInstanceMgr:GetInstance();
-      end
-
-      promotionInstance.PromotionSelection:SetOffsetVal((row.Column-1)*SIZE_NODE_X + SIZE_BORDER_X, (row.Level-1)*SIZE_NODE_Y + SIZE_BORDER_Y);
-      if (promotionDefinition ~= nil) then
-        promotionInstance.PromotionName:SetText(Locale.ToUpper(promotionDefinition.Name));
-        promotionInstance.PromotionDescription:SetText(Locale.Lookup(promotionDefinition.Description));
-        local iconName = "ICON_" .. promotionDefinition.UnitPromotionType;
-        local textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas(iconName,32);
-        if (textureOffsetX ~= nil) then
-          promotionInstance.PromotionIcon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-        end
-      end
-
-      local bAvailable:boolean = false;
-      -- are they available to be clicked?
-      for i, item in pairs(tPromotions) do
-        if(item == row.Index) then
-          bAvailable = true;
-          local ePromotion = item;
-          promotionInstance.PromotionSlot:RegisterCallback( Mouse.eLClick, OnPromoteUnit );
-          promotionInstance.PromotionSlot:SetVoid1( ePromotion );
-        end
-      end
-
-      if bAvailable then
-        promotionInstance.PromotionSlot:SetDisabled(false);
-      else
-        promotionInstance.PromotionSlot:SetDisabled(true);
-      end
-    end
-  end
-
-  Controls.PromotionScrollPanel:CalculateInternalSize();
-  UIManager:QueuePopup(ContextPtr, PopupPriority.Current)
+	Controls.PromotionScrollPanel:CalculateInternalSize();
+	UIManager:QueuePopup(ContextPtr, PopupPriority.Current)
 end
 
 function OnPromoteUnitPopupReport( unit )
-  local pUnit:table = unit
+	local pUnit:table	= unit
 
-  local bCanStart, tResults = UnitManager.CanStartCommand( pUnit, UnitCommandTypes.PROMOTE, true, true);
-  local tPromotions = tResults[UnitCommandResults.PROMOTIONS];
+	local bCanStart, tResults = UnitManager.CanStartCommand( pUnit, UnitCommandTypes.PROMOTE, true, true);
+	local tPromotions		= tResults[UnitCommandResults.PROMOTIONS];
 
-  local unitExperience = pUnit:GetExperience();
-  local currentPromotionList :table = unitExperience:GetPromotions();
-  local promotionClass = GameInfo.Units[pUnit:GetUnitType()].PromotionClass;
+	local unitExperience = pUnit:GetExperience();
+	local currentPromotionList :table = unitExperience:GetPromotions();
+	local promotionClass = GameInfo.Units[pUnit:GetUnitType()].PromotionClass;
 
-  local strengthString:string = "";
-  local experienceString:string = "";
-  if pUnit:GetCombat() > 0 then
-    strengthString = strengthString .. "[ICON_Strength]" ..pUnit:GetCombat()
-  end
-  if pUnit:GetRangedCombat() > 0 then
-    strengthString = strengthString .. "[ICON_Ranged]" ..pUnit:GetRangedCombat()
-  end
-  if pUnit:GetBombardCombat() > 0 then
-    strengthString = strengthString .. "[ICON_Bombard]" ..pUnit:GetBombardCombat()
-  end
-  if pUnit:GetAntiAirCombat() > 0 then
-    strengthString = strengthString .. "[ICON_AntiAir_Large]" ..pUnit:GetAntiAirCombat()
-  end
-  if pUnit:GetReligiousStrength() > 0 then
-    strengthString = strengthString .. "[ICON_Religion]" ..pUnit:GetReligiousStrength()
-  end
-  if pUnit:GetMaxMoves() > 0 then
-    strengthString = strengthString .. "[ICON_Movement]" ..pUnit:GetMaxMoves()
-  end
+	local strengthString:string = "";
+	local experienceString:string = "";
+	if pUnit:GetCombat() > 0 then
+		strengthString = strengthString .. "[ICON_Strength]" ..pUnit:GetCombat()
+	end
+	if pUnit:GetRangedCombat() > 0 then
+		strengthString = strengthString .. "[ICON_Ranged]" ..pUnit:GetRangedCombat()
+	end
+	if pUnit:GetBombardCombat() > 0 then
+		strengthString = strengthString .. "[ICON_Bombard]" ..pUnit:GetBombardCombat()
+	end
+	if pUnit:GetAntiAirCombat() > 0 then
+		strengthString = strengthString .. "[ICON_AntiAir_Large]" ..pUnit:GetAntiAirCombat()
+	end
+	if pUnit:GetReligiousStrength() > 0 then
+		strengthString = strengthString .. "[ICON_Religion]" ..pUnit:GetReligiousStrength()
+	end
+	if pUnit:GetMaxMoves() > 0 then
+		strengthString = strengthString .. "[ICON_Movement]" ..pUnit:GetMaxMoves()
+	end
 
-  experienceString = Locale.Lookup("LOC_HUD_UNIT_PANEL_XP") .. " " .. unitExperience:GetExperiencePoints();
+	experienceString = Locale.Lookup("LOC_HUD_UNIT_PANEL_XP") .. " " .. unitExperience:GetExperiencePoints();
 
-  Controls.StrMoveLabel:SetText(Locale.Lookup(strengthString));
-  Controls.ExperienceLabel:SetText(Locale.Lookup(experienceString));
+	Controls.StrMoveLabel:SetText(Locale.Lookup(strengthString));
+	Controls.ExperienceLabel:SetText(Locale.Lookup(experienceString));
 
-  m_PromotionListInstanceMgr:ResetInstances();
-  m_CompletedPromotionListInstanceMgr:ResetInstances();
-  m_kLineIM:ResetInstances();
-  m_uiNodes = {};
-  local hasPromotion:boolean;
+	m_PromotionListInstanceMgr:ResetInstances();
+	m_CompletedPromotionListInstanceMgr:ResetInstances();
+	m_kLineIM:ResetInstances();
+	m_uiNodes = {};
+	local hasPromotion:boolean;
 
-  for row in GameInfo.UnitPromotions() do
+	for row in GameInfo.UnitPromotions() do
 
-    if row.PromotionClass == promotionClass then
-      m_uiNodes[row.UnitPromotionType] = row;
-    end
-  end
+		if row.PromotionClass == promotionClass then
+			m_uiNodes[row.UnitPromotionType] = row;
+		end
+	end
 
-  local numUnlocks = 0;
-  for _, i in pairs(m_uiNodes) do
-    for row in GameInfo.UnitPromotionPrereqs() do
-      hasPromotion = false;
-      numUnlocks = 0
+	local numUnlocks = 0;
+	for _, i in pairs(m_uiNodes) do
+		for row in GameInfo.UnitPromotionPrereqs() do
+			hasPromotion = false;
+			numUnlocks = 0
+			
+			if row.PrereqUnitPromotion == i.UnitPromotionType then
+				local previousRow	:number = i.Level;
+				local previousColumn:number = i.Column;
+				local currentRow:number = m_uiNodes[row.UnitPromotion].Level;
+				local currentColumn:number = m_uiNodes[row.UnitPromotion].Column;
+			
+				for _, promotion in pairs(currentPromotionList) do
+					if row.UnitPromotion == GameInfo.UnitPromotions[promotion].UnitPromotionType or i.UnitPromotionType == GameInfo.UnitPromotions[promotion].UnitPromotionType then
+						numUnlocks = numUnlocks+1;
+					end
+				end
+				hasPromotion = numUnlocks >= 2;
 
-      if row.PrereqUnitPromotion == i.UnitPromotionType then
-        local previousRow :number = i.Level;
-        local previousColumn:number = i.Column;
-        local currentRow:number = m_uiNodes[row.UnitPromotion].Level;
-        local currentColumn:number = m_uiNodes[row.UnitPromotion].Column;
+				if (currentColumn > previousColumn or currentColumn < previousColumn) and  (currentRow > previousRow or currentRow < previousRow) then
+					local inst	:table = m_kLineIM:GetInstance();
+					local line1	:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line2:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line3:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line4:table = inst.LineImage;
+					inst = m_kLineIM:GetInstance();
+					local line5:table = inst.LineImage;
 
-        for _, promotion in pairs(currentPromotionList) do
-          if row.UnitPromotion == GameInfo.UnitPromotions[promotion].UnitPromotionType or i.UnitPromotionType == GameInfo.UnitPromotions[promotion].UnitPromotionType then
-            numUnlocks = numUnlocks+1;
-          end
-        end
-        hasPromotion = numUnlocks >= 2;
+					local PrereqX = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+					local MyX = previousColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+					local PrereqY = (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
+					local MyY = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
+					local CurveY = PrereqY + LINE_BEFORE_CURVE;
 
-        if (currentColumn > previousColumn or currentColumn < previousColumn) and (currentRow > previousRow or currentRow < previousRow) then
-          local inst :table = m_kLineIM:GetInstance();
-          local line1 :table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line2:table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line3:table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line4:table = inst.LineImage;
-          inst = m_kLineIM:GetInstance();
-          local line5:table = inst.LineImage;
+					line1:SetOffsetVal(MyX, PrereqY);
+					line1:SetSizeVal(SIZE_PATH, CurveY - PrereqY-SIZE_PATH_HALF);
 
-          local PrereqX = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
-          local MyX = previousColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
-          local PrereqY = (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
-          local MyY = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
-          local CurveY = PrereqY + LINE_BEFORE_CURVE;
+					line2:SetOffsetVal(MyX, CurveY-SIZE_PATH_HALF);
+					line2:SetSizeVal(SIZE_PATH, SIZE_PATH);
 
-          line1:SetOffsetVal(MyX, PrereqY);
-          line1:SetSizeVal(SIZE_PATH, CurveY - PrereqY-SIZE_PATH_HALF);
+					line3:SetOffsetVal(math.min(PrereqX, MyX)+SIZE_PATH, CurveY-SIZE_PATH_HALF);
+					line3:SetSizeVal(math.abs(PrereqX - MyX)-SIZE_PATH, SIZE_PATH);
 
-          line2:SetOffsetVal(MyX, CurveY-SIZE_PATH_HALF);
-          line2:SetSizeVal(SIZE_PATH, SIZE_PATH);
+					line4:SetOffsetVal(PrereqX, CurveY-SIZE_PATH_HALF);
+					line4:SetSizeVal(SIZE_PATH, SIZE_PATH);
 
-          line3:SetOffsetVal(math.min(PrereqX, MyX)+SIZE_PATH, CurveY-SIZE_PATH_HALF);
-          line3:SetSizeVal(math.abs(PrereqX - MyX)-SIZE_PATH, SIZE_PATH);
+					line5:SetOffsetVal(PrereqX, CurveY + SIZE_PATH_HALF);
+					line5:SetSizeVal(SIZE_PATH, MyY - CurveY - SIZE_PATH_HALF);
+					
+					if hasPromotion then
+						line1:SetTexture("Controls_TreePathNS");
+						line3:SetTexture("Controls_TreePathEW");
+						line5:SetTexture("Controls_TreePathNS");
 
-          line4:SetOffsetVal(PrereqX, CurveY-SIZE_PATH_HALF);
-          line4:SetSizeVal(SIZE_PATH, SIZE_PATH);
+						if( PrereqX < MyX) then
+							line2:SetTexture("Controls_TreePathEN");
+							line4:SetTexture("Controls_TreePathNE");
+						else
+							line2:SetTexture("Controls_TreePathSE");
+							line4:SetTexture("Controls_TreePathES");
+						end
 
-          line5:SetOffsetVal(PrereqX, CurveY + SIZE_PATH_HALF);
-          line5:SetSizeVal(SIZE_PATH, MyY - CurveY - SIZE_PATH_HALF);
+						line1:SetColor(0xFF71A2BF);
+						line2:SetColor(0xFF71A2BF);
+						line3:SetColor(0xFF71A2BF);
+						line4:SetColor(0xFF71A2BF);
+						line5:SetColor(0xFF71A2BF);
+					else
+						line1:SetTexture("Controls_TreePathDashNS");
+						line3:SetTexture("Controls_TreePathDashEW");
+						line5:SetTexture("Controls_TreePathDashNS");
 
-          if hasPromotion then
-            line1:SetTexture("Controls_TreePathNS");
-            line3:SetTexture("Controls_TreePathEW");
-            line5:SetTexture("Controls_TreePathNS");
+						if( PrereqX < MyX) then
+							line2:SetTexture("Controls_TreePathDashEN");
+							line4:SetTexture("Controls_TreePathDashNE");
+						else
+							line2:SetTexture("Controls_TreePathDashSE");
+							line4:SetTexture("Controls_TreePathDashES");
+						end
 
-            if( PrereqX < MyX) then
-              line2:SetTexture("Controls_TreePathEN");
-              line4:SetTexture("Controls_TreePathNE");
-            else
-              line2:SetTexture("Controls_TreePathSE");
-              line4:SetTexture("Controls_TreePathES");
-            end
+						--line1:SetColor(63,83,100,255);
+						--line2:SetColor(63,83,100,255);
+						--line3:SetColor(63,83,100,255);
+						--line4:SetColor(63,83,100,255);
+						--line5:SetColor(63,83,100,255);
+					end
+				else
+					local inst:table = m_kLineIM:GetInstance();
+					local line:table = inst.LineImage;
+					if(currentColumn > previousColumn or currentColumn < previousColumn) then
+						local startX:number= (math.min(previousColumn,currentColumn))*SIZE_NODE_X + SIZE_BORDER_X;
+						local endX :number = (math.max(previousColumn,currentColumn)-1)*SIZE_NODE_X + SIZE_BORDER_X;
+						local yVal:number = (currentRow-1)*SIZE_NODE_Y + SIZE_NODE_Y_HALF;
+						
+						line:SetOffsetVal(startX, yVal);				
+						line:SetSizeVal( endX - startX, SIZE_PATH);
+						if hasPromotion then
+							line:SetTexture("Controls_TreePathEW");
+							line:SetColor(0xFF71A2BF);
+						else
+							line:SetTexture("Controls_TreePathDashEW");
+							--line:SetColor(63,83,100,255);
+						end
+					else
+						local startY:number= (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
+						local endY :number = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
+						local XVal:number = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+						
+						line:SetOffsetVal(XVal, startY);				
+						line:SetSizeVal(SIZE_PATH,  endY - startY);
+						if hasPromotion then
+							line:SetTexture("Controls_TreePathNS");
+							line:SetColor(0xFF71A2BF);
+						else
+							line:SetTexture("Controls_TreePathDashNS");
+							--line:SetColor(63,83,100,255);
+						end
+					end
+				end
+			end
+		end
+	end
 
-            line1:SetColor(0xFF71A2BF);
-            line2:SetColor(0xFF71A2BF);
-            line3:SetColor(0xFF71A2BF);
-            line4:SetColor(0xFF71A2BF);
-            line5:SetColor(0xFF71A2BF);
-          else
-            line1:SetTexture("Controls_TreePathDashNS");
-            line3:SetTexture("Controls_TreePathDashEW");
-            line5:SetTexture("Controls_TreePathDashNS");
+	for row in GameInfo.UnitPromotions() do
+		hasPromotion = false;
+		for i, promotion in pairs(currentPromotionList) do
+			if row == GameInfo.UnitPromotions[promotion] then
+				hasPromotion = true;
+			end
+		end
 
-            if( PrereqX < MyX) then
-              line2:SetTexture("Controls_TreePathDashEN");
-              line4:SetTexture("Controls_TreePathDashNE");
-            else
-              line2:SetTexture("Controls_TreePathDashSE");
-              line4:SetTexture("Controls_TreePathDashES");
-            end
+		if row.PromotionClass == promotionClass then
+			local promotionInstance;
+			local promotionDefinition = row;
+			m_uiNodes[row.UnitPromotionType] = row;
+			
+			if hasPromotion then
+				promotionInstance = m_CompletedPromotionListInstanceMgr:GetInstance();
+			else
+				promotionInstance = m_PromotionListInstanceMgr:GetInstance();
+			end
 
-            --line1:SetColor(63,83,100,255);
-            --line2:SetColor(63,83,100,255);
-            --line3:SetColor(63,83,100,255);
-            --line4:SetColor(63,83,100,255);
-            --line5:SetColor(63,83,100,255);
-          end
-        else
-          local inst:table = m_kLineIM:GetInstance();
-          local line:table = inst.LineImage;
-          if(currentColumn > previousColumn or currentColumn < previousColumn) then
-            local startX:number= (math.min(previousColumn,currentColumn))*SIZE_NODE_X + SIZE_BORDER_X;
-            local endX :number = (math.max(previousColumn,currentColumn)-1)*SIZE_NODE_X + SIZE_BORDER_X;
-            local yVal:number = (currentRow-1)*SIZE_NODE_Y + SIZE_NODE_Y_HALF;
+			promotionInstance.PromotionSelection:SetOffsetVal((row.Column-1)*SIZE_NODE_X + SIZE_BORDER_X, (row.Level-1)*SIZE_NODE_Y + SIZE_BORDER_Y);
+			if (promotionDefinition ~= nil) then
+				promotionInstance.PromotionName:SetText(Locale.ToUpper(promotionDefinition.Name));
+				promotionInstance.PromotionDescription:SetText(Locale.Lookup(promotionDefinition.Description));
+				local iconName = "ICON_" .. promotionDefinition.UnitPromotionType;
+				local textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas(iconName,32);
+				if (textureOffsetX ~= nil) then
+					promotionInstance.PromotionIcon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+				end
+			end
 
-            line:SetOffsetVal(startX, yVal);
-            line:SetSizeVal( endX - startX, SIZE_PATH);
-            if hasPromotion then
-              line:SetTexture("Controls_TreePathEW");
-              line:SetColor(0xFF71A2BF);
-            else
-              line:SetTexture("Controls_TreePathDashEW");
-              --line:SetColor(63,83,100,255);
-            end
-          else
-            local startY:number= (math.min(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y + SIZE_ROW_Y;
-            local endY :number = (math.max(previousRow,currentRow)-1)*SIZE_NODE_Y + SIZE_BORDER_Y;
-            local XVal:number = currentColumn*SIZE_NODE_X + SIZE_BORDER_X - SIZE_NODE_X_HALF;
+			local bAvailable:boolean = false;
+			-- are they available to be clicked?
+			for i, item in pairs(tPromotions) do
+				if(item == row.Index) then
+					bAvailable = true;
+					local ePromotion = item;
+					promotionInstance.PromotionSlot:RegisterCallback( Mouse.eLClick, function() local tParameters = {}; tParameters[UnitCommandTypes.PARAM_PROMOTION_TYPE] = ePromotion; UnitManager.RequestCommand( pUnit, UnitCommandTypes.PROMOTE, tParameters ) end )
+					
+				end
+			end
 
-            line:SetOffsetVal(XVal, startY);
-            line:SetSizeVal(SIZE_PATH, endY - startY);
-            if hasPromotion then
-              line:SetTexture("Controls_TreePathNS");
-              line:SetColor(0xFF71A2BF);
-            else
-              line:SetTexture("Controls_TreePathDashNS");
-              --line:SetColor(63,83,100,255);
-            end
-          end
-        end
-      end
-    end
-  end
+			if bAvailable then
+				promotionInstance.PromotionSlot:SetDisabled(false);
+			else
+				promotionInstance.PromotionSlot:SetDisabled(true);
+			end
+		end
+	end
 
-  for row in GameInfo.UnitPromotions() do
-    hasPromotion = false;
-    for i, promotion in pairs(currentPromotionList) do
-      if row == GameInfo.UnitPromotions[promotion] then
-        hasPromotion = true;
-      end
-    end
-
-    if row.PromotionClass == promotionClass then
-      local promotionInstance;
-      local promotionDefinition = row;
-      m_uiNodes[row.UnitPromotionType] = row;
-
-      if hasPromotion then
-        promotionInstance = m_CompletedPromotionListInstanceMgr:GetInstance();
-      else
-        promotionInstance = m_PromotionListInstanceMgr:GetInstance();
-      end
-
-      promotionInstance.PromotionSelection:SetOffsetVal((row.Column-1)*SIZE_NODE_X + SIZE_BORDER_X, (row.Level-1)*SIZE_NODE_Y + SIZE_BORDER_Y);
-      if (promotionDefinition ~= nil) then
-        promotionInstance.PromotionName:SetText(Locale.ToUpper(promotionDefinition.Name));
-        promotionInstance.PromotionDescription:SetText(Locale.Lookup(promotionDefinition.Description));
-        local iconName = "ICON_" .. promotionDefinition.UnitPromotionType;
-        local textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas(iconName,32);
-        if (textureOffsetX ~= nil) then
-          promotionInstance.PromotionIcon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-        end
-      end
-
-      local bAvailable:boolean = false;
-      -- are they available to be clicked?
-      for i, item in pairs(tPromotions) do
-        if(item == row.Index) then
-          bAvailable = true;
-          local ePromotion = item;
-          promotionInstance.PromotionSlot:RegisterCallback( Mouse.eLClick, function() local tParameters = {}; tParameters[UnitCommandTypes.PARAM_PROMOTION_TYPE] = ePromotion; UnitManager.RequestCommand( pUnit, UnitCommandTypes.PROMOTE, tParameters ) end )
-
-        end
-      end
-
-      if bAvailable then
-        promotionInstance.PromotionSlot:SetDisabled(false);
-      else
-        promotionInstance.PromotionSlot:SetDisabled(true);
-      end
-    end
-  end
-
-  Controls.PromotionScrollPanel:CalculateInternalSize();
-  UIManager:QueuePopup(ContextPtr, PopupPriority.Current)
+	Controls.PromotionScrollPanel:CalculateInternalSize();
+	UIManager:QueuePopup(ContextPtr, PopupPriority.Current)
 end
 
--- ===========================================================================
-function Initialize()
-  -- Controls Events
-  Controls.CloseButton:RegisterCallback( eLClick, OnClose );
-  ContextPtr:SetInitHandler( OnInit );
 
-  LuaEvents.UnitPanel_PromoteUnit.Add(OnPromoteUnitPopup);
-  LuaEvents.UnitPanel_HideUnitPromotion.Add(OnClose);
-  LuaEvents.Report_PromoteUnit.Add(function( unit ) OnPromoteUnitPopupReport( unit ) end);
+-- ===========================================================================
+function Initialize()	
+	-- Controls Events
+	Controls.CloseButton:RegisterCallback( eLClick, OnClose );
+	ContextPtr:SetInitHandler( OnInit );
+
+	LuaEvents.UnitPanel_PromoteUnit.Add(OnPromoteUnitPopup);
+	LuaEvents.UnitPanel_HideUnitPromotion.Add(OnClose);
+	LuaEvents.Report_PromoteUnit.Add(function( unit ) OnPromoteUnitPopupReport( unit ) end);
 end
 Initialize();


### PR DESCRIPTION
This PR resolves all existing conflicts introduced by the Fall 2016 patch (10.0.0.38).

This includes:
* Missing city rename UI
* Broken city governor buttons
* Next plot overlay not working
* All Unit Report Screen issues (courtesy of URS patch 1.6.1)
* Removing the hotkeys obsoleted by the fall patch
  * [Y] Toggle Yields
  * [,] Prev Unit
  * [.] Next unit
* Tweaking the next plot cultural growth overlay to work with the next city plot tweaks. Also maps the Next City Plot UI element to toggling the visibility of the cultural overlay

This does not include:
* A fix for the BTS issues. These will come when the main mod updates. If no update comes, I'll see about fixing anything broken myself