### PR TITLE
Added option to adjust resource dimming style / Refactored resource dimming logic

### DIFF
--- a/CQUI/CQUI_Settings.sql
+++ b/CQUI/CQUI_Settings.sql
@@ -36,4 +36,5 @@ INSERT INTO CQUI_Settings -- Don't touch this line!
 */
 
 INSERT INTO CQUI_Settings -- Don't touch this line!
-  VALUES  ("CQUI_BindingsMode", 1); -- Set of keybindings used │ 0=Civ6 default │ 1=keybinds from Civ5 │ 2=Civ5 with additions such as WASD camera control │
+  VALUES  ("CQUI_ResourceIconStyle", 0),
+    ("CQUI_BindingsMode", 1); -- Set of keybindings used │ 0=Civ6 default │ 1=keybinds from Civ5 │ 2=Civ5 with additions such as WASD camera control │

--- a/CQUI/CQUI_Settings.sql
+++ b/CQUI/CQUI_Settings.sql
@@ -37,7 +37,8 @@ INSERT INTO CQUI_Settings -- Don't touch this line!
 */
 
 INSERT INTO CQUI_Settings -- Don't touch this line!
-  VALUES  ("CQUI_BindingsMode", 1); -- Set of keybindings used │ 0=Civ6 default │ 1=keybinds from Civ5 │ 2=Civ5 with additions such as WASD camera control │
+  VALUES  ("CQUI_BindingsMode", 1), -- Set of keybindings used │ 0=Civ6 default │ 1=keybinds from Civ5 │ 2=Civ5 with additions such as WASD camera control │
+      ("CQUI_ResourceIconStyle", 0);
 
 /*  
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/CQUI/CQUI_Settings.sql
+++ b/CQUI/CQUI_Settings.sql
@@ -37,8 +37,8 @@ INSERT INTO CQUI_Settings -- Don't touch this line!
 */
 
 INSERT INTO CQUI_Settings -- Don't touch this line!
-  VALUES  ("CQUI_BindingsMode", 1), -- Set of keybindings used │ 0=Civ6 default │ 1=keybinds from Civ5 │ 2=Civ5 with additions such as WASD camera control │
-      ("CQUI_ResourceIconStyle", 0);
+  VALUES  ("CQUI_BindingsMode", 1), -- Set of keybindings used │ 0=Civ6 default │ 1=keybinds from Civ5 │ 2=Civ5 with additions such as WASD camera control |
+      ("CQUI_ResourceDimmingStyle", 1); -- Affects the way resource icons look when they have been improved  | 0=No Change | 1=Transparent | 2=Hidden |
 
 /*  
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/CQUI/CQUI_SettingsElement.lua
+++ b/CQUI/CQUI_SettingsElement.lua
@@ -13,6 +13,13 @@ local bindings_options = {
   {"Enhanced", 2}
 };
 
+local resource_icon_style_options = 
+{
+  {"Solid", 0},
+  {"Transparent", 1},
+  {"Hidden", 2}
+};
+
 --Used to populate combobox options
 function PopulateComboBox(control, values, setting_name, tooltip)
   control:ClearEntries();
@@ -112,6 +119,8 @@ function Initialize()
   --Populating/binding comboboxes...
   --PopulateComboBox(Controls.BindingsPullDown, bindings_options, "CQUI_BindingsMode", Locale.Lookup("LOC_CQUI_BINDINGS_DROPDOWN_TOOLTIP"));
   PopulateComboBox(Controls.BindingsPullDown, bindings_options, "CQUI_BindingsMode", "Standard: Unchanged[NEWLINE]Classic: Civ V binds[NEWLINE]Enhanced: Civ V Binds with the following changes[NEWLINE]  WASD camera control[NEWLINE]  Q/E unit/city cycling[NEWLINE]  Shift toggles city/unit selection[NEWLINE]  Quarry/Airstrike are moved to alt-key + Q/S[NEWLINE]  NOTE:UNBIND W/E IN SETTINGS OR THINGS WON'T WORK!");
+
+  PopulateComboBox(Controls.ResourceIconStyle, resource_icon_style_options, "CQUI_ResourceIconStyle", "Solid: always draw the resource icons[NEWLINE]Transparent: improved resources are transparent[NEWLINE]Hidden: improved resources are hidden");
   
   --Populating/binding checkboxes...
   PopulateCheckBox(Controls.ShowLuxuryCheckbox, "CQUI_ShowLuxuries");

--- a/CQUI/CQUI_SettingsElement.lua
+++ b/CQUI/CQUI_SettingsElement.lua
@@ -297,8 +297,8 @@ function Initialize()
   --Populating/binding comboboxes...
   --PopulateComboBox(Controls.BindingsPullDown, bindings_options, "CQUI_BindingsMode", Locale.Lookup("LOC_CQUI_BINDINGS_DROPDOWN_TOOLTIP"));
   PopulateComboBox(Controls.BindingsPullDown, bindings_options, "CQUI_BindingsMode", "Standard: Unchanged[NEWLINE]Classic: Civ V binds[NEWLINE]Enhanced: Civ V Binds with the following changes[NEWLINE]  WASD camera control[NEWLINE]  Q/E unit/city cycling[NEWLINE]  Shift toggles city/unit selection[NEWLINE]  Quarry/Airstrike are moved to alt-key + Q/S[NEWLINE]  NOTE:UNBIND W/E IN SETTINGS OR THINGS WON'T WORK!");
-
-  PopulateComboBox(Controls.ResourceIconStyle, resource_icon_style_options, "CQUI_ResourceIconStyle", "Solid: always draw the resource icons[NEWLINE]Transparent: improved resources are transparent[NEWLINE]Hidden: improved resources are hidden");
+  -- PopulateComboBox(Controls.ResourceIconStyle, resource_icon_style_options, "CQUI_ResourceDimmingStyle", "LOC_CQUI_GENERAL_RESOURCEDIMMINGSTYLE", "LOC_CQUI_GENERAL_RESOURCEDIMMINGSTYLE_TOOLTIP");
+  PopulateComboBox(Controls.ResourceIconStyle, resource_icon_style_options, "CQUI_ResourceDimmingStyle", "Solid: always draw resource icons[NEWLINE]Transparent: improved resource icons are transparent[NEWLINE]Hidden: improved resource icons are hidden");
   
   --Populating/binding checkboxes...
   PopulateCheckBox(Controls.ShowLuxuryCheckbox, "CQUI_ShowLuxuries");

--- a/CQUI/CQUI_SettingsElement.xml
+++ b/CQUI/CQUI_SettingsElement.xml
@@ -36,6 +36,11 @@
             <!--<GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_SMARTBANNER" />-->
             <GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="Enable Smartbanner" />
           </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <PullDown ID="ResourceIconStyle" Style="PullDownBlue" ScrollThreshold="400" Size="300,24" Offset="0,0" SpaceForScroll="0"/>
+            <!--<Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_BINDINGS_DROPDOWN"/>-->
+            <Label Anchor="L,C" Style="ShellOptionText" String="Resource Icon Style"/>
+          </Stack>
         </Stack>
       </Container>
       <Container ID="PopupsOptions" Size="parent,parent" Hidden="1">

--- a/CQUI/CQUI_SettingsElement.xml
+++ b/CQUI/CQUI_SettingsElement.xml
@@ -42,8 +42,8 @@
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <PullDown ID="ResourceIconStyle" Style="PullDownBlue" ScrollThreshold="400" Size="300,24" Offset="0,0" SpaceForScroll="0"/>
-            <!--<Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_BINDINGS_DROPDOWN"/>-->
-            <Label Anchor="L,C" Style="ShellOptionText" String="Resource Icon Style"/>
+            <!--<Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_GENERAL_RESOURCEDIMMINGSTYLE"/>-->
+            <Label Anchor="L,C" Style="ShellOptionText" String="Improved resource icon style"/>
             </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <!--<GridButton ID="ToggleYieldsOnLoadCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" />-->

--- a/CQUI/CQUI_Text_Settings.xml
+++ b/CQUI/CQUI_Text_Settings.xml
@@ -22,7 +22,13 @@
   <Row Tag="LOC_CQUI_GENERAL" Language="en_US">
       <Text>General</Text>
     </Row>
-  <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="en_US">
+  <Row Tag="LOC_CQUI_GENERAL_RESOURCEDIMMINGSTYLE" Language="en_US">
+    <Text>Improved resource icon style</Text>
+  </Row>
+  <Row Tag="LOC_CQUI_GENERAL_RESOURCEDIMMINGSTYLE_TOOLTIP" Language="en_US">
+    <Text>Solid: always draw resource icons[NEWLINE]Transparent: improved resource icons are transparent[NEWLINE]Hidden: improved resource icons are hidden</Text>
+  </Row>
+    <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="en_US">
       <Text>Show luxuries in top panel</Text>
     </Row>
   <Row Tag="LOC_CQUI_GENERAL_SMARTBANNER" Language="en_US">

--- a/UI/WorldViewIconsManager.lua
+++ b/UI/WorldViewIconsManager.lua
@@ -29,6 +29,8 @@ local m_RecommendedImprovementPlots :table = {};
 -- Used to efficiently clear settlement recommendations
 local m_RecommendedSettlementPlots :table = {};
 
+local g_resource_icon_style = 1;
+
 -- ===========================================================================
 function GetStartingPlotPlayer( pPlot )
   local x = pPlot:GetX();
@@ -185,23 +187,44 @@ function SetResourceIcon( pInstance:table, pPlot, type, state)
       pInstance.ResourceIcon:SetToolTipString(table.concat(toolTipItems, "[NEWLINE]"));
 
       --CQUI: Resource icon becomes transparent after being improved
-      local CQUI_plotWasImproved;
       local CQUI_ICON_LOW_OPACITY :number = 0x77ffffff;
-      local CQUI_optimalTileImprovement = resourceInfo.ImprovementCollection[1].ImprovementType; --Represents the tile improvement that utilizes the resource most effectively
-      local CQUI_tileImprovement = GameInfo.Improvements[pPlot:GetImprovementType()]; --Can be nil if there is no tile improvement
-      if (CQUI_tileImprovement ~= nil) then CQUI_tileImprovement = CQUI_tileImprovement.ImprovementType; end --If the tile improvement isn't nil, find the ImprovementType value
-      if (CQUI_tileImprovement ~= CQUI_optimalTileImprovement) then
-        CQUI_plotWasImproved = false;
-      else
-        CQUI_plotWasImproved = true;
-      end
-      if CQUI_plotWasImproved then
-        pInstance.ResourceIcon:SetColor(CQUI_ICON_LOW_OPACITY);
-      else
-        pInstance.ResourceIcon:SetColor(nil);
+
+      local icon_style = g_resource_icon_style;
+
+      if icon_style == 0 then
+        local white :number = 0xffffffff;
+        pInstance.ResourceIcon:SetColor(white);
+      elseif icon_style == 1 then 
+        if CQUI_IsResourceOptimalImproved(resourceInfo, pPlot) then
+          pInstance.ResourceIcon:SetColor(CQUI_ICON_LOW_OPACITY);
+        else
+          pInstance.ResourceIcon:SetColor(nil);
+        end
+      elseif icon_style == 2 then
+        if CQUI_IsResourceOptimalImproved(resourceInfo, pPlot) then
+          local no_color :number = 0x00ffffff;
+          pInstance.ResourceIcon:SetColor(no_color);
+        else
+          pInstance.ResourceIcon:SetColor(nil);
+        end
       end
     end
   end
+end
+
+function CQUI_IsResourceOptimalImproved(resourceInfo, pPlot)
+  if table.count(resourceInfo.ImprovementCollection) > 0 then
+    local optimalTileImprovement = resourceInfo.ImprovementCollection[1].ImprovementType; --Represents the tile improvement that utilizes the resource most effectively
+    local tileImprovement = GameInfo.Improvements[pPlot:GetImprovementType()]; --Can be nil if there is no tile improvement
+
+    --If the tile improvement isn't nil, find the ImprovementType value
+    if (tileImprovement ~= nil) then 
+      tileImprovement = tileImprovement.ImprovementType;
+    end 
+
+    return tileImprovement == optimalTileImprovement;
+  end
+  return false;
 end
 
 -------------------------------------------------------------------------------
@@ -659,6 +682,16 @@ function OnUnitSelectionChanged(player, unitId, locationX, locationY, locationZ,
     end
   end
 end
+
+-- ===========================================================================
+-- register the settings callback
+function CQUI_OnIconStyleSettingsUpdate()
+  g_resource_icon_style = GameConfiguration.GetValue("CQUI_ResourceIconStyle");
+  --print("resource icon style global setting: ", g_resource_icon_style);
+  Rebuild();
+end
+LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnIconStyleSettingsUpdate );
+
 
 -- ===========================================================================
 function Initialize()

--- a/UI/WorldViewIconsManager.lua
+++ b/UI/WorldViewIconsManager.lua
@@ -29,7 +29,7 @@ local m_RecommendedImprovementPlots :table = {};
 -- Used to efficiently clear settlement recommendations
 local m_RecommendedSettlementPlots :table = {};
 
-local g_resource_icon_style = 1;
+local CQUI_ResourceIconStyle = 1;
 
 -- ===========================================================================
 function GetStartingPlotPlayer( pPlot )
@@ -189,7 +189,7 @@ function SetResourceIcon( pInstance:table, pPlot, type, state)
       --CQUI: Resource icon becomes transparent after being improved
       local CQUI_ICON_LOW_OPACITY :number = 0x77ffffff;
 
-      local icon_style = g_resource_icon_style;
+      local icon_style = CQUI_ResourceIconStyle;
 
       if icon_style == 0 then
         local white :number = 0xffffffff;
@@ -686,8 +686,8 @@ end
 -- ===========================================================================
 -- register the settings callback
 function CQUI_OnIconStyleSettingsUpdate()
-  g_resource_icon_style = GameConfiguration.GetValue("CQUI_ResourceIconStyle");
-  --print("resource icon style global setting: ", g_resource_icon_style);
+  CQUI_ResourceIconStyle = GameConfiguration.GetValue("CQUI_ResourceDimmingStyle");
+  --print("resource icon style global setting: ", CQUI_ResourceIconStyle);
   Rebuild();
 end
 LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnIconStyleSettingsUpdate );


### PR DESCRIPTION
* added a resource icon option in cqui settings. It has three options
- 0: always resource icons.
- 1: draw optimally improved resources as transparent.
- 2: hide optimally improved resources.
* fixed an lua exception when drawing archaeology site icon. archaeology site does not have an improvement table, but the old code was accessing the first improvement nonetheless. This bug luckily caused not visual bug, only a bunch of exception logs in the game log. 