### PR TITLE
Adds Hover information when mousing over City Banner Resolves #136

### DIFF
--- a/UI/WorldInput.lua
+++ b/UI/WorldInput.lua
@@ -1000,6 +1000,10 @@ end
 function DefaultKeyUpHandler( uiKey:number )
   local keyPanChanged :boolean = false;
 
+  if( uiKey == Keys.Y ) then
+    LuaEvents.CQUI_Option_ToggleYields();
+  end
+
   --CQUI Keybinds
   if CQUI_hotkeyMode ~= 0 then
     if CQUI_hotkeyMode == 2 then

--- a/UI/WorldView/CityBannerManager.xml
+++ b/UI/WorldView/CityBannerManager.xml
@@ -6,8 +6,25 @@
   <Container ID="CityBanners"/>
   <Container ID="CityDistrictIcons"/>
   <Container ID="StrategicViewStrikeButtons" Hidden="1"/>
-  
-  
+
+  <Container ID="CQUI_WorkedPlotContainer" />
+
+  <!-- Worked Plots of Local Cities -->
+  <Instance         Name="CQUI_WorkedPlotInstance">
+    <WorldAnchor    ID="Anchor"                                           Size="2,2" >
+      <Image      ID="CitizenMeterBG"       Anchor="L,C"  Offset="-10,-20"  Size="76,62"  Texture="CityPanel_ManageCitizensMeterBacking" Hidden="1">
+        <TextureBar ID="CitizenMeter"       Anchor="C,B"  Offset="19,3"   Direction="Up" Speed="0" Size="31,56" Texture="CityPanel_ManageCitizensMeter"/>
+        <Label      ID="CurrentAmount"      Anchor="L,T"  Offset="49,10"  Style="FontFlair18"   FontStyle="Stroke"  Color="201,217,227,255" EffectColor="0,0,0,150"/>
+        <Line                               Anchor="L,T"                  Start="49,37" End="67,25" Width="1" Color="201,217,227,255" />
+        <Label      ID="TotalAmount"        Anchor="R,B"  Offset="9,7"    Style="FontFlair18"   FontStyle="Stroke"  Color="201,217,227,255" EffectColor="0,0,0,150"/>
+      </Image>
+      <GridButton       ID="CQUI_NextPlotButton" Anchor="C,T"  Offset="0,-10" Size="95,30" Hidden="1" Style="PurchaseTileButton" ToolTip="The city will expand to this tile upon the next cultural borders growth">
+        <Label      ID="CQUI_NextPlotLabel" String="Next Tile" ToolTip="The city will expand to this tile upon the next cultural borders growth" Anchor="C,C"  Offset="0,0" Style="CityPanelCBCulture" Align="Left"/>
+      </GridButton>
+      <Button       ID="CitizenButton"  Anchor="C,T"  Offset="0,-50"  Size="64,64" Alpha=".50"      Texture="CityPanel_ManageCitizenButton.dds" Hidden="1"  NoStateChange="1" />
+      <Image      ID="LockedIcon"     Anchor="R,B"  Offset="-35,30" Size="32,32"    Texture="Padlock" Hidden="1"/>
+    </WorldAnchor>
+  </Instance>  
   
   <!-- Local Team Banner -->
   <Instance               Name="TeamCityBanner">

--- a/UI/WorldView/PlotInfo.lua
+++ b/UI/WorldView/PlotInfo.lua
@@ -434,6 +434,18 @@ function InitYieldIcons()
   UpdateYieldIcons(yields);
 end
 
+function CQUI_ResetYieldIcons(yieldIDs:table)
+
+  local yields:table = {};
+  local count:number = Map.GetPlotCount();
+
+  for i, plotId in ipairs(yieldIDs) do
+    GetPlotYields(plotId, yields);
+  end
+
+  UpdateYieldIcons(yields);
+end
+
 -- ===========================================================================
 local m_PlotYieldsChanged = {};
 function OnPlotYieldChanged(x, y)
@@ -946,6 +958,8 @@ function Initialize()
   if( UserConfiguration.ShowMapYield() ) then
     ShowYieldIcons();
   end
+
+  LuaEvents.CQUI_ResetYieldIcons.Add( CQUI_ResetYieldIcons );
 
 end
 Initialize();


### PR DESCRIPTION
When mousing over a city, the yields for that city are displayed. Tiles
being worked are represented using the same graphics as when one is
managing citizens. The next culture plot is displayed using the CQUI
next plot button. Also in this commit is making the "y" hotkey do the
same action as pressing on the "Show Yields" checkbox in the minimap map
options.
TODO: Display colored culture hex
TODO: More efficient way to only reveal yields for a specific city