### PR TITLE
Fixes #138 culture overlay incorrectly being left on tiles.

### DIFF
--- a/UI/Panels/CityPanel.lua
+++ b/UI/Panels/CityPanel.lua
@@ -107,10 +107,6 @@ function CQUI_OnCityviewDisabled()
   UILens.ToggleLayerOff(LensLayers.PURCHASE_PLOT);
   UILens.ToggleLayerOff(LensLayers.CITIZEN_MANAGEMENT);
   UI.SetFixedTiltMode(false);
-  if m_GrowthPlot ~= -1 then
-    UILens.ClearHex(LensLayers.PURCHASE_PLOT, m_GrowthPlot);
-    m_GrowthPlot = -1;
-  end
   UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
 end
 
@@ -147,6 +143,14 @@ function CQUI_OnInterfaceModeChanged( eOldMode:number, eNewMode:number )
   end
 end
 
+-- Clear city culture growth tile overlay if one exists
+function CQUI_ClearGrowthTile()
+  if m_GrowthPlot ~= -1 then
+    UILens.ClearHex(LensLayers.PURCHASE_PLOT, m_GrowthPlot);
+    m_GrowthPlot = -1;
+  end
+end
+
 function CQUI_OnCitySelectionChanged( ownerPlayerID:number, cityID:number, i:number, j:number, k:number, isSelected:boolean, isEditable:boolean)
   if (ownerPlayerID == Game.GetLocalPlayer()) then
     if (isSelected) then
@@ -172,6 +176,8 @@ function CQUI_OnCitySelectionChanged( ownerPlayerID:number, cityID:number, i:num
         LuaEvents.CQUI_CityviewEnable();
         Refresh();
       end
+    else
+      CQUI_ClearGrowthTile();
     end
   end
 end
@@ -1102,6 +1108,7 @@ function DisplayGrowthTile()
     end
   end
 end
+
 
 -- ===========================================================================
 --  Engine EVENT

--- a/UI/WorldInput.lua
+++ b/UI/WorldInput.lua
@@ -1043,7 +1043,7 @@ function DefaultKeyUpHandler( uiKey:number )
           UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
           UI.SelectNextReadyUnit();
         else
-          UI.SelectNextCity();
+          LuaEvents.CQUI_GoNextCity();
         end
       end
     else --Classic binds that would overlap with the enhanced binds
@@ -3348,13 +3348,11 @@ function OnInputActionTriggered( actionId )
         UI.PlaySound("Play_UI_Click");
 
     elseif actionId == m_actionHotkeyPrevCity then
-        local curCity:table = UI.GetHeadSelectedCity();
-        UI.SelectPrevCity(curCity);
+        LuaEvents.CQUI_GoPrevCity();
         UI.PlaySound("Play_UI_Click");
 
     elseif actionId == m_actionHotkeyNextCity then
-        local curCity:table = UI.GetHeadSelectedCity();
-        UI.SelectNextCity(curCity);
+        LuaEvents.CQUI_GoNextCity();
         UI.PlaySound("Play_UI_Click");
 
     elseif actionId == m_actionHotkeyOnlinePause then


### PR DESCRIPTION
Fixed by moving culture overlay clearing code into CQUI_OnCitySelectionChanged
instead of CQUI_OnCityviewDisabled which isn't invoked when moving between
cities.

Unified selecting next/previous cities by calling
LuaEvents.CQUI_GoNext/PrevCity() in all places that previously used
UI.SelectNext/PrevCity(). This isn't necessary for this commit's fix after
moving the clearing code around but if there will be more logic in
CQUI_GoNext/PrevCity then there won't be bugs from inconsistent function calls
when selecting adjacent cities from various sources.