### PR TITLE
GPP Per Turn Resolves Part 1 of Issue #41

### DIFF
--- a/UI/Popups/GreatPeoplePopup.lua
+++ b/UI/Popups/GreatPeoplePopup.lua
@@ -252,6 +252,10 @@ function ViewCurrent( data:table )
           local recruitInst:table = instance["m_RecruitIM"]:GetInstance();      
           recruitInst.Country:SetText( kPlayerPoints.PlayerName );
           recruitInst.Amount:SetText( tostring(Round(kPlayerPoints.PointsTotal,1)) .. "/" .. tostring(kPerson.RecruitCost) );
+
+          -- CQUI Points Per Turn -- Add the turn icon into the text 
+          recruitInst.CQUI_PerTurn:SetText( "+" .. tostring(Round(kPlayerPoints.PointsPerTurn,1)) .. " /[ICON_Turn]" );
+
           local progressPercent :number = Clamp( kPlayerPoints.PointsTotal / kPerson.RecruitCost, 0, 1 );
           recruitInst.ProgressBar:SetPercent( progressPercent );
 
@@ -260,8 +264,9 @@ function ViewCurrent( data:table )
             recruitColorName = "GreatPeopleActiveCS";     
           end
           recruitInst.Amount:SetColorByName( recruitColorName );
+          recruitInst.CQUI_PerTurn:SetColorByName( recruitColorName );
           recruitInst.Country:SetColorByName( recruitColorName );
-          recruitInst.Country:SetColorByName( recruitColorName );
+          --recruitInst.Country:SetColorByName( recruitColorName );
           recruitInst.ProgressBar:SetColorByName( recruitColorName );
 
           local recruitDetails:string = Locale.Lookup("LOC_GREAT_PEOPLE_POINT_DETAILS", Round(kPlayerPoints.PointsPerTurn, 1), classData.IconString, classData.Name);

--- a/UI/Popups/GreatPeoplePopup.xml
+++ b/UI/Popups/GreatPeoplePopup.xml
@@ -152,6 +152,7 @@
     <Container        ID="Top"                AutoSize="V"                  Size="160,50" >
       <Image          ID="WinnerIcon"                       Offset="-15,0"                  Texture="Controls_Winner12" Hidden="1" />
       <Label          ID="Country"            Anchor="L,T"  Offset="0,0"    WrapWidth="160" Style="GreatPeopleSmallText" Color="220,220,200,255" String="$Text$" />
+      <Label          ID="CQUI_PerTurn"             Anchor="C,T"  Offset="20,1"    WrapWidth="160" Style="GreatPeopleSmallText" Color="220,220,200,255" String="+x/turn" />
       <Label          ID="Amount"             Anchor="R,T"  Offset="0,0"    WrapWidth="160" Style="GreatPeopleSmallText" Color="220,220,200,255" String="X/Y" />
       <Bar            ID="ProgressBar"                      Offset="0,14"   Size="parent,6" FGColor="220,220,200,255" BGColor="0,0,0,255" Percent="0.5" />
     </Container>


### PR DESCRIPTION
Adds points per turn to each line of the standings in the GP popup.
Removes the need to access the tooltip in order to see points per turn.