### PR TITLE
Fixes #152 - Show 2nd highest envoy number in City-states Overview Panel

### DIFF
--- a/UI/PartialScreens/CityStates.lua
+++ b/UI/PartialScreens/CityStates.lua
@@ -1,0 +1,1582 @@
+﻿-- ===========================================================================
+--	CityStates "Rundown" partial-screen
+--
+--	su·ze·rain (noun)
+--	a sovereign or state having some control over another state that is
+--	internally autonomous.
+-- ===========================================================================
+
+include("AnimSidePanelSupport");
+include("InstanceManager");
+include("SupportFunctions");
+
+
+-- ===========================================================================
+--	CONSTANTS
+-- ===========================================================================
+local COLOR_ICON_BONUS_OFF				:number = 0xff606060;
+local COLOR_ICON_BONUS_ON				:number = 0xff999900;
+local COLOR_TEXT_BONUS_OFF				:number = 0xff606060;
+local COLOR_TEXT_BONUS_ON				:number = 0xffb0b0b0;
+local FONT_SIZE_SINGLE_DIGIT_ENVOYS		:number = 40;
+local FONT_SIZE_TWO_DIGIT_ENVOYS		:number = 26;
+local FONT_SIZE_THREE_DIGIT_ENVOYS		:number = 18;
+local MIN_ENVOY_TOKENS_SUZERAIN			:number = 3;	--TODO: expose via game core
+local NUM_ENVOY_TOKENS_FOR_FIRST_BONUS	:number = 1;
+local NUM_ENVOY_TOKENS_FOR_SECOND_BONUS	:number = 3;
+local NUM_ENVOY_TOKENS_FOR_THIRD_BONUS	:number = 6;
+local MAX_BEFORE_TRUNC_SUZERAIN:number = 310;
+local DIPLO_PIP_INFO = {};
+		DIPLO_PIP_INFO["DIPLO_STATE_PROTECTOR"]		= { IconName="ICON_RELATIONSHIP_SUZERAIN",	Tooltip="LOC_CITY_STATES_DIPLO_SUZERAIN"};
+		DIPLO_PIP_INFO["DIPLO_STATE_PATRON"]		= { IconName="ICON_RELATIONSHIP_GOOD",		Tooltip="LOC_CITY_STATES_DIPLO_GOOD"};
+		DIPLO_PIP_INFO["DIPLO_STATE_AWARE"]			= { IconName="ICON_RELATIONSHIP_NEUTRAL",	Tooltip="LOC_CITY_STATES_DIPLO_AWARE"};
+		DIPLO_PIP_INFO["DIPLO_STATE_WAR_WITH_MAJOR"]= { IconName="ICON_RELATIONSHIP_WAR",		Tooltip="LOC_CITY_STATES_DIPLO_WAR"};
+local RELOAD_CACHE_ID					:string = "CityStates"; -- Must be unique (usually the same as the file name)
+
+local MODE								:table = {
+	Overview	= "Overview",
+	SendEnvoys	= "SendEnvoys",
+	EnvoySent	= "EnvoySent",
+	InfluencedBy= "InfluencedBy",
+	Quests		= "Quests"
+}
+
+
+-- ===========================================================================
+--	MEMBERS
+-- ===========================================================================
+local m_CityStateRowIM			:table = InstanceManager:new( "CityStateRowInstance",	"CityStateBase",Controls.CityStateStack);
+local m_CityStateColumnIM		:table = InstanceManager:new( "CityStateIconInstance",	"Top",			Controls.CityStateIconStack);
+local m_BonusCityHeaderIM		:table = InstanceManager:new( "BonusCityHeaderInstance","Top",			Controls.BonusStack);
+local m_BonusItemIM				:table = InstanceManager:new( "BonusItemOnInstance",	"Top",			Controls.BonusStack);
+local m_EnvoysBonusCityHeaderIM	:table = InstanceManager:new( "BonusCityHeaderInstance","Top",			Controls.EnvoysBonusStack);
+local m_EnvoysBonusItemIM		:table = InstanceManager:new( "BonusItemOnInstance",	"Top",			Controls.EnvoysBonusStack);
+local m_InfluenceRowIM			:table = InstanceManager:new( "InfluenceRowInstance",	"Top",			Controls.InfluenceStack);
+local m_QuestsIM				:table = InstanceManager:new( "QuestInstance",			"Top",			Controls.QuestsStack);
+
+local m_kScreenSlideAnim		:table;				-- Controls overall look/feel of animation.
+local m_kCityStates				:table = {};		-- City states, key is player num of city state
+local m_kLastCityStates			:table;				-- Last set before confirming a city state change.
+local m_kPlayerData				:table = {};		-- Holds live player data that hasn't been solidifed in the game core.
+local m_kEnvoyChanges			:table = {};		-- Table (player,deltas) for envoy tokens about to be given out
+local m_uiCityStateRows			:table = {};		-- Instances holding the city state rows
+local m_mode					:string;			-- How the screen should act.
+local m_iCurrentCityState		:number= -1;		-- Player # of the city state currently active
+local m_iTurnsOfPeace			:number= tonumber(GameInfo.GlobalParameters["DIPLOMACY_PEACE_MIN_TURNS"].Value);
+local m_iTurnsOfWar				:number= tonumber(GameInfo.GlobalParameters["DIPLOMACY_WAR_MIN_TURNS"].Value);
+
+local m_isLocalPlayerTurn		:boolean = true;
+
+-- ===========================================================================
+--	FUNCTIONS
+-- ===========================================================================
+
+function GetCityStatesMetNum()
+	local total:number = 0;
+	for _,kCityState in pairs(m_kCityStates) do
+		if kCityState.isHasMet then
+			total = total + 1;
+		end
+	end
+	return total;
+end
+
+
+-- ===========================================================================
+--	Helper
+--	iPlayerID is the city state player to move the camera to point towards.
+-- ===========================================================================
+function LookAtCityState( iPlayerID:number )
+	local pPlayer		:table = Players[iPlayerID];
+	local pPlayerCities	:table = pPlayer:GetCities();
+	if pPlayerCities:GetCount() > 1 then
+		-- Might change in the future; currently city states will just raze
+		UI.DataError("The CityState player "..tostring(iPlayerID).." has "..tostring(pPlayerCities:GetCount()).." cities, but should only have 1.");
+	end
+	for _, pCity in pPlayerCities:Members() do
+		local locX			:number = pCity:GetX();
+		local locY			:number = pCity:GetY();
+		UI.LookAtPlotScreenPosition( locX, locY, 0.33, 0.5 );
+	end
+end
+
+
+-- ===========================================================================
+--	Helper
+--	playerID which player to look up the bonus type for
+--	envoyTokenNum	1,3,4,6 for the type of bonus to obtain
+--	RETURN type of bonus, the bonus text type for a city
+-- ===========================================================================
+function GetBonusText( playerID:number, envoyTokenNum:number )
+	local leader	:string = PlayerConfigurations[playerID]:GetLeaderTypeName();
+	local leaderInfo:table	= GameInfo.Leaders[leader];
+	if leaderInfo == nil or leaderInfo.InheritFrom == nil then
+		UI.DataError("Cannot determine the type of city state bonus for player #: "..tostring(playerID) );
+		return "UNKNOWN";
+	end
+
+	local bonusTypeText = "";
+	if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_SMALL_INFLUENCE_ENVOYS");
+	elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_MEDIUM_INFLUENCE_ENVOYS");
+	elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_LARGE_INFLUENCE_ENVOYS");
+	else UI.DataError("Unknown envoy number for city-state type bonus:" .. tostring(envoyTokenNum));
+	end
+
+	local bonusDetailsText = "";
+	if (leader == "LEADER_MINOR_CIV_SCIENTIFIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_SCIENTIFIC") then
+		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_SMALL_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_MEDIUM_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_LARGE_INFLUENCE_BONUS");
+		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+		end
+	elseif (leader == "LEADER_MINOR_CIV_RELIGIOUS" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_RELIGIOUS") then
+		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_SMALL_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_MEDIUM_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_LARGE_INFLUENCE_BONUS");
+		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+		end
+	elseif (leader == "LEADER_MINOR_CIV_TRADE" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_TRADE") then
+		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_SMALL_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_MEDIUM_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_LARGE_INFLUENCE_BONUS");
+		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+		end
+	elseif (leader == "LEADER_MINOR_CIV_CULTURAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_CULTURAL") then
+		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_SMALL_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_MEDIUM_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_LARGE_INFLUENCE_BONUS");
+		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+		end
+	elseif (leader == "LEADER_MINOR_CIV_MILITARISTIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_MILITARISTIC") then
+		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_SMALL_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_MEDIUM_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_LARGE_INFLUENCE_BONUS");
+		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+		end
+	elseif (leader == "LEADER_MINOR_CIV_INDUSTRIAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_INDUSTRIAL") then
+		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_SMALL_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_MEDIUM_INFLUENCE_BONUS");
+		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_LARGE_INFLUENCE_BONUS");
+		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+		end
+	else
+		UI.DataError("Unknown leader type for city-state type bonus");
+	end
+
+	return bonusTypeText, bonusDetailsText;
+end
+
+
+-- ===========================================================================
+--	Obtain the bonus text for a Suzerain
+--	playerID which player to look up the bonus type for
+--	envoyTokenNum	1,3,4,6 for the type of bonus to obtain
+--
+--	RETURN the full bonus text type for a city, and a short (brief) version
+-- ===========================================================================
+function GetSuzerainBonusText( playerID:number )
+
+	local leader	:string = PlayerConfigurations[playerID]:GetLeaderTypeName();
+	local leaderInfo:table	= GameInfo.Leaders[leader];
+	if leaderInfo == nil then
+		UI.DataError("GetSuzerainBonusText, cannot determine the type of city state suzerain bonus for player #: "..tostring(playerID) );
+		return "UNKNOWN";
+	end
+
+	local text		:string = "";
+
+	-- Unique Bonus
+	for leaderTraitPairInfo in GameInfo.LeaderTraits() do
+		if (leader ~= nil and leader == leaderTraitPairInfo.LeaderType) then
+			local traitInfo = GameInfo.Traits[leaderTraitPairInfo.TraitType];
+			if (traitInfo ~= nil) then
+				local name = PlayerConfigurations[playerID]:GetCivilizationShortDescription();
+				text = text .. "[COLOR:SuzerainDark]" .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_UNIQUE_BONUS", name) .. "[ENDCOLOR] ";
+				text = text .. Locale.Lookup(traitInfo.Description);
+			end
+		end
+	end
+
+	-- Diplomatic Bonus
+	text = text .. "[NEWLINE][NEWLINE]" .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_DIPLOMATIC_BONUS");
+
+	-- Resources Available
+	local resourceIcons	:string = "";
+	local player = Players[playerID];
+	if (player ~= nil) then
+		for resourceInfo in GameInfo.Resources() do
+			local resource = resourceInfo.Index;
+			-- Include exports, so we see what another player is getting if suzerain
+			if (player:GetResources():HasResource(resource) or player:GetResources():HasExportedResource(resource)) then
+				local amount = player:GetResources():GetResourceAmount(resource) + player:GetResources():GetExportedResourceAmount(resource);
+				if (resourceIcons ~= "") then
+					resourceIcons = resourceIcons .. ", ";
+				end
+				resourceIcons = resourceIcons .. amount .. " [ICON_" .. resourceInfo.ResourceType .. "] " .. Locale.Lookup(resourceInfo.Name);
+			end
+		end
+	end
+	if (resourceIcons ~= "") then
+		text = text .. " " .. resourceIcons;
+	else
+		text = text .. " " .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_NO_RESOURCES_AVAILABLE");
+	end
+
+	return text;
+end
+
+-- ===========================================================================
+--	RETURN a table of quests for a given CityState
+-- ===========================================================================
+function GetQuests( playerID:number )
+	local kQuests		:table  = {};
+	local questsManager	:table = Game.GetQuestsManager();
+	local localPlayerID :number = Game.GetLocalPlayer();
+	if questsManager ~= nil then
+		for questInfo in GameInfo.Quests() do
+			if questsManager:HasActiveQuestFromPlayer( localPlayerID, playerID, questInfo.Index) then
+				kQuests[questInfo.Index] = {
+					Description = questsManager:GetActiveQuestDescription( localPlayerID, playerID, questInfo.Index),
+					Name		= questsManager:GetActiveQuestName( localPlayerID, playerID, questInfo.Index),
+					Reward		= questsManager:GetActiveQuestReward( localPlayerID, playerID, questInfo.Index),
+					Type		= questInfo.QuestType,
+					Callout		= questInfo.IconString
+				};
+			end
+		end
+	else
+		UI.DataError("City-States were unable to obtain the QuestManager.");
+	end
+	return kQuests;
+end
+
+
+-- ===========================================================================
+--	Returns the texture name and UV for a bonus icon type.
+-- ===========================================================================
+function GetBonusIconAtlasPieces( kCityState:table, size:number )
+	local iconName:string = "";
+	if	   kCityState.Type == "SCIENTIFIC"		then	iconName = "ICON_ENVOY_BONUS_SCIENCE";
+	elseif kCityState.Type == "RELIGIOUS"		then	iconName = "ICON_ENVOY_BONUS_FAITH";
+	elseif kCityState.Type == "TRADE"			then	iconName = "ICON_ENVOY_BONUS_GOLD";
+	elseif kCityState.Type == "CULTURE"			then	iconName = "ICON_ENVOY_BONUS_CULTURE";
+	elseif kCityState.Type == "MILITARISTIC"	then	iconName = "ICON_ENVOY_BONUS_MILITARY";
+	elseif kCityState.Type == "INDUSTRIAL"		then	iconName = "ICON_ENVOY_BONUS_PRODUCTION";
+	end
+	return IconManager:FindIconAtlas(iconName, size);
+end
+
+-- ===========================================================================
+--	Obtain art and text related to the relationship status
+--	RETURNS: atlas texture info (u, v, and image), as well as a tooltip
+-- ===========================================================================
+function GetRelationshipPipAtlasPieces( kCityState:table )
+	local iconName	:string = DIPLO_PIP_INFO[kCityState.DiplomaticState].IconName;
+	local tooltip	:string = Locale.Lookup( DIPLO_PIP_INFO[kCityState.DiplomaticState].Tooltip );
+	if iconName == nil or iconName == "" then
+		print("WARNING: Unexpected DiplomaticState when obtain PIP art. value:"..kCityState.DiplomaticState);
+		iconName = "ICON_RELATIONSHIP_NEUTRAL";
+	end
+	local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(iconName, 23);
+	return textureOffsetX, textureOffsetY, textureSheet, tooltip;
+end
+
+-- ===========================================================================
+--	Return the type of city-state this is in a tooltip ready form.
+-- ===========================================================================
+function GetTypeTooltip( kCityState:table )
+	local toolTip		:string;
+	if	   kCityState.Type == "SCIENTIFIC"		then	toolTip	 = "LOC_CITY_STATES_TYPE_SCIENTIFIC";
+	elseif kCityState.Type == "RELIGIOUS"		then	toolTip	 = "LOC_CITY_STATES_TYPE_RELIGIOUS";
+	elseif kCityState.Type == "TRADE"			then	toolTip	 = "LOC_CITY_STATES_TYPE_TRADE";
+	elseif kCityState.Type == "CULTURE"			then	toolTip	 = "LOC_CITY_STATES_TYPE_CULTURAL";
+	elseif kCityState.Type == "MILITARISTIC"	then	toolTip	 = "LOC_CITY_STATES_TYPE_MILITARISTIC";
+	elseif kCityState.Type == "INDUSTRIAL"		then	toolTip	 = "LOC_CITY_STATES_TYPE_INDUSTRIAL";
+	else
+		UI.DataError("WARNING: Unknown type '"..kCityState.Type.."' for getting the City-State tooltip.");
+		return 0,0,"","";
+	end
+	return toolTip;
+end
+
+-- ===========================================================================
+--	Returns the texture name and UV for a given City-States type, also a
+--	tooltip describing that type.
+-- ===========================================================================
+function GetTypeAtlasPieces( kCityState:table, size:number )
+	local iconName		:string;
+	if	   kCityState.Type == "SCIENTIFIC"		then	iconName = "ICON_CITYSTATE_SCIENCE";
+	elseif kCityState.Type == "RELIGIOUS"		then	iconName = "ICON_CITYSTATE_FAITH";
+	elseif kCityState.Type == "TRADE"			then	iconName = "ICON_CITYSTATE_TRADE";
+	elseif kCityState.Type == "CULTURE"			then	iconName = "ICON_CITYSTATE_CULTURE";
+	elseif kCityState.Type == "MILITARISTIC"	then	iconName = "ICON_CITYSTATE_MILITARISTIC";
+	elseif kCityState.Type == "INDUSTRIAL"		then	iconName = "ICON_CITYSTATE_INDUSTRIAL";
+	else
+		UI.DataError("WARNING: Unknown type '"..kCityState.Type.."' for getting the City-State icon (at size "..tostring(size)..")");
+		return 0,0,"","";
+	end
+
+	local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(iconName, size);
+	return textureOffsetX, textureOffsetY, textureSheet;
+end
+
+-- ===========================================================================
+--	Returns the texture name and UV for a bonus icon type.
+-- ===========================================================================
+function GetTypeName( kCityState:table )
+	if	   kCityState.Type == "SCIENTIFIC"		then	return Locale.Lookup("LOC_CITY_STATES_TYPE_SCIENTIFIC");
+	elseif kCityState.Type == "RELIGIOUS"		then	return Locale.Lookup("LOC_CITY_STATES_TYPE_RELIGIOUS");
+	elseif kCityState.Type == "TRADE"			then	return Locale.Lookup("LOC_CITY_STATES_TYPE_TRADE");
+	elseif kCityState.Type == "CULTURE"			then	return Locale.Lookup("LOC_CITY_STATES_TYPE_CULTURAL");
+	elseif kCityState.Type == "MILITARISTIC"	then	return Locale.Lookup("LOC_CITY_STATES_TYPE_MILITARISTIC");
+	elseif kCityState.Type == "INDUSTRIAL"		then	return Locale.Lookup("LOC_CITY_STATES_TYPE_INDUSTRIAL");
+	end
+	return "unknownType'"..kCityState.Type.."'";
+end
+
+-- ===========================================================================
+--	Sum up the envoy changes the player is proposing to make (but not
+--	submitted to the game engine).
+--	RETURNS: # of envoy token changes across all City States
+-- ===========================================================================
+function SumEnvoyChanges()
+	local sum:number = 0;
+	for _,value in pairs( m_kEnvoyChanges ) do
+		sum = sum + value;
+	end
+	return sum;
+end
+
+-- ===========================================================================
+function Close()
+	m_kEnvoyChanges = {};		-- Zero out any pending envoy choices
+
+    if not ContextPtr:IsHidden() then
+        UI.PlaySound("CityStates_Panel_Close");
+    end
+
+    m_kScreenSlideAnim.Hide();
+end
+
+-- ===========================================================================
+--	UI Callback
+--	Clicking close on interface.
+-- ===========================================================================
+function OnClose()
+	Close();
+end
+
+-- ===========================================================================
+--	UI Callback
+--	Go back to the main list view.
+-- ===========================================================================
+function OnBackClose()
+	if m_kPlayerData.EnvoyTokens ~= nil and m_kPlayerData.EnvoyTokens > 0 then
+		m_mode = MODE.SendEnvoys;
+	else
+		m_mode = MODE.Overview;
+	end
+	Refresh();
+end
+
+-- ===========================================================================
+--	LUA Event
+--	Explicit close (from partial screen hooks), part of closing everything,
+-- ===========================================================================
+function OnCloseAllExcept( contextToStayOpen:string )
+	if contextToStayOpen == ContextPtr:GetID() then return; end
+	Close();
+end
+
+-- ===========================================================================
+--	LUA Event
+--	Explicit close called from else-where.
+-- ===========================================================================
+function OnCloseCityStates()
+	Close();
+end
+
+
+-- ===========================================================================
+--	LUA Event
+-- ===========================================================================
+function OnOpenCityStates()
+	OpenOverview();
+end
+
+-- ===========================================================================
+--	LUA Event
+--	Open up the screen.
+--	iPlayer	(optional) the player number for the city state to focus on, if
+--			-1 or nil it will show an overview list.
+-- ===========================================================================
+function OpenOverview( iPlayer:number )
+	UI.PlaySound("CityStates_Panel_Open");
+	m_mode = MODE.Overview;
+	m_kScreenSlideAnim.Show();
+	Refresh();
+end
+
+
+-- ===========================================================================
+--	LUA Event
+--	Open up the screen for envoy sending.
+--	iPlayer	(optional) the player number for the city state to focus on, if
+--			-1 or nil it will show an overview list.
+-- ===========================================================================
+function OnOpenSendEnvoys( iPlayer:number )
+	m_mode = MODE.SendEnvoys;
+	UI.PlaySound("CityStates_Panel_Open");
+	m_kScreenSlideAnim.Show();
+	Refresh();
+
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID ~= -1) then
+		local localPlayer = Players[localPlayerID];
+		if (localPlayer ~= nil and localPlayer:GetInfluence() ~= nil and not localPlayer:GetInfluence():IsGivingTokensConsidered()) then
+			localPlayer:GetInfluence():SetGivingTokensConsidered(true);
+		end
+	end
+end
+
+
+-- ===========================================================================
+--	LUA EVENT
+--	Open panel pointing to a specific City State
+-- ===========================================================================
+function OnRaiseMinorCivicsPanel( playerID:number )
+	OpenSingleViewCityState( playerID );
+end
+
+-- ===========================================================================
+--	Open panel pointing to a specific City State
+-- ===========================================================================
+function OpenSingleViewCityState( playerID:number )
+	if m_mode == MODE.Overview or m_mode == MODE.SendEnvoys then
+		m_mode = MODE.EnvoySent;
+	end
+
+	UI.PlaySound("CityStates_Panel_Open");
+	m_iCurrentCityState = playerID;
+	m_kScreenSlideAnim.Show();
+	Refresh();
+	LookAtCityState( playerID );
+end
+
+
+
+-- ===========================================================================
+--	Obtain latest data and display it.
+-- ===========================================================================
+function Refresh()
+	GetData();
+	if m_mode == MODE.Overview or m_mode == MODE.SendEnvoys then
+		ViewList();
+	else
+		-- If no city state is selected, then change to the overview.
+		if m_iCurrentCityState == -1 then
+			m_mode = MODE.Overview;
+			ViewList();
+		else
+			ViewCityState( m_iCurrentCityState );
+		end
+	end
+end
+
+-- ===========================================================================
+--	Helper to realize an envoy's contents and size of font use
+-- ===========================================================================
+function RealizeEnvoyToken( total:number, control:table )
+	if total < 10 then
+		control:SetFontSize(FONT_SIZE_SINGLE_DIGIT_ENVOYS);
+	elseif total < 100 then
+		control:SetFontSize(FONT_SIZE_TWO_DIGIT_ENVOYS);
+	else
+		control:SetFontSize(FONT_SIZE_THREE_DIGIT_ENVOYS);	-- So much envoy!
+	end
+	control:SetText( total );
+end
+
+-- ===========================================================================
+function RealizeListHeader()
+	local sum:number = SumEnvoyChanges();
+
+	if (m_kPlayerData.EnvoyTokens - sum) < 0 then
+		UI.DataError("Less envoy tokens than going into the deploy envoy.");
+	end
+
+	local header:string = Locale.ToUpper(Locale.Lookup("LOC_CITY_STATES_OVERVIEW"));
+	if m_mode == MODE.SendEnvoys then
+		header = Locale.ToUpper( Locale.Lookup("LOC_CITY_STATES_SEND_ENVOYS", (m_kPlayerData.EnvoyTokens - sum)) );
+		header = header .. " " .. Locale.Lookup("LOC_CITY_STATES_SEND_ENVOY_AMOUNT", (m_kPlayerData.EnvoyTokens - sum)) .. " ";	--HACK: space on end due to textcontrol bug, see below
+	end
+	--TODO: Space after [ICON..] breaks smallcaps?! ??TRON: header="SEND ENVOYS (2[ICON_Envoy] )";
+	--print("Envoy Header:",header);
+	Controls.Header:SetText( header );
+
+	local localPlayer = Players[Game.GetLocalPlayer()];
+	if (localPlayer == nil) then
+		return;
+	end
+
+	local playerInfluence	:table	= localPlayer:GetInfluence();
+	local influenceBalance	:number	= Round(playerInfluence:GetPointsEarned(), 1);
+	local influenceRate		:number = Round(playerInfluence:GetPointsPerTurn(), 1);
+	local influenceThreshold:number	= playerInfluence:GetPointsThreshold();
+	local envoysPerThreshold:number = playerInfluence:GetTokensPerThreshold();
+	local currentEnvoys		:number = playerInfluence:GetTokensToGive();
+
+	local envoyDetails:string = Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_THRESHOLD", envoysPerThreshold, influenceThreshold);
+	Controls.EnvoyDetails:SetText(envoyDetails);
+
+	local sTooltip:string = "";
+	if (currentEnvoys > 0) then
+		sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_ENVOYS", currentEnvoys);
+		sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
+	end
+	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_THRESHOLD", envoysPerThreshold, influenceThreshold);
+	sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
+	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_BALANCE", influenceBalance);
+	sTooltip = sTooltip .. "[NEWLINE]";
+	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_RATE", influenceRate);
+	sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
+	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_SOURCES_HELP");
+
+	local meterRatio = influenceBalance / influenceThreshold;
+	if (meterRatio < 0) then
+		meterRatio = 0;
+	elseif (meterRatio > 1) then
+		meterRatio = 1;
+	end
+	Controls.EnvoysMeter:SetPercent(meterRatio);
+	Controls.Envoys:SetToolTipString(sTooltip);
+	Controls.EnvoysStack:CalculateSize();
+	Controls.EnvoysStack:ReprocessAnchoring();
+end
+
+-- ===========================================================================
+--	Enable/Disable change buttons
+-- ===========================================================================
+function RealizeEnvoyChangeButtons()
+	local sum:number = SumEnvoyChanges();
+
+	-- Enable/disable every button based on if any more tokens can be given out.
+	local totalLeft		:number = (m_kPlayerData.EnvoyTokens - sum);
+	local isMoreDisabled:boolean = not m_isLocalPlayerTurn or (totalLeft == 0);
+	local isLessDisabled:boolean = not m_isLocalPlayerTurn or (sum <= 0);
+
+	-- Likely going away so even if warring envoys can still be sent.
+	for iPlayer,inst in pairs( m_uiCityStateRows ) do
+		inst.EnvoyMoreButton:SetDisabled( isMoreDisabled or (not m_kCityStates[iPlayer].CanReceiveTokensFrom) );
+		inst.EnvoyLessButton:SetDisabled( isLessDisabled or (not m_kCityStates[iPlayer].CanReceiveTokensFrom) );
+		local amount:number = m_kEnvoyChanges[iPlayer];
+		inst.EnvoyLessButton:SetHide( amount == nil or amount == 0 );
+		if m_kCityStates[iPlayer].isAlive then
+			if m_kCityStates[iPlayer].CanReceiveTokensFrom then
+				inst.EnvoyMoreButton:SetToolTipString( Locale.Lookup("LOC_CITY_STATES_ADD_AN_ENVOY") );
+				inst.EnvoyLessButton:SetToolTipString( Locale.Lookup("LOC_CITY_STATES_REMOVE_AN_ENVOY") );
+				inst.Envoy:SetToolTipString( nil );
+			else
+				local tooltip:string = Locale.Lookup("LOC_CITY_STATES_CURRENTLY_AT_WAR");
+				inst.EnvoyMoreButton:SetToolTipString( tooltip );
+				inst.EnvoyLessButton:SetToolTipString( tooltip );
+				inst.Envoy:SetToolTipString( tooltip );
+			end
+		else
+			local tooltip:string = Locale.Lookup("LOC_CITY_STATES_DESTROYED_LONG");
+			inst.EnvoyMoreButton:SetToolTipString( tooltip );
+			inst.EnvoyLessButton:SetToolTipString( tooltip );
+			inst.Envoy:SetToolTipString( tooltip );
+		end
+	end
+
+	Controls.ConfirmButton:SetDisabled(not m_isLocalPlayerTurn or sum == 0);
+end
+
+-- ===========================================================================
+function OnLessEnvoyTokens( iPlayer:number )
+
+	local amount :number = m_kEnvoyChanges[iPlayer];
+	if amount == nil then
+		amount = 0;
+	end
+	amount = amount - 1;
+	if amount < 0 then
+		-- Do nothing, below the initial value
+		m_kEnvoyChanges[iPlayer] = nil;
+		return;
+	end
+	m_kEnvoyChanges[iPlayer] = amount;
+	m_uiCityStateRows[iPlayer].EnvoyLessButton:SetDisabled( m_kEnvoyChanges[iPlayer] == 0 );
+
+	UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
+
+	RealizeEnvoyChangeButtons();
+	RealizeEnvoyToken(m_kCityStates[iPlayer].Tokens + m_kEnvoyChanges[iPlayer], m_uiCityStateRows[iPlayer].EnvoyCount);
+	RealizeListHeader();
+end
+
+-- ===========================================================================
+function OnMoreEnvoyTokens( iPlayer:number )
+
+	local amount :number = m_kEnvoyChanges[iPlayer];
+	if amount == nil then
+		amount = 1;
+	else
+		amount = amount + 1;
+	end
+	m_kEnvoyChanges[iPlayer] = amount;
+
+	UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
+
+	RealizeEnvoyChangeButtons();
+	RealizeEnvoyToken( m_kCityStates[iPlayer].Tokens + m_kEnvoyChanges[iPlayer], m_uiCityStateRows[iPlayer].EnvoyCount);
+	RealizeListHeader();
+end
+
+-- ===========================================================================
+--	Confirm where Envoy tokens are going
+-- ===========================================================================
+function OnConfirmPlacement()
+	local playerID		:number= Game.GetLocalPlayer();
+	local pLocalPlayer	:table = Players[playerID];
+	local sum			:number = SumEnvoyChanges();
+	local totalLeft		:number = (m_kPlayerData.EnvoyTokens - sum);
+
+	if pLocalPlayer ~= nil then
+		for cityStatePlayerID,numTokens in pairs(m_kEnvoyChanges) do
+			for i=1,numTokens,1 do
+				local parameters:table = {};
+				parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = cityStatePlayerID;
+				UI.RequestPlayerOperation( playerID, PlayerOperations.GIVE_INFLUENCE_TOKEN, parameters);
+			end
+		end
+		m_kEnvoyChanges		= {};
+		m_kLastCityStates	= m_kCityStates;	-- Save last city states to check against once an update occurs
+		UI.PlaySound("Click_Confirm");
+		if totalLeft < 1 then					-- If no changes are left to be made, we're done here; goodbye.
+			Close();
+		end
+	else
+		UI.DataError("Unable to get a valid local player when confirming envoy tokens.");
+	end
+end
+
+-- ===========================================================================
+--	UI Callback
+-- ===========================================================================
+function OnEnvoySentClick()
+	m_mode = MODE.EnvoySent;
+	Refresh();
+end
+
+-- ===========================================================================
+--	UI Callback
+-- ===========================================================================
+function OnInfluencedByClick()
+	m_mode = MODE.InfluencedBy;
+	Refresh();
+end
+
+-- ===========================================================================
+--	UI Callback
+-- ===========================================================================
+function OnQuestsClick()
+	m_mode = MODE.Quests;
+	Refresh();
+end
+
+-- ===========================================================================
+--	Change from WAR to peace or peace to WAR with a City-State
+-- ===========================================================================
+function OnChangeWarPeaceStatus( kCityState:table )
+	local iPlayer		:number = kCityState.iPlayer;
+	local localPlayerID :number = Game.GetLocalPlayer();
+	local pLocalPlayer	:table	= Players[localPlayerID];
+
+	if pLocalPlayer ~= nil then
+		if kCityState.isAtWar then
+			local parameters :table = {};
+			parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = localPlayerID;
+			parameters[ PlayerOperations.PARAM_PLAYER_TWO ] = iPlayer;
+			UI.RequestPlayerOperation( localPlayerID, PlayerOperations.DIPLOMACY_MAKE_PEACE, parameters);
+		else
+			LuaEvents.CityStates_ConfirmWarDialog(localPlayerID, iPlayer, WarTypes.SURPRISE_WAR);
+		end
+	else
+		UI.DataError("Could not get local player to declare war on city state '"..kCityState.Name.."'.");
+	end
+end
+
+-- ===========================================================================
+--	Levy the Military of a City-State
+-- ===========================================================================
+function OnLevyMilitary( kCityState:table)
+	local iPlayer		:number = kCityState.iPlayer;
+	local localPlayerID :number = Game.GetLocalPlayer();
+	local pLocalPlayer	:table	= Players[localPlayerID];
+
+	if pLocalPlayer ~= nil then
+		local parameters :table = {};
+		parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = iPlayer;
+		UI.RequestPlayerOperation(localPlayerID, PlayerOperations.LEVY_MILITARY, parameters);
+	else
+		UI.DataError("Could not get local player to levy military from city state '"..kCityState.Name.."'.");
+	end
+end
+
+
+-- ===========================================================================
+function AddCityStateRow( kCityState:table )
+
+	local kInst				:table = m_CityStateRowIM:GetInstance();
+	local textureOffsetX	:number;
+	local textureOffsetY	:number;
+	local textureSheet		:string;
+	local questToolTip		:string = Locale.Lookup("LOC_CITY_STATES_QUESTS");
+	local numQuests			:number = 0;
+	local cityStateName		:string = Locale.ToUpper( Locale.Lookup(kCityState.Name) .. (kCityState.isAlive and "" or "("..Locale.Lookup("LOC_CITY_STATES_DESTROYED")..")") );
+
+	-- Set name, truncate if necessary
+	kInst.NameLabel:SetText( cityStateName );
+	local targetSize:number = (kInst.NameButton:GetSizeX() - 12);
+	TruncateStringWithTooltip(kInst.NameLabel, targetSize, cityStateName);
+
+	kInst.NameLabel:SetColor( kCityState.ColorSecondary );
+	kInst.NameButton:SetColor( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
+	kInst.NameButton:RegisterCallback( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
+
+	textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
+	kInst.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+	kInst.DiplomacyPip:SetToolTipString(tooltip);
+
+	for _,kQuest in pairs( kCityState.Quests ) do
+		numQuests = numQuests + 1;
+		questToolTip = questToolTip .. "[NEWLINE]" .. kQuest.Callout .. kQuest.Name;
+	end
+	kInst.QuestIcon:SetHide(numQuests <= 0);
+	kInst.QuestIcon:SetToolTipString(questToolTip);
+
+	RealizeEnvoyToken( kCityState.Tokens, kInst.EnvoyCount);
+	kInst.EnvoyLessButton:SetDisabled( true );
+	kInst.EnvoyLessButton:SetHide( m_mode ~= MODE.SendEnvoys );
+	kInst.EnvoyMoreButton:SetHide( m_mode ~= MODE.SendEnvoys );
+	kInst.EnvoyLessButton:SetVoid1( kCityState.iPlayer );
+	kInst.EnvoyMoreButton:SetVoid1( kCityState.iPlayer );
+	kInst.EnvoyLessButton:RegisterCallback( Mouse.eLClick, OnLessEnvoyTokens );
+	kInst.EnvoyMoreButton:RegisterCallback( Mouse.eLClick, OnMoreEnvoyTokens );
+
+	-- Get small icons
+	textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 26 );
+
+	kInst.BonusImage1:SetTexture( kCityState.isBonus1 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
+	kInst.BonusImage1:SetToolTipString( kCityState.Bonuses[1].Title .."[NEWLINE]".. kCityState.Bonuses[1].Details );
+
+	kInst.BonusIcon1:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+	kInst.BonusIcon1:SetColor( kCityState.isBonus1 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.BonusText1:SetColor( kCityState.isBonus1 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
+	kInst.BonusImage3:SetTexture( kCityState.isBonus3 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
+	kInst.BonusImage3:SetToolTipString( kCityState.Bonuses[3].Title .."[NEWLINE]".. kCityState.Bonuses[3].Details );
+	kInst.BonusIcon3:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+	kInst.BonusIcon3:SetColor( kCityState.isBonus3 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.BonusText3:SetColor( kCityState.isBonus3 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
+	kInst.BonusImage6:SetTexture( kCityState.isBonus6 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
+	kInst.BonusImage6:SetToolTipString( kCityState.Bonuses[6].Title .."[NEWLINE]".. kCityState.Bonuses[6].Details );
+	kInst.BonusIcon6:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+	kInst.BonusIcon6:SetColor( kCityState.isBonus6 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.BonusText6:SetColor( kCityState.isBonus6 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
+	kInst.BonusImageSuzerainOff:SetHide( kCityState.isBonusSuzerain );
+	kInst.BonusImageSuzerainOff:SetColor( COLOR_ICON_BONUS_OFF );
+	kInst.BonusImageSuzerainOn:SetHide( not kCityState.isBonusSuzerain );
+	kInst.BonusImageSuzerainOn:SetColor( COLOR_ICON_BONUS_ON );
+	kInst.BonusImageSuzerainOff:SetToolTipString( kCityState.Bonuses["Suzerain"].Title .."[NEWLINE]".. kCityState.Bonuses["Suzerain"].Details );
+	kInst.BonusImageSuzerainOn:SetToolTipString( kCityState.Bonuses["Suzerain"].Title .."[NEWLINE]".. kCityState.Bonuses["Suzerain"].Details );
+	kInst.BonusIconSuzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.BonusTextSuzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_TEXT_BONUS_OFF );
+	kInst.BonusTextSuzerain:SetText( kCityState.SuzerainTokensNeeded );
+	kInst.SuzerainLabel:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.Suzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.Suzerain:SetText( kCityState.SuzerainName );
+
+	kInst.LookAtButton:SetVoid1( kCityState.iPlayer );
+	kInst.LookAtButton:RegisterCallback( Mouse.eLClick, LookAtCityState );
+
+	kInst.Icon:SetIcon( "ICON_"..kCityState.CivType );
+	kInst.Icon:SetToolTipString( Locale.Lookup( GetTypeTooltip(kCityState) ));
+	kInst.Icon:SetColor( kCityState.ColorSecondary );
+	kInst.Button:RegisterCallback( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
+
+	return kInst;
+end
+
+-- ===========================================================================
+--	View a list of all the City States that are alive and have been met.
+-- ===========================================================================
+function ViewList()
+
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+
+	if (m_kPlayerData == nil or m_kPlayerData.EnvoyTokens == nil) then
+		return;
+	end
+
+	-- Last minute switch; if there are envoy tokens left and at least one City-State has
+	-- been met, then allow player to change the # of envoys sent.
+	local numMet:number = GetCityStatesMetNum();
+	if m_kPlayerData.EnvoyTokens > 0 and numMet > 0 then
+		m_mode = MODE.SendEnvoys;
+	else
+		m_mode = MODE.Overview;
+	end
+	Controls.NoneMet:SetHide( numMet > 0 );
+
+	Controls.ListOfCityStates:SetHide( false );
+	Controls.SingleCityState:SetHide( true );
+	RealizeListHeader( m_kPlayerData.EnvoyTokens );
+
+	-- Top list
+	m_CityStateRowIM:ResetInstances();
+	m_uiCityStateRows = {};
+	for iPlayer, kCityState in pairs( m_kCityStates ) do
+		if kCityState.isHasMet then
+			local kInst :table = AddCityStateRow( kCityState );
+			m_uiCityStateRows[iPlayer] = kInst;
+		end
+	end
+
+	if m_mode == MODE.SendEnvoys then
+		Controls.BonusArea:SetHide( false );
+
+		-- Looping again, adding bonuses.
+		m_BonusCityHeaderIM:ResetInstances();
+		m_BonusItemIM:ResetInstances();
+		for iPlayer, kCityState in pairs( m_kCityStates ) do
+
+			-- At least the simplest of bonuses?
+			if kCityState.isBonus1 then
+				local kHeader	:table = m_BonusCityHeaderIM:GetInstance();
+				kHeader.CityName:SetText( Locale.ToUpper(  kCityState.Name ) );
+
+				local kItem		:table = m_BonusItemIM:GetInstance();
+				local textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 50 );
+				kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+				kItem.Icon:SetColor( kCityState.ColorSecondary );
+				kItem.Title:SetColor( kCityState.ColorSecondary );
+				kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Title );
+				kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Details );
+
+				if kCityState.isBonus3 then
+					kItem		= m_BonusItemIM:GetInstance();
+					kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
+					kItem.Icon:SetColor( kCityState.ColorSecondary );
+					kItem.Title:SetColor( kCityState.ColorSecondary );
+					kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Title );
+					kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Details );
+				end
+
+				if kCityState.isBonus6 then
+					kItem		= m_BonusItemIM:GetInstance();
+					kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
+					kItem.Icon:SetColor( kCityState.ColorSecondary );
+					kItem.Title:SetColor( kCityState.ColorSecondary );
+					kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Title );
+					kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Details );
+				end
+
+				if kCityState.isBonusSuzerain then
+					kItem		= m_BonusItemIM:GetInstance();
+					textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas("ICON_ENVOY_BONUS_SUZERAIN", 50);
+					kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+					kItem.Icon:SetColor( kCityState.ColorSecondary );
+					kItem.Title:SetColor( kCityState.ColorSecondary );
+					TruncateStringWithTooltip(kItem.Title, MAX_BEFORE_TRUNC_SUZERAIN, Locale.Lookup(kCityState.Bonuses["Suzerain"].Title));
+					kItem.Details:SetText( kCityState.Bonuses["Suzerain"].Details );
+					local PADDING:number = 40;
+					kItem.Top:SetSizeY( kItem.Details:GetSizeY() + PADDING );
+				end
+
+			end
+		end
+
+		Controls.BonusStack:CalculateSize();
+		Controls.BonusScroll:CalculateSize();
+		Controls.BonusArea:ReprocessAnchoring();
+
+		local bonusAreaY:number = Controls.BonusArea:GetSizeY();
+		Controls.CityStateScroll:SetSizeY( m_height - (264 + bonusAreaY ) );
+
+	else
+		Controls.BonusArea:SetHide( true );
+		Controls.CityStateScroll:SetSizeY( m_height - 210 );
+	end
+
+	Controls.ConfirmFrame:SetHide( m_mode ~= MODE.SendEnvoys );
+	Controls.ConfirmButton:SetDisabled( true );
+
+	Controls.CityStateStack:CalculateSize();
+	Controls.CityStateScroll:CalculateSize();
+
+	RealizeEnvoyChangeButtons();
+end
+
+
+-- ===========================================================================
+function ColorizeBonusItem( isHaveBonus:boolean, pInst:table, kCityState:table)
+	pInst.Check:SetHide( not isHaveBonus );
+	if isHaveBonus then
+		pInst.Icon:SetColor( kCityState.ColorSecondary );
+		pInst.Title:SetColor( kCityState.ColorSecondary );
+		pInst.Details:SetColorByName("CityStateCS");
+	else
+		pInst.Icon:SetColorByName("CityStateDisabledCS");
+		pInst.Title:SetColorByName("CityStateDisabledCS");
+		pInst.Details:SetColorByName("CityStateDisabledCS");
+	end
+end
+
+-- ===========================================================================
+--	View detailed information for a single City State
+-- ===========================================================================
+function ViewCityState( iPlayer:number )
+
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+
+	-- Create a column of City-States on the left side so a player can click
+	-- and instantly view them.
+	m_CityStateColumnIM:ResetInstances();
+	m_uiCityStateRows = {};
+	for _, kCityState in pairs( m_kCityStates ) do
+		if kCityState.isHasMet then
+			local kInst :table = m_CityStateColumnIM:GetInstance();
+			kInst.Icon:SetIcon( "ICON_"..kCityState.CivType );
+			kInst.Icon:SetColor( kCityState.ColorSecondary );
+			kInst.Icon:SetToolTipString( Locale.Lookup(kCityState.Name) );
+
+			kInst.IconButton:SetColor( kCityState.ColorPrimary );
+			kInst.IconButton:SetVoid1( kCityState.iPlayer );
+			kInst.IconButton:RegisterCallback( Mouse.eLClick, OpenSingleViewCityState );
+
+			textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
+			kInst.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+			kInst.DiplomacyPip:SetToolTipString(tooltip);
+		end
+	end
+	Controls.CityStateIconStack:CalculateSize();
+
+	-- Grab city state, and then sanity check.  (We did have an error where a liberated city wasn't updated in the
+	-- cache and so if a player clicked the banner it would immediately bail.)
+	local kCityState:table= m_kCityStates[iPlayer];
+	if kCityState == nil then
+		UI.DataError("Attempt to show details for CityState player #"..tostring(iPlayer)..", but that doesn't exist!");
+
+		-- Best attempt to salvage error is to show the list view.
+		m_mode = MODE.Overview;
+		ViewList();
+		return;
+	end
+
+	Controls.ListOfCityStates:SetHide( true);
+	Controls.SingleCityState:SetHide( false );
+
+	Controls.CityStateTypeIcon:SetIcon("ICON_"..kCityState.CivType);
+	Controls.CityStateTypeIcon:SetColor( kCityState.ColorSecondary );
+	Controls.CityStateTypeIcon:SetToolTipString( Locale.Lookup( GetTypeTooltip(kCityState) ));
+	Controls.CityStateName:SetText( Locale.ToUpper(kCityState.Name) );
+
+	local textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
+	Controls.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+	Controls.DiplomacyPip:SetToolTipString(tooltip);
+
+	local warPeaceTooltip:string = "";
+	if kCityState.isAtWar then
+		Controls.PeaceWarButton:SetText( Locale.Lookup("LOC_CITY_STATES_MAKE_PEACE") );
+		Controls.PeaceWarButton:SetDisabled( not kCityState.CanMakePeaceWith );
+		if not kCityState.CanMakePeaceWith then
+			warPeaceTooltip = warPeaceTooltip .. Locale.Lookup("LOC_CITY_STATES_TURNS_WAR", m_iTurnsOfWar + kCityState.iTurnChanged - Game.GetCurrentGameTurn() );
+		end
+	else
+		Controls.PeaceWarButton:SetText( Locale.Lookup("LOC_CITY_STATES_DECLARE_WAR_BUTTON") );
+		Controls.PeaceWarButton:SetDisabled( not kCityState.CanDeclareWarOn );
+		warPeaceTooltip = warPeaceTooltip .. Locale.Lookup("LOC_CITY_STATES_DECLARE_WAR_DETAILS");
+		if not kCityState.CanDeclareWarOn then
+			warPeaceTooltip = warPeaceTooltip .. " " .. Locale.Lookup("LOC_CITY_STATES_TURNS_PEACE", m_iTurnsOfPeace + kCityState.iTurnChanged - Game.GetCurrentGameTurn() );
+		end
+	end
+	Controls.PeaceWarButton:SetToolTipString( warPeaceTooltip );
+	Controls.PeaceWarButton:RegisterCallback( Mouse.eLClick, function() OnChangeWarPeaceStatus( kCityState ); end );
+
+	Controls.LevyMilitaryButton:SetDisabled(not kCityState.CanLevyMilitary);
+	if kCityState.HasLevyActive and kCityState.IsLocalPlayerSuzerain then
+		local levyTooltip = Locale.Lookup("LOC_CITY_STATES_MILITARY_ALREADY_LEVIED");
+		Controls.LevyMilitaryButton:SetToolTipString(levyTooltip);
+	else
+		local levyTooltip = Locale.Lookup("LOC_CITY_STATES_LEVY_MILITARY_DETAILS", kCityState.LevyMilitaryCost, kCityState.LevyMilitaryTurnLimit);
+		Controls.LevyMilitaryButton:SetToolTipString(levyTooltip);
+	end
+	Controls.LevyMilitaryButton:RegisterCallback( Mouse.eLClick, function() OnLevyMilitary( kCityState ); end );
+
+	Controls.TypeValue:SetText( GetTypeName(kCityState) );
+	Controls.PatronValue:SetText( kCityState.SuzerainName );
+	Controls.InfluencedByValue:SetText( Locale.Lookup("LOC_CITY_STATES_CIVILIZATIONS",table.count(kCityState.Influence)) );
+	Controls.EnvoysSentValue:SetText( tostring(kCityState.Tokens) );
+	Controls.QuestsValue:SetText( tostring(table.count(kCityState.Quests)) );
+
+	if m_mode == MODE.EnvoySent then
+		-- Setup the buttons and what (sub) areas are shown/hidden.
+		Controls.EnvoysSentButton:SetSelected( true );
+		Controls.InfluencedByButton:SetSelected( false );
+		Controls.QuestsButton:SetSelected( false );
+
+		Controls.EnvoysSentArea:SetHide( false );
+		Controls.InfluenceArea:SetHide( true );
+		Controls.QuestsArea:SetHide( true );
+
+		Controls.EnvoysSentValue2:SetText( tostring(kCityState.Tokens) );
+
+		m_EnvoysBonusCityHeaderIM:ResetInstances();
+		m_EnvoysBonusItemIM:ResetInstances();
+
+		local kHeader	:table = m_EnvoysBonusCityHeaderIM:GetInstance();
+		kHeader.CityName:SetText( Locale.ToUpper( Locale.Lookup("LOC_CITY_STATES_BONUSES",kCityState.Name)) );
+
+		-- At least the simplest of bonuses?
+		local kItem		:table = m_EnvoysBonusItemIM:GetInstance();
+		local textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 50 );
+		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+		kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Title );
+		kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Details );
+		ColorizeBonusItem( kCityState.isBonus1, kItem, kCityState );
+
+		kItem		= m_EnvoysBonusItemIM:GetInstance();
+		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
+		kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Title );
+		kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Details );
+		ColorizeBonusItem( kCityState.isBonus3, kItem, kCityState );
+
+		kItem		= m_EnvoysBonusItemIM:GetInstance();
+		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
+		kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Title );
+		kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Details );
+		ColorizeBonusItem( kCityState.isBonus6, kItem, kCityState );
+
+		kItem		= m_EnvoysBonusItemIM:GetInstance();
+		textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas("ICON_ENVOY_BONUS_SUZERAIN", 50);
+		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+		TruncateStringWithTooltip(kItem.Title, MAX_BEFORE_TRUNC_SUZERAIN, Locale.Lookup(kCityState.Bonuses["Suzerain"].Title));
+		kItem.Details:SetText( kCityState.Bonuses["Suzerain"].Details );
+
+		local PADDING:number = 40;
+		kItem.Top:SetSizeY( kItem.Details:GetSizeY() + PADDING );
+
+		Controls.EnvoysBonusStack:CalculateSize();
+		Controls.EnvoysBonusScroll:CalculateSize();
+
+		ColorizeBonusItem( kCityState.isBonusSuzerain, kItem, kCityState );
+
+	elseif m_mode == MODE.InfluencedBy then
+		-- Setup the buttons and what (sub) areas are shown/hidden.
+		Controls.EnvoysSentButton:SetSelected( false );
+		Controls.InfluencedByButton:SetSelected( true );
+		Controls.QuestsButton:SetSelected( false );
+
+		Controls.EnvoysSentArea:SetHide( true );
+		Controls.InfluenceArea:SetHide( false );
+		Controls.QuestsArea:SetHide( true );
+
+		m_InfluenceRowIM:ResetInstances();
+
+		-- First determine the large # of envoy tokens given for influence so
+		-- there can be a max for the ratio to set the bar.
+		local largestAmount:number = 0;
+		for iOtherPlayer,influence in pairs(kCityState.Influence) do
+			if influence > largestAmount then
+				largestAmount = influence;
+			end
+		end
+
+		-- Ensure highest influenced civilizations are at the top of the list
+		local kSortTable:table = {};
+		function SortHighestFirst(a, b)
+			local aOrder = kSortTable[ tostring( a ) ];
+			local bOrder = kSortTable[ tostring( b ) ];
+			if aOrder == nil then return false; end
+			if bOrder == nil then return true; end
+			return aOrder.influence > bOrder.influence;
+		end
+
+		-- Generate the information for each City-State
+		for iOtherPlayer,influence in pairs(kCityState.Influence) do
+			local kItem			:table	= m_InfluenceRowIM:GetInstance();
+			local pLocalPlayer	:table	= Players[localPlayerID];
+			local civName		:string = "LOCAL_CITY_STATES_UNKNOWN";
+			if (pLocalPlayer ~= nil) then
+				local pPlayerConfig :table = PlayerConfigurations[iOtherPlayer];
+				if (localPlayerID == iOtherPlayer) then
+					civName = Locale.Lookup(pPlayerConfig:GetPlayerName()) .. " (" .. Locale.Lookup("LOC_CITY_STATES_YOU") .. ")";
+				elseif (pLocalPlayer:GetDiplomacy():HasMet(iOtherPlayer)) then
+					civName = pPlayerConfig:GetPlayerName();
+				end
+			end
+			kItem.CityName:SetText( Locale.ToUpper(civName) );
+			kItem.AmountBar:SetPercent( influence / largestAmount);
+			kItem.Amount:SetText( tostring(influence) );
+			kSortTable[ tostring(kItem.GetTopControl()) ] = { influence = influence };	-- Store for sorting.
+		end
+		Controls.InfluenceStack:SortChildren( SortHighestFirst )
+
+	elseif m_mode == MODE.Quests then
+		-- Setup the buttons and what (sub) areas are shown/hidden.
+		Controls.EnvoysSentButton:SetSelected( false );
+		Controls.InfluencedByButton:SetSelected( false );
+		Controls.QuestsButton:SetSelected( true );
+
+		Controls.EnvoysSentArea:SetHide( true );
+		Controls.InfluenceArea:SetHide( true );
+		Controls.QuestsArea:SetHide( false );
+
+		m_QuestsIM:ResetInstances();
+		for _,kQuest in pairs( kCityState.Quests ) do
+			local kItem:table = m_QuestsIM:GetInstance();
+			kItem.Title:SetString( kQuest.Name );
+			kItem.Description:SetString( kQuest.Description );
+			kItem.Reward:SetString( kQuest.Reward );
+			kItem.Callout:SetString( kQuest.Callout );
+		end
+
+		Controls.QuestsStack:CalculateSize();
+		Controls.QuestsScroll:CalculateSize();
+
+	else
+		UI.DataError("City-States in an unhandled mode '"..tostring(m_mode).."' when attempting to view a single City-State.");
+		return;
+	end
+
+	Controls.SingleViewStack:CalculateSize();
+end
+
+
+-- ===========================================================================
+--	Obtain data on city states
+-- ===========================================================================
+function GetData()
+
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+
+	m_kCityStates = {};		-- Clear any previous data
+	m_kPlayerData = {};
+	m_kEnvoyChanges = {};
+
+	-- Collect information about current player
+	local pLocalPlayer			:table = Players[localPlayerID];
+	local isCanGiveInfluence	:boolean = false;
+	local pLocalPlayerInfluence	:table = pLocalPlayer:GetInfluence();
+	local envoyTokensAvailable	:number = 0;
+	if pLocalPlayerInfluence ~= nil then
+		envoyTokensAvailable = pLocalPlayerInfluence:GetTokensToGive();
+		if pLocalPlayerInfluence:CanGiveInfluence() and envoyTokensAvailable > 0 then
+			isCanGiveInfluence = true;
+		end
+	end
+
+	-- Build player specific data for interacting with CityStates
+	m_kPlayerData = {
+		EnvoyTokens = envoyTokensAvailable
+	}
+
+	local isNewBonusAchieved:boolean = false;
+
+	-- Every player that is in this game...
+	for i, pPlayer in ipairs(PlayerManager.GetAliveMinors()) do
+		local iPlayer = pPlayer:GetID();
+		local isCanReceiveInfluence		:boolean= false;
+		local envoyTokens				:number	= 0;
+		local envoyTokensMostReceived	:number	= 0;
+		local kInfluence				:table	= {};
+		local suzerainID				:number	= -1;
+		local pPlayerInfluence			:table	= pPlayer:GetInfluence();
+		if pPlayerInfluence ~= nil then
+			isCanReceiveInfluence	= pPlayerInfluence:CanReceiveInfluence();
+			envoyTokens				= pPlayerInfluence:GetTokensReceived(pLocalPlayer:GetID());
+			envoyTokensMostReceived = pPlayerInfluence:GetMostTokensReceived();
+			suzerainID				= pPlayerInfluence:GetSuzerain();
+
+			-- Take this CityState and compare against others to determine influence information.
+			for _, iInfluencePlayer in ipairs(PlayerManager.GetAliveMajorIDs()) do
+				local tokensReceived :number = pPlayerInfluence:GetTokensReceived( iInfluencePlayer );
+				if tokensReceived > 0 then
+					kInfluence[iInfluencePlayer] = tokensReceived;
+				end
+			end
+
+		end
+
+		-- For all players (other than ourselves) and can receive influence (only CityStates)...
+		if iPlayer ~= pLocalPlayer:GetID() and isCanReceiveInfluence then
+			local primaryColor, secondaryColor = UI.GetPlayerColors( iPlayer );
+
+			local suzerainName:string = Locale.Lookup("LOC_CITY_STATES_NONE");
+			if suzerainID ~=-1 then
+				if (suzerainID == localPlayerID) then
+					local pPlayerConfig :table = PlayerConfigurations[suzerainID];
+					suzerainName = Locale.Lookup("LOC_CITY_STATES_YOU");
+				elseif pLocalPlayer:GetDiplomacy():HasMet(suzerainID) then
+					local pPlayerConfig :table = PlayerConfigurations[suzerainID];
+					suzerainName = Locale.Lookup(pPlayerConfig:GetPlayerName());
+				else
+					suzerainName = Locale.Lookup("LOCAL_CITY_STATES_UNKNOWN");
+				end
+			end
+
+			local cityStateType	:string = "";
+			local leader		:string = PlayerConfigurations[ iPlayer ]:GetLeaderTypeName();
+			local leaderInfo	:table	= GameInfo.Leaders[leader];
+			if leaderInfo == nil or leaderInfo.InheritFrom == nil then
+				UI.DataError("Cannot determine leader type for player #"..tostring( iPlayer ));
+				cityStateType = "unknown";
+			elseif (leader == "LEADER_MINOR_CIV_SCIENTIFIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_SCIENTIFIC") then
+				cityStateType = "SCIENTIFIC";
+			elseif (leader == "LEADER_MINOR_CIV_RELIGIOUS" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_RELIGIOUS") then
+				cityStateType = "RELIGIOUS";
+			elseif (leader == "LEADER_MINOR_CIV_TRADE" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_TRADE") then
+				cityStateType = "TRADE";
+			elseif (leader == "LEADER_MINOR_CIV_CULTURAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_CULTURAL") then
+				cityStateType = "CULTURE";
+			elseif (leader == "LEADER_MINOR_CIV_MILITARISTIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_MILITARISTIC") then
+				cityStateType = "MILITARISTIC";
+			elseif (leader == "LEADER_MINOR_CIV_INDUSTRIAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_INDUSTRIAL") then
+				cityStateType = "INDUSTRIAL";
+			end
+
+			local leader	:string = PlayerConfigurations[iPlayer]:GetLeaderTypeName();
+			local civType	:string = GameInfo.CivilizationLeaders[leader].CivilizationType;
+
+			local iPlayerDiploState :number = pPlayer:GetDiplomaticAI():GetDiplomaticStateIndex( localPlayerID );
+			local diplomaticState	:string = nil;
+			if iPlayerDiploState ~= -1 then
+				diplomaticState = GameInfo.DiplomaticStates[iPlayerDiploState].StateType;
+			end
+
+
+			local kCityState :table		= {
+				iPlayer					= pPlayer:GetID(),
+				Bonuses					= {},
+				CanDeclareWarOn			= pLocalPlayer:GetDiplomacy():CanDeclareWarOn( iPlayer ),
+				CanLevyMilitary			= pLocalPlayer:GetInfluence():CanLevyMilitary( iPlayer ),
+				CanMakePeaceWith		= pLocalPlayer:GetDiplomacy():CanMakePeaceWith( iPlayer ),
+				CanReceiveTokensFrom	= pLocalPlayer:GetInfluence():CanGiveTokensToPlayer( iPlayer ),
+				ColorPrimary			= primaryColor,
+				ColorSecondary			= secondaryColor,
+				CivType					= civType,
+				DiplomaticState			= diplomaticState,
+				Government				= pPlayer:GetCulture():GetCurrentGovernment(),
+				Influence				= kInfluence,
+				Name					= PlayerConfigurations[iPlayer]:GetCivilizationShortDescription(),
+				isAlive					= pPlayer:IsAlive(),
+				isAtWar					= pLocalPlayer:GetDiplomacy():IsAtWarWith( iPlayer ),
+				isBonus1				= (envoyTokens >= NUM_ENVOY_TOKENS_FOR_FIRST_BONUS),	-- WARNING: Inferring game rules to set bonus thresholds.
+				isBonus3				= (envoyTokens >= NUM_ENVOY_TOKENS_FOR_SECOND_BONUS),	-- WARNING: Inferring game rules to set bonus thresholds.
+				isBonus6				= (envoyTokens >= NUM_ENVOY_TOKENS_FOR_THIRD_BONUS),	-- WARNING: Inferring game rules to set bonus thresholds.
+				isBonusSuzerain			= (suzerainID == localPlayerID),
+				isHasMet				= pLocalPlayer:GetDiplomacy():HasMet( iPlayer ),
+				iScore					= pPlayer:GetDiplomaticAI():GetDiplomaticScore( localPlayerID ),
+				iState					= iPlayerDiploState,
+				iTurnChanged			= pLocalPlayer:GetDiplomacy():GetAtWarChangeTurn( iPlayer ),
+				iVisibility				= pLocalPlayer:GetDiplomacy():GetVisibilityOn( iPlayer ),
+				iGameScore				= pPlayer:GetScore(),
+				LevyMilitaryCost		= pLocalPlayer:GetInfluence():GetLevyMilitaryCost( iPlayer ),
+				LevyMilitaryTurnLimit	= pPlayer:GetInfluence():GetLevyTurnLimit(),
+				HasLevyActive			= (pPlayer:GetInfluence():GetLevyTurnCounter() >= 0),
+				IsLocalPlayerSuzerain	= (pLocalPlayer:GetID() == suzerainID),
+				Quests					= GetQuests( iPlayer ),
+				SuzerainID				= suzerainID,
+				SuzerainName			= suzerainName,
+				SuzerainTokensNeeded	= envoyTokensMostReceived,
+				Tokens					= envoyTokens,
+				TokensMostReceived		= envoyTokensMostReceived,
+				Type					= cityStateType,
+			};
+
+			-- Make and changes to tokens needed based on range and who (if anyone) is Suzerain
+			if kCityState.SuzerainTokensNeeded < MIN_ENVOY_TOKENS_SUZERAIN then
+				kCityState.SuzerainTokensNeeded = MIN_ENVOY_TOKENS_SUZERAIN
+			elseif not kCityState.isBonusSuzerain then
+				kCityState.SuzerainTokensNeeded = kCityState.SuzerainTokensNeeded + 1;
+			end
+
+			-- Obtain bonus text:
+			local title:string, details:string = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_FIRST_BONUS );
+			kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_FIRST_BONUS ] = { Title = title, Details = details }
+			if kCityState.isBonus1 then
+				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus1 then
+					isNewBonusAchieved = true;
+				end
+			end
+			title, details = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_SECOND_BONUS );
+			kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_SECOND_BONUS ] = { Title = title, Details = details }
+			if kCityState.isBonus3 then
+				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus3 then
+					isNewBonusAchieved = true;
+				end
+			end
+			title, details = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_THIRD_BONUS );
+			kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_THIRD_BONUS ] = { Title = title, Details = details }
+			if kCityState.isBonus6 then
+				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus6 then
+					isNewBonusAchieved = true;
+				end
+			end
+			details = GetSuzerainBonusText( iPlayer );
+			kCityState.Bonuses["Suzerain"] = {
+				Title = Locale.Lookup("LOC_CITY_STATES_SUZERAIN_ENVOYS"),
+				Details = details
+				}
+			if kCityState.isBonusSuzerain then
+				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonusSuzerain then
+					isNewBonusAchieved = true;
+				end
+			end
+
+			-- Save to master table
+			m_kCityStates[iPlayer] = kCityState;
+		end
+	end
+
+	-- Play sound if any city state just achieved a bonus.
+	if isNewBonusAchieved then
+		UI.PlaySound("Receive_Envoy_Bonus");
+	end
+
+	-- Clear previous cached city states items and store currect.
+	m_kLastCityStates = nil;
+end
+
+
+-- ===========================================================================
+--	UI EVENT
+-- ===========================================================================
+function OnInputHandler( input:table )
+	--if m_mode == MODE.EnvoySent or m_mode == MODE.InfluencedBy or m_mode == MODE.Quests then
+	return m_kScreenSlideAnim.OnInputHandler( input );
+end
+
+-- ===========================================================================
+--	UI EVENT
+-- ===========================================================================
+function OnInit(isReload:boolean)
+	if isReload then
+		LuaEvents.GameDebug_GetValues(RELOAD_CACHE_ID);
+	end
+end
+
+-- ===========================================================================
+--	UI EVENT
+-- ===========================================================================
+function OnShutdown()
+	LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "isHidden", ContextPtr:IsHidden());
+	LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "m_mode", m_mode);
+	LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "m_iCurrentCityState", m_iCurrentCityState);
+end
+
+-- ===========================================================================
+--	LUA EVENT
+--	Reload support
+-- ===========================================================================
+function OnGameDebugReturn(context:string, contextTable:table)
+	if context == RELOAD_CACHE_ID then
+		if contextTable["m_mode"] ~= nil				then m_mode = contextTable["m_mode"]; end
+		if contextTable["m_iCurrentCityState"] ~= nil	then m_iCurrentCityState = contextTable["m_iCurrentCityState"]; end
+		if contextTable["isHidden"] ~= nil and not contextTable["isHidden"] then
+			if		m_mode == MODE.Overview then OpenOverview();
+			elseif	m_mode == MODE.SendEnvoys then OnOpenSendEnvoys();
+			elseif	m_mode == MODE.EnvoySent or m_mode == MODE.InfluencedBy or m_mode == MODE.Quests then
+				m_kScreenSlideAnim.Show();
+				Refresh();
+			end
+		end
+	end
+end
+
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnCityLiberated(playerID:number, cityID:number)
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+	Refresh();
+end
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnDiplomacyDeclareWar(firstPlayerID, secondPlayerID)
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID ~= nil) then
+		if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
+			m_kEnvoyChanges = {}; -- Zero out any pending envoy choices
+		end
+	end
+	Refresh();
+end
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnDiplomacyMakePeace(firstPlayerID, secondPlayerID)
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID ~= nil) then
+		if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
+			m_kEnvoyChanges = {}; -- Zero out any pending envoy choices
+		end
+	end
+	Refresh();
+end
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnInfluenceChanged()
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+	Refresh();
+end
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnInfluenceGiven()
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+	Refresh();
+end
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
+	if eNewMode == InterfaceModeTypes.VIEW_MODAL_LENS then
+		Close();
+	end
+end
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnQuestChanged()
+	local localPlayerID = Game.GetLocalPlayer();
+	if (localPlayerID == -1) then
+		return;
+	end
+	Refresh();
+end
+
+-- ===========================================================================
+--	Game Event
+-- ===========================================================================
+function OnUpdateUI( type:number, tag:string, iData1:number, iData2:number, strData1:string)
+	m_kScreenSlideAnim.OnUpdateUI( type, tag, iData1, iData2, strData1 );
+	if type == SystemUpdateUI.ScreenResize then
+		Resize();
+	end
+end
+
+-- ===========================================================================
+function Resize()
+	_, m_height = UIManager:GetScreenSizeVal();
+
+	local subMenuY:number = Controls.SubMenu:GetSizeY();
+
+	Controls.EnvoysSentArea:SetSizeY( m_height - (360+subMenuY) );
+	Controls.InfluenceArea:SetSizeY( m_height - (360+subMenuY));
+	Controls.QuestsArea:SetSizeY( m_height - (360+subMenuY));
+
+	Controls.EnvoysBonusScroll:SetSizeY( m_height - (424+subMenuY));
+	Controls.InfluenceScroll:SetSizeY( m_height - (424+subMenuY));
+	Controls.QuestsScroll:SetSizeY( m_height - (424+subMenuY));
+end
+
+-- ===========================================================================
+--	Player Turn Events
+-- ===========================================================================
+function OnLocalPlayerTurnBegin()
+	m_isLocalPlayerTurn = true;
+	if not ContextPtr:IsHidden() then
+		Refresh();
+	end
+end
+function OnLocalPlayerTurnEnd()
+	m_isLocalPlayerTurn = false;
+	if not ContextPtr:IsHidden() then
+		Refresh();
+	end
+end
+
+-- ===========================================================================
+--	Initialize
+-- ===========================================================================
+function Initialize()
+
+	-- Check:
+	if	NUM_ENVOY_TOKENS_FOR_FIRST_BONUS   == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS or
+		NUM_ENVOY_TOKENS_FOR_SECOND_BONUS  == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS	or
+		NUM_ENVOY_TOKENS_FOR_FIRST_BONUS   == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then
+		alert("At least 2 city state bonuses have the same value, this will cause issues!");
+	end
+
+	m_kScreenSlideAnim = CreateScreenAnimation( Controls.SlideAnim );
+
+	-- UI Callbacks
+	Controls.CloseListButton:RegisterCallback( Mouse.eLClick, OnClose );
+	Controls.CloseBackButton:RegisterCallback( Mouse.eLClick, OnBackClose );
+	Controls.Title:SetText(Locale.ToUpper(Locale.Lookup("LOC_CITY_STATES_TITLE")));
+	Controls.ConfirmButton:RegisterCallback( Mouse.eLClick, OnConfirmPlacement );
+	Controls.EnvoysSentButton:RegisterCallback( Mouse.eLClick, OnEnvoySentClick );
+	Controls.InfluencedByButton:RegisterCallback( Mouse.eLClick, OnInfluencedByClick );
+	Controls.QuestsButton:RegisterCallback( Mouse.eLClick, OnQuestsClick );
+
+	-- UI Events
+	ContextPtr:SetInitHandler( OnInit );
+	ContextPtr:SetInputHandler(OnInputHandler, true);
+	ContextPtr:SetShutdown( OnShutdown );
+
+	-- Game Events
+	Events.CityLiberated.Add( OnCityLiberated );
+	Events.DiplomacyDeclareWar.Add( OnDiplomacyDeclareWar );
+	Events.DiplomacyMakePeace.Add( OnDiplomacyMakePeace );
+	Events.InfluenceChanged.Add( OnInfluenceChanged );
+	Events.InfluenceGiven.Add( OnInfluenceGiven );
+	Events.InterfaceModeChanged.Add( OnInterfaceModeChanged );
+	Events.QuestChanged.Add( OnQuestChanged );
+	Events.SystemUpdateUI.Add( OnUpdateUI );
+	Events.LocalPlayerTurnBegin.Add(OnLocalPlayerTurnBegin);
+	Events.LocalPlayerTurnEnd.Add(OnLocalPlayerTurnEnd);
+	Events.LocalPlayerChanged.Add(OnClose);
+
+	-- LUA Events
+	LuaEvents.CityBannerManager_RaiseMinorCivPanel.Add( OnRaiseMinorCivicsPanel );
+	LuaEvents.GameDebug_Return.Add( OnGameDebugReturn );
+	LuaEvents.NotificationPanel_OpenCityStatesSendEnvoys.Add( OnOpenSendEnvoys );
+	LuaEvents.PartialScreenHooks_OpenCityStates.Add( OnOpenCityStates );
+	LuaEvents.PartialScreenHooks_CloseCityStates.Add( OnCloseCityStates );
+	LuaEvents.PartialScreenHooks_CloseAllExcept.Add( OnCloseAllExcept );
+	LuaEvents.WorldRankings_CloseCityStates.Add( OnClose );
+
+	Resize();
+	m_mode = MODE.Overview;
+end
+Initialize();

--- a/UI/PartialScreens/CityStates.lua
+++ b/UI/PartialScreens/CityStates.lua
@@ -1,9 +1,9 @@
 -- ===========================================================================
---	CityStates "Rundown" partial-screen
+--  CityStates "Rundown" partial-screen
 --
---	su·ze·rain (noun)
---	a sovereign or state having some control over another state that is
---	internally autonomous.
+--  su·ze·rain (noun)
+--  a sovereign or state having some control over another state that is
+--  internally autonomous.
 -- ===========================================================================
 
 include("AnimSidePanelSupport");
@@ -12,344 +12,344 @@ include("SupportFunctions");
 
 
 -- ===========================================================================
---	CONSTANTS
+--  CONSTANTS
 -- ===========================================================================
-local COLOR_ICON_BONUS_OFF				:number = 0xff606060;
-local COLOR_ICON_BONUS_ON				:number = 0xff999900;
-local COLOR_TEXT_BONUS_OFF				:number = 0xff606060;
-local COLOR_TEXT_BONUS_ON				:number = 0xffb0b0b0;
-local FONT_SIZE_SINGLE_DIGIT_ENVOYS		:number = 40;
-local FONT_SIZE_TWO_DIGIT_ENVOYS		:number = 26;
-local FONT_SIZE_THREE_DIGIT_ENVOYS		:number = 18;
-local MIN_ENVOY_TOKENS_SUZERAIN			:number = 3;	--TODO: expose via game core
-local NUM_ENVOY_TOKENS_FOR_FIRST_BONUS	:number = 1;
-local NUM_ENVOY_TOKENS_FOR_SECOND_BONUS	:number = 3;
-local NUM_ENVOY_TOKENS_FOR_THIRD_BONUS	:number = 6;
+local COLOR_ICON_BONUS_OFF        :number = 0xff606060;
+local COLOR_ICON_BONUS_ON        :number = 0xff999900;
+local COLOR_TEXT_BONUS_OFF        :number = 0xff606060;
+local COLOR_TEXT_BONUS_ON        :number = 0xffb0b0b0;
+local FONT_SIZE_SINGLE_DIGIT_ENVOYS    :number = 40;
+local FONT_SIZE_TWO_DIGIT_ENVOYS    :number = 26;
+local FONT_SIZE_THREE_DIGIT_ENVOYS    :number = 18;
+local MIN_ENVOY_TOKENS_SUZERAIN      :number = 3;  --TODO: expose via game core
+local NUM_ENVOY_TOKENS_FOR_FIRST_BONUS  :number = 1;
+local NUM_ENVOY_TOKENS_FOR_SECOND_BONUS  :number = 3;
+local NUM_ENVOY_TOKENS_FOR_THIRD_BONUS  :number = 6;
 local MAX_BEFORE_TRUNC_SUZERAIN:number = 310;
 local DIPLO_PIP_INFO = {};
-		DIPLO_PIP_INFO["DIPLO_STATE_PROTECTOR"]		= { IconName="ICON_RELATIONSHIP_SUZERAIN",	Tooltip="LOC_CITY_STATES_DIPLO_SUZERAIN"};
-		DIPLO_PIP_INFO["DIPLO_STATE_PATRON"]		= { IconName="ICON_RELATIONSHIP_GOOD",		Tooltip="LOC_CITY_STATES_DIPLO_GOOD"};
-		DIPLO_PIP_INFO["DIPLO_STATE_AWARE"]			= { IconName="ICON_RELATIONSHIP_NEUTRAL",	Tooltip="LOC_CITY_STATES_DIPLO_AWARE"};
-		DIPLO_PIP_INFO["DIPLO_STATE_WAR_WITH_MAJOR"]= { IconName="ICON_RELATIONSHIP_WAR",		Tooltip="LOC_CITY_STATES_DIPLO_WAR"};
-local RELOAD_CACHE_ID					:string = "CityStates"; -- Must be unique (usually the same as the file name)
+    DIPLO_PIP_INFO["DIPLO_STATE_PROTECTOR"]    = { IconName="ICON_RELATIONSHIP_SUZERAIN",  Tooltip="LOC_CITY_STATES_DIPLO_SUZERAIN"};
+    DIPLO_PIP_INFO["DIPLO_STATE_PATRON"]    = { IconName="ICON_RELATIONSHIP_GOOD",    Tooltip="LOC_CITY_STATES_DIPLO_GOOD"};
+    DIPLO_PIP_INFO["DIPLO_STATE_AWARE"]      = { IconName="ICON_RELATIONSHIP_NEUTRAL",  Tooltip="LOC_CITY_STATES_DIPLO_AWARE"};
+    DIPLO_PIP_INFO["DIPLO_STATE_WAR_WITH_MAJOR"]= { IconName="ICON_RELATIONSHIP_WAR",    Tooltip="LOC_CITY_STATES_DIPLO_WAR"};
+local RELOAD_CACHE_ID          :string = "CityStates"; -- Must be unique (usually the same as the file name)
 
-local MODE								:table = {
-	Overview	= "Overview",
-	SendEnvoys	= "SendEnvoys",
-	EnvoySent	= "EnvoySent",
-	InfluencedBy= "InfluencedBy",
-	Quests		= "Quests"
+local MODE                :table = {
+  Overview  = "Overview",
+  SendEnvoys  = "SendEnvoys",
+  EnvoySent  = "EnvoySent",
+  InfluencedBy= "InfluencedBy",
+  Quests    = "Quests"
 }
 
 
 -- ===========================================================================
---	MEMBERS
+--  MEMBERS
 -- ===========================================================================
-local m_CityStateRowIM			:table = InstanceManager:new( "CityStateRowInstance",	"CityStateBase",Controls.CityStateStack);
-local m_CityStateColumnIM		:table = InstanceManager:new( "CityStateIconInstance",	"Top",			Controls.CityStateIconStack);
-local m_BonusCityHeaderIM		:table = InstanceManager:new( "BonusCityHeaderInstance","Top",			Controls.BonusStack);
-local m_BonusItemIM				:table = InstanceManager:new( "BonusItemOnInstance",	"Top",			Controls.BonusStack);
-local m_EnvoysBonusCityHeaderIM	:table = InstanceManager:new( "BonusCityHeaderInstance","Top",			Controls.EnvoysBonusStack);
-local m_EnvoysBonusItemIM		:table = InstanceManager:new( "BonusItemOnInstance",	"Top",			Controls.EnvoysBonusStack);
-local m_InfluenceRowIM			:table = InstanceManager:new( "InfluenceRowInstance",	"Top",			Controls.InfluenceStack);
-local m_QuestsIM				:table = InstanceManager:new( "QuestInstance",			"Top",			Controls.QuestsStack);
+local m_CityStateRowIM      :table = InstanceManager:new( "CityStateRowInstance",  "CityStateBase",Controls.CityStateStack);
+local m_CityStateColumnIM    :table = InstanceManager:new( "CityStateIconInstance",  "Top",      Controls.CityStateIconStack);
+local m_BonusCityHeaderIM    :table = InstanceManager:new( "BonusCityHeaderInstance","Top",      Controls.BonusStack);
+local m_BonusItemIM        :table = InstanceManager:new( "BonusItemOnInstance",  "Top",      Controls.BonusStack);
+local m_EnvoysBonusCityHeaderIM  :table = InstanceManager:new( "BonusCityHeaderInstance","Top",      Controls.EnvoysBonusStack);
+local m_EnvoysBonusItemIM    :table = InstanceManager:new( "BonusItemOnInstance",  "Top",      Controls.EnvoysBonusStack);
+local m_InfluenceRowIM      :table = InstanceManager:new( "InfluenceRowInstance",  "Top",      Controls.InfluenceStack);
+local m_QuestsIM        :table = InstanceManager:new( "QuestInstance",      "Top",      Controls.QuestsStack);
 
-local m_kScreenSlideAnim		:table;				-- Controls overall look/feel of animation.
-local m_kCityStates				:table = {};		-- City states, key is player num of city state
-local m_kLastCityStates			:table;				-- Last set before confirming a city state change.
-local m_kPlayerData				:table = {};		-- Holds live player data that hasn't been solidifed in the game core.
-local m_kEnvoyChanges			:table = {};		-- Table (player,deltas) for envoy tokens about to be given out
-local m_uiCityStateRows			:table = {};		-- Instances holding the city state rows
-local m_mode					:string;			-- How the screen should act.
-local m_iCurrentCityState		:number= -1;		-- Player # of the city state currently active
-local m_iTurnsOfPeace			:number= tonumber(GameInfo.GlobalParameters["DIPLOMACY_PEACE_MIN_TURNS"].Value);
-local m_iTurnsOfWar				:number= tonumber(GameInfo.GlobalParameters["DIPLOMACY_WAR_MIN_TURNS"].Value);
+local m_kScreenSlideAnim    :table;        -- Controls overall look/feel of animation.
+local m_kCityStates        :table = {};    -- City states, key is player num of city state
+local m_kLastCityStates      :table;        -- Last set before confirming a city state change.
+local m_kPlayerData        :table = {};    -- Holds live player data that hasn't been solidifed in the game core.
+local m_kEnvoyChanges      :table = {};    -- Table (player,deltas) for envoy tokens about to be given out
+local m_uiCityStateRows      :table = {};    -- Instances holding the city state rows
+local m_mode          :string;      -- How the screen should act.
+local m_iCurrentCityState    :number= -1;    -- Player # of the city state currently active
+local m_iTurnsOfPeace      :number= tonumber(GameInfo.GlobalParameters["DIPLOMACY_PEACE_MIN_TURNS"].Value);
+local m_iTurnsOfWar        :number= tonumber(GameInfo.GlobalParameters["DIPLOMACY_WAR_MIN_TURNS"].Value);
 
-local m_isLocalPlayerTurn		:boolean = true;
+local m_isLocalPlayerTurn    :boolean = true;
 
 -- ===========================================================================
---	FUNCTIONS
+--  FUNCTIONS
 -- ===========================================================================
 
 function GetCityStatesMetNum()
-	local total:number = 0;
-	for _,kCityState in pairs(m_kCityStates) do
-		if kCityState.isHasMet then
-			total = total + 1;
-		end
-	end
-	return total;
+  local total:number = 0;
+  for _,kCityState in pairs(m_kCityStates) do
+    if kCityState.isHasMet then
+      total = total + 1;
+    end
+  end
+  return total;
 end
 
 
 -- ===========================================================================
---	Helper
---	iPlayerID is the city state player to move the camera to point towards.
+--  Helper
+--  iPlayerID is the city state player to move the camera to point towards.
 -- ===========================================================================
 function LookAtCityState( iPlayerID:number )
-	local pPlayer		:table = Players[iPlayerID];
-	local pPlayerCities	:table = pPlayer:GetCities();
-	if pPlayerCities:GetCount() > 1 then
-		-- Might change in the future; currently city states will just raze
-		UI.DataError("The CityState player "..tostring(iPlayerID).." has "..tostring(pPlayerCities:GetCount()).." cities, but should only have 1.");
-	end
-	for _, pCity in pPlayerCities:Members() do
-		local locX			:number = pCity:GetX();
-		local locY			:number = pCity:GetY();
-		UI.LookAtPlotScreenPosition( locX, locY, 0.33, 0.5 );
-	end
+  local pPlayer    :table = Players[iPlayerID];
+  local pPlayerCities  :table = pPlayer:GetCities();
+  if pPlayerCities:GetCount() > 1 then
+    -- Might change in the future; currently city states will just raze
+    UI.DataError("The CityState player "..tostring(iPlayerID).." has "..tostring(pPlayerCities:GetCount()).." cities, but should only have 1.");
+  end
+  for _, pCity in pPlayerCities:Members() do
+    local locX      :number = pCity:GetX();
+    local locY      :number = pCity:GetY();
+    UI.LookAtPlotScreenPosition( locX, locY, 0.33, 0.5 );
+  end
 end
 
 
 -- ===========================================================================
---	Helper
---	playerID which player to look up the bonus type for
---	envoyTokenNum	1,3,4,6 for the type of bonus to obtain
---	RETURN type of bonus, the bonus text type for a city
+--  Helper
+--  playerID which player to look up the bonus type for
+--  envoyTokenNum  1,3,4,6 for the type of bonus to obtain
+--  RETURN type of bonus, the bonus text type for a city
 -- ===========================================================================
 function GetBonusText( playerID:number, envoyTokenNum:number )
-	local leader	:string = PlayerConfigurations[playerID]:GetLeaderTypeName();
-	local leaderInfo:table	= GameInfo.Leaders[leader];
-	if leaderInfo == nil or leaderInfo.InheritFrom == nil then
-		UI.DataError("Cannot determine the type of city state bonus for player #: "..tostring(playerID) );
-		return "UNKNOWN";
-	end
+  local leader  :string = PlayerConfigurations[playerID]:GetLeaderTypeName();
+  local leaderInfo:table  = GameInfo.Leaders[leader];
+  if leaderInfo == nil or leaderInfo.InheritFrom == nil then
+    UI.DataError("Cannot determine the type of city state bonus for player #: "..tostring(playerID) );
+    return "UNKNOWN";
+  end
 
-	local bonusTypeText = "";
-	if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_SMALL_INFLUENCE_ENVOYS");
-	elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_MEDIUM_INFLUENCE_ENVOYS");
-	elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_LARGE_INFLUENCE_ENVOYS");
-	else UI.DataError("Unknown envoy number for city-state type bonus:" .. tostring(envoyTokenNum));
-	end
+  local bonusTypeText = "";
+  if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_SMALL_INFLUENCE_ENVOYS");
+  elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_MEDIUM_INFLUENCE_ENVOYS");
+  elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusTypeText = Locale.Lookup("LOC_MINOR_CIV_LARGE_INFLUENCE_ENVOYS");
+  else UI.DataError("Unknown envoy number for city-state type bonus:" .. tostring(envoyTokenNum));
+  end
 
-	local bonusDetailsText = "";
-	if (leader == "LEADER_MINOR_CIV_SCIENTIFIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_SCIENTIFIC") then
-		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_SMALL_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_MEDIUM_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_LARGE_INFLUENCE_BONUS");
-		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
-		end
-	elseif (leader == "LEADER_MINOR_CIV_RELIGIOUS" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_RELIGIOUS") then
-		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_SMALL_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_MEDIUM_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_LARGE_INFLUENCE_BONUS");
-		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
-		end
-	elseif (leader == "LEADER_MINOR_CIV_TRADE" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_TRADE") then
-		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_SMALL_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_MEDIUM_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_LARGE_INFLUENCE_BONUS");
-		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
-		end
-	elseif (leader == "LEADER_MINOR_CIV_CULTURAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_CULTURAL") then
-		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_SMALL_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_MEDIUM_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_LARGE_INFLUENCE_BONUS");
-		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
-		end
-	elseif (leader == "LEADER_MINOR_CIV_MILITARISTIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_MILITARISTIC") then
-		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_SMALL_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_MEDIUM_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_LARGE_INFLUENCE_BONUS");
-		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
-		end
-	elseif (leader == "LEADER_MINOR_CIV_INDUSTRIAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_INDUSTRIAL") then
-		if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_SMALL_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_MEDIUM_INFLUENCE_BONUS");
-		elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_LARGE_INFLUENCE_BONUS");
-		else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
-		end
-	else
-		UI.DataError("Unknown leader type for city-state type bonus");
-	end
+  local bonusDetailsText = "";
+  if (leader == "LEADER_MINOR_CIV_SCIENTIFIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_SCIENTIFIC") then
+    if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_SMALL_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_MEDIUM_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_SCIENTIFIC_TRAIT_LARGE_INFLUENCE_BONUS");
+    else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+    end
+  elseif (leader == "LEADER_MINOR_CIV_RELIGIOUS" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_RELIGIOUS") then
+    if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_SMALL_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_MEDIUM_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_RELIGIOUS_TRAIT_LARGE_INFLUENCE_BONUS");
+    else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+    end
+  elseif (leader == "LEADER_MINOR_CIV_TRADE" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_TRADE") then
+    if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_SMALL_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_MEDIUM_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_TRADE_TRAIT_LARGE_INFLUENCE_BONUS");
+    else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+    end
+  elseif (leader == "LEADER_MINOR_CIV_CULTURAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_CULTURAL") then
+    if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_SMALL_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_MEDIUM_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_CULTURAL_TRAIT_LARGE_INFLUENCE_BONUS");
+    else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+    end
+  elseif (leader == "LEADER_MINOR_CIV_MILITARISTIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_MILITARISTIC") then
+    if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_SMALL_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_MEDIUM_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_MILITARISTIC_TRAIT_LARGE_INFLUENCE_BONUS");
+    else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+    end
+  elseif (leader == "LEADER_MINOR_CIV_INDUSTRIAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_INDUSTRIAL") then
+    if envoyTokenNum == NUM_ENVOY_TOKENS_FOR_FIRST_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_SMALL_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_MEDIUM_INFLUENCE_BONUS");
+    elseif envoyTokenNum == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then bonusDetailsText = Locale.Lookup("LOC_MINOR_CIV_INDUSTRIAL_TRAIT_LARGE_INFLUENCE_BONUS");
+    else UI.DataError("Unknown envoy number for city-state type bonus: " .. tostring(envoyTokenNum));
+    end
+  else
+    UI.DataError("Unknown leader type for city-state type bonus");
+  end
 
-	return bonusTypeText, bonusDetailsText;
+  return bonusTypeText, bonusDetailsText;
 end
 
 
 -- ===========================================================================
---	Obtain the bonus text for a Suzerain
---	playerID which player to look up the bonus type for
---	envoyTokenNum	1,3,4,6 for the type of bonus to obtain
+--  Obtain the bonus text for a Suzerain
+--  playerID which player to look up the bonus type for
+--  envoyTokenNum  1,3,4,6 for the type of bonus to obtain
 --
---	RETURN the full bonus text type for a city, and a short (brief) version
+--  RETURN the full bonus text type for a city, and a short (brief) version
 -- ===========================================================================
 function GetSuzerainBonusText( playerID:number )
 
-	local leader	:string = PlayerConfigurations[playerID]:GetLeaderTypeName();
-	local leaderInfo:table	= GameInfo.Leaders[leader];
-	if leaderInfo == nil then
-		UI.DataError("GetSuzerainBonusText, cannot determine the type of city state suzerain bonus for player #: "..tostring(playerID) );
-		return "UNKNOWN";
-	end
+  local leader  :string = PlayerConfigurations[playerID]:GetLeaderTypeName();
+  local leaderInfo:table  = GameInfo.Leaders[leader];
+  if leaderInfo == nil then
+    UI.DataError("GetSuzerainBonusText, cannot determine the type of city state suzerain bonus for player #: "..tostring(playerID) );
+    return "UNKNOWN";
+  end
 
-	local text		:string = "";
+  local text    :string = "";
 
-	-- Unique Bonus
-	for leaderTraitPairInfo in GameInfo.LeaderTraits() do
-		if (leader ~= nil and leader == leaderTraitPairInfo.LeaderType) then
-			local traitInfo = GameInfo.Traits[leaderTraitPairInfo.TraitType];
-			if (traitInfo ~= nil) then
-				local name = PlayerConfigurations[playerID]:GetCivilizationShortDescription();
-				text = text .. "[COLOR:SuzerainDark]" .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_UNIQUE_BONUS", name) .. "[ENDCOLOR] ";
-				text = text .. Locale.Lookup(traitInfo.Description);
-			end
-		end
-	end
+  -- Unique Bonus
+  for leaderTraitPairInfo in GameInfo.LeaderTraits() do
+    if (leader ~= nil and leader == leaderTraitPairInfo.LeaderType) then
+      local traitInfo = GameInfo.Traits[leaderTraitPairInfo.TraitType];
+      if (traitInfo ~= nil) then
+        local name = PlayerConfigurations[playerID]:GetCivilizationShortDescription();
+        text = text .. "[COLOR:SuzerainDark]" .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_UNIQUE_BONUS", name) .. "[ENDCOLOR] ";
+        text = text .. Locale.Lookup(traitInfo.Description);
+      end
+    end
+  end
 
-	-- Diplomatic Bonus
-	text = text .. "[NEWLINE][NEWLINE]" .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_DIPLOMATIC_BONUS");
+  -- Diplomatic Bonus
+  text = text .. "[NEWLINE][NEWLINE]" .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_DIPLOMATIC_BONUS");
 
-	-- Resources Available
-	local resourceIcons	:string = "";
-	local player = Players[playerID];
-	if (player ~= nil) then
-		for resourceInfo in GameInfo.Resources() do
-			local resource = resourceInfo.Index;
-			-- Include exports, so we see what another player is getting if suzerain
-			if (player:GetResources():HasResource(resource) or player:GetResources():HasExportedResource(resource)) then
-				local amount = player:GetResources():GetResourceAmount(resource) + player:GetResources():GetExportedResourceAmount(resource);
-				if (resourceIcons ~= "") then
-					resourceIcons = resourceIcons .. ", ";
-				end
-				resourceIcons = resourceIcons .. amount .. " [ICON_" .. resourceInfo.ResourceType .. "] " .. Locale.Lookup(resourceInfo.Name);
-			end
-		end
-	end
-	if (resourceIcons ~= "") then
-		text = text .. " " .. resourceIcons;
-	else
-		text = text .. " " .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_NO_RESOURCES_AVAILABLE");
-	end
+  -- Resources Available
+  local resourceIcons  :string = "";
+  local player = Players[playerID];
+  if (player ~= nil) then
+    for resourceInfo in GameInfo.Resources() do
+      local resource = resourceInfo.Index;
+      -- Include exports, so we see what another player is getting if suzerain
+      if (player:GetResources():HasResource(resource) or player:GetResources():HasExportedResource(resource)) then
+        local amount = player:GetResources():GetResourceAmount(resource) + player:GetResources():GetExportedResourceAmount(resource);
+        if (resourceIcons ~= "") then
+          resourceIcons = resourceIcons .. ", ";
+        end
+        resourceIcons = resourceIcons .. amount .. " [ICON_" .. resourceInfo.ResourceType .. "] " .. Locale.Lookup(resourceInfo.Name);
+      end
+    end
+  end
+  if (resourceIcons ~= "") then
+    text = text .. " " .. resourceIcons;
+  else
+    text = text .. " " .. Locale.Lookup("LOC_CITY_STATES_SUZERAIN_NO_RESOURCES_AVAILABLE");
+  end
 
-	return text;
+  return text;
 end
 
 -- ===========================================================================
---	RETURN a table of quests for a given CityState
+--  RETURN a table of quests for a given CityState
 -- ===========================================================================
 function GetQuests( playerID:number )
-	local kQuests		:table  = {};
-	local questsManager	:table = Game.GetQuestsManager();
-	local localPlayerID :number = Game.GetLocalPlayer();
-	if questsManager ~= nil then
-		for questInfo in GameInfo.Quests() do
-			if questsManager:HasActiveQuestFromPlayer( localPlayerID, playerID, questInfo.Index) then
-				kQuests[questInfo.Index] = {
-					Description = questsManager:GetActiveQuestDescription( localPlayerID, playerID, questInfo.Index),
-					Name		= questsManager:GetActiveQuestName( localPlayerID, playerID, questInfo.Index),
-					Reward		= questsManager:GetActiveQuestReward( localPlayerID, playerID, questInfo.Index),
-					Type		= questInfo.QuestType,
-					Callout		= questInfo.IconString
-				};
-			end
-		end
-	else
-		UI.DataError("City-States were unable to obtain the QuestManager.");
-	end
-	return kQuests;
+  local kQuests    :table  = {};
+  local questsManager  :table = Game.GetQuestsManager();
+  local localPlayerID :number = Game.GetLocalPlayer();
+  if questsManager ~= nil then
+    for questInfo in GameInfo.Quests() do
+      if questsManager:HasActiveQuestFromPlayer( localPlayerID, playerID, questInfo.Index) then
+        kQuests[questInfo.Index] = {
+          Description = questsManager:GetActiveQuestDescription( localPlayerID, playerID, questInfo.Index),
+          Name    = questsManager:GetActiveQuestName( localPlayerID, playerID, questInfo.Index),
+          Reward    = questsManager:GetActiveQuestReward( localPlayerID, playerID, questInfo.Index),
+          Type    = questInfo.QuestType,
+          Callout    = questInfo.IconString
+        };
+      end
+    end
+  else
+    UI.DataError("City-States were unable to obtain the QuestManager.");
+  end
+  return kQuests;
 end
 
 
 -- ===========================================================================
---	Returns the texture name and UV for a bonus icon type.
+--  Returns the texture name and UV for a bonus icon type.
 -- ===========================================================================
 function GetBonusIconAtlasPieces( kCityState:table, size:number )
-	local iconName:string = "";
-	if	   kCityState.Type == "SCIENTIFIC"		then	iconName = "ICON_ENVOY_BONUS_SCIENCE";
-	elseif kCityState.Type == "RELIGIOUS"		then	iconName = "ICON_ENVOY_BONUS_FAITH";
-	elseif kCityState.Type == "TRADE"			then	iconName = "ICON_ENVOY_BONUS_GOLD";
-	elseif kCityState.Type == "CULTURE"			then	iconName = "ICON_ENVOY_BONUS_CULTURE";
-	elseif kCityState.Type == "MILITARISTIC"	then	iconName = "ICON_ENVOY_BONUS_MILITARY";
-	elseif kCityState.Type == "INDUSTRIAL"		then	iconName = "ICON_ENVOY_BONUS_PRODUCTION";
-	end
-	return IconManager:FindIconAtlas(iconName, size);
+  local iconName:string = "";
+  if     kCityState.Type == "SCIENTIFIC"    then  iconName = "ICON_ENVOY_BONUS_SCIENCE";
+  elseif kCityState.Type == "RELIGIOUS"    then  iconName = "ICON_ENVOY_BONUS_FAITH";
+  elseif kCityState.Type == "TRADE"      then  iconName = "ICON_ENVOY_BONUS_GOLD";
+  elseif kCityState.Type == "CULTURE"      then  iconName = "ICON_ENVOY_BONUS_CULTURE";
+  elseif kCityState.Type == "MILITARISTIC"  then  iconName = "ICON_ENVOY_BONUS_MILITARY";
+  elseif kCityState.Type == "INDUSTRIAL"    then  iconName = "ICON_ENVOY_BONUS_PRODUCTION";
+  end
+  return IconManager:FindIconAtlas(iconName, size);
 end
 
 -- ===========================================================================
---	Obtain art and text related to the relationship status
---	RETURNS: atlas texture info (u, v, and image), as well as a tooltip
+--  Obtain art and text related to the relationship status
+--  RETURNS: atlas texture info (u, v, and image), as well as a tooltip
 -- ===========================================================================
 function GetRelationshipPipAtlasPieces( kCityState:table )
-	local iconName	:string = DIPLO_PIP_INFO[kCityState.DiplomaticState].IconName;
-	local tooltip	:string = Locale.Lookup( DIPLO_PIP_INFO[kCityState.DiplomaticState].Tooltip );
-	if iconName == nil or iconName == "" then
-		print("WARNING: Unexpected DiplomaticState when obtain PIP art. value:"..kCityState.DiplomaticState);
-		iconName = "ICON_RELATIONSHIP_NEUTRAL";
-	end
-	local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(iconName, 23);
-	return textureOffsetX, textureOffsetY, textureSheet, tooltip;
+  local iconName  :string = DIPLO_PIP_INFO[kCityState.DiplomaticState].IconName;
+  local tooltip  :string = Locale.Lookup( DIPLO_PIP_INFO[kCityState.DiplomaticState].Tooltip );
+  if iconName == nil or iconName == "" then
+    print("WARNING: Unexpected DiplomaticState when obtain PIP art. value:"..kCityState.DiplomaticState);
+    iconName = "ICON_RELATIONSHIP_NEUTRAL";
+  end
+  local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(iconName, 23);
+  return textureOffsetX, textureOffsetY, textureSheet, tooltip;
 end
 
 -- ===========================================================================
---	Return the type of city-state this is in a tooltip ready form.
+--  Return the type of city-state this is in a tooltip ready form.
 -- ===========================================================================
 function GetTypeTooltip( kCityState:table )
-	local toolTip		:string;
-	if	   kCityState.Type == "SCIENTIFIC"		then	toolTip	 = "LOC_CITY_STATES_TYPE_SCIENTIFIC";
-	elseif kCityState.Type == "RELIGIOUS"		then	toolTip	 = "LOC_CITY_STATES_TYPE_RELIGIOUS";
-	elseif kCityState.Type == "TRADE"			then	toolTip	 = "LOC_CITY_STATES_TYPE_TRADE";
-	elseif kCityState.Type == "CULTURE"			then	toolTip	 = "LOC_CITY_STATES_TYPE_CULTURAL";
-	elseif kCityState.Type == "MILITARISTIC"	then	toolTip	 = "LOC_CITY_STATES_TYPE_MILITARISTIC";
-	elseif kCityState.Type == "INDUSTRIAL"		then	toolTip	 = "LOC_CITY_STATES_TYPE_INDUSTRIAL";
-	else
-		UI.DataError("WARNING: Unknown type '"..kCityState.Type.."' for getting the City-State tooltip.");
-		return 0,0,"","";
-	end
-	return toolTip;
+  local toolTip    :string;
+  if     kCityState.Type == "SCIENTIFIC"    then  toolTip   = "LOC_CITY_STATES_TYPE_SCIENTIFIC";
+  elseif kCityState.Type == "RELIGIOUS"    then  toolTip   = "LOC_CITY_STATES_TYPE_RELIGIOUS";
+  elseif kCityState.Type == "TRADE"      then  toolTip   = "LOC_CITY_STATES_TYPE_TRADE";
+  elseif kCityState.Type == "CULTURE"      then  toolTip   = "LOC_CITY_STATES_TYPE_CULTURAL";
+  elseif kCityState.Type == "MILITARISTIC"  then  toolTip   = "LOC_CITY_STATES_TYPE_MILITARISTIC";
+  elseif kCityState.Type == "INDUSTRIAL"    then  toolTip   = "LOC_CITY_STATES_TYPE_INDUSTRIAL";
+  else
+    UI.DataError("WARNING: Unknown type '"..kCityState.Type.."' for getting the City-State tooltip.");
+    return 0,0,"","";
+  end
+  return toolTip;
 end
 
 -- ===========================================================================
---	Returns the texture name and UV for a given City-States type, also a
---	tooltip describing that type.
+--  Returns the texture name and UV for a given City-States type, also a
+--  tooltip describing that type.
 -- ===========================================================================
 function GetTypeAtlasPieces( kCityState:table, size:number )
-	local iconName		:string;
-	if	   kCityState.Type == "SCIENTIFIC"		then	iconName = "ICON_CITYSTATE_SCIENCE";
-	elseif kCityState.Type == "RELIGIOUS"		then	iconName = "ICON_CITYSTATE_FAITH";
-	elseif kCityState.Type == "TRADE"			then	iconName = "ICON_CITYSTATE_TRADE";
-	elseif kCityState.Type == "CULTURE"			then	iconName = "ICON_CITYSTATE_CULTURE";
-	elseif kCityState.Type == "MILITARISTIC"	then	iconName = "ICON_CITYSTATE_MILITARISTIC";
-	elseif kCityState.Type == "INDUSTRIAL"		then	iconName = "ICON_CITYSTATE_INDUSTRIAL";
-	else
-		UI.DataError("WARNING: Unknown type '"..kCityState.Type.."' for getting the City-State icon (at size "..tostring(size)..")");
-		return 0,0,"","";
-	end
+  local iconName    :string;
+  if     kCityState.Type == "SCIENTIFIC"    then  iconName = "ICON_CITYSTATE_SCIENCE";
+  elseif kCityState.Type == "RELIGIOUS"    then  iconName = "ICON_CITYSTATE_FAITH";
+  elseif kCityState.Type == "TRADE"      then  iconName = "ICON_CITYSTATE_TRADE";
+  elseif kCityState.Type == "CULTURE"      then  iconName = "ICON_CITYSTATE_CULTURE";
+  elseif kCityState.Type == "MILITARISTIC"  then  iconName = "ICON_CITYSTATE_MILITARISTIC";
+  elseif kCityState.Type == "INDUSTRIAL"    then  iconName = "ICON_CITYSTATE_INDUSTRIAL";
+  else
+    UI.DataError("WARNING: Unknown type '"..kCityState.Type.."' for getting the City-State icon (at size "..tostring(size)..")");
+    return 0,0,"","";
+  end
 
-	local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(iconName, size);
-	return textureOffsetX, textureOffsetY, textureSheet;
+  local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(iconName, size);
+  return textureOffsetX, textureOffsetY, textureSheet;
 end
 
 -- ===========================================================================
---	Returns the texture name and UV for a bonus icon type.
+--  Returns the texture name and UV for a bonus icon type.
 -- ===========================================================================
 function GetTypeName( kCityState:table )
-	if	   kCityState.Type == "SCIENTIFIC"		then	return Locale.Lookup("LOC_CITY_STATES_TYPE_SCIENTIFIC");
-	elseif kCityState.Type == "RELIGIOUS"		then	return Locale.Lookup("LOC_CITY_STATES_TYPE_RELIGIOUS");
-	elseif kCityState.Type == "TRADE"			then	return Locale.Lookup("LOC_CITY_STATES_TYPE_TRADE");
-	elseif kCityState.Type == "CULTURE"			then	return Locale.Lookup("LOC_CITY_STATES_TYPE_CULTURAL");
-	elseif kCityState.Type == "MILITARISTIC"	then	return Locale.Lookup("LOC_CITY_STATES_TYPE_MILITARISTIC");
-	elseif kCityState.Type == "INDUSTRIAL"		then	return Locale.Lookup("LOC_CITY_STATES_TYPE_INDUSTRIAL");
-	end
-	return "unknownType'"..kCityState.Type.."'";
+  if     kCityState.Type == "SCIENTIFIC"    then  return Locale.Lookup("LOC_CITY_STATES_TYPE_SCIENTIFIC");
+  elseif kCityState.Type == "RELIGIOUS"    then  return Locale.Lookup("LOC_CITY_STATES_TYPE_RELIGIOUS");
+  elseif kCityState.Type == "TRADE"      then  return Locale.Lookup("LOC_CITY_STATES_TYPE_TRADE");
+  elseif kCityState.Type == "CULTURE"      then  return Locale.Lookup("LOC_CITY_STATES_TYPE_CULTURAL");
+  elseif kCityState.Type == "MILITARISTIC"  then  return Locale.Lookup("LOC_CITY_STATES_TYPE_MILITARISTIC");
+  elseif kCityState.Type == "INDUSTRIAL"    then  return Locale.Lookup("LOC_CITY_STATES_TYPE_INDUSTRIAL");
+  end
+  return "unknownType'"..kCityState.Type.."'";
 end
 
 -- ===========================================================================
---	Sum up the envoy changes the player is proposing to make (but not
---	submitted to the game engine).
---	RETURNS: # of envoy token changes across all City States
+--  Sum up the envoy changes the player is proposing to make (but not
+--  submitted to the game engine).
+--  RETURNS: # of envoy token changes across all City States
 -- ===========================================================================
 function SumEnvoyChanges()
-	local sum:number = 0;
-	for _,value in pairs( m_kEnvoyChanges ) do
-		sum = sum + value;
-	end
-	return sum;
+  local sum:number = 0;
+  for _,value in pairs( m_kEnvoyChanges ) do
+    sum = sum + value;
+  end
+  return sum;
 end
 
 -- ===========================================================================
 function Close()
-	m_kEnvoyChanges = {};		-- Zero out any pending envoy choices
+  m_kEnvoyChanges = {};    -- Zero out any pending envoy choices
 
     if not ContextPtr:IsHidden() then
         UI.PlaySound("CityStates_Panel_Close");
@@ -359,1267 +359,1267 @@ function Close()
 end
 
 -- ===========================================================================
---	UI Callback
---	Clicking close on interface.
+--  UI Callback
+--  Clicking close on interface.
 -- ===========================================================================
 function OnClose()
-	Close();
+  Close();
 end
 
 -- ===========================================================================
---	UI Callback
---	Go back to the main list view.
+--  UI Callback
+--  Go back to the main list view.
 -- ===========================================================================
 function OnBackClose()
-	if m_kPlayerData.EnvoyTokens ~= nil and m_kPlayerData.EnvoyTokens > 0 then
-		m_mode = MODE.SendEnvoys;
-	else
-		m_mode = MODE.Overview;
-	end
-	Refresh();
+  if m_kPlayerData.EnvoyTokens ~= nil and m_kPlayerData.EnvoyTokens > 0 then
+    m_mode = MODE.SendEnvoys;
+  else
+    m_mode = MODE.Overview;
+  end
+  Refresh();
 end
 
 -- ===========================================================================
---	LUA Event
---	Explicit close (from partial screen hooks), part of closing everything,
+--  LUA Event
+--  Explicit close (from partial screen hooks), part of closing everything,
 -- ===========================================================================
 function OnCloseAllExcept( contextToStayOpen:string )
-	if contextToStayOpen == ContextPtr:GetID() then return; end
-	Close();
+  if contextToStayOpen == ContextPtr:GetID() then return; end
+  Close();
 end
 
 -- ===========================================================================
---	LUA Event
---	Explicit close called from else-where.
+--  LUA Event
+--  Explicit close called from else-where.
 -- ===========================================================================
 function OnCloseCityStates()
-	Close();
+  Close();
 end
 
 
 -- ===========================================================================
---	LUA Event
+--  LUA Event
 -- ===========================================================================
 function OnOpenCityStates()
-	OpenOverview();
+  OpenOverview();
 end
 
 -- ===========================================================================
---	LUA Event
---	Open up the screen.
---	iPlayer	(optional) the player number for the city state to focus on, if
---			-1 or nil it will show an overview list.
+--  LUA Event
+--  Open up the screen.
+--  iPlayer  (optional) the player number for the city state to focus on, if
+--      -1 or nil it will show an overview list.
 -- ===========================================================================
 function OpenOverview( iPlayer:number )
-	UI.PlaySound("CityStates_Panel_Open");
-	m_mode = MODE.Overview;
-	m_kScreenSlideAnim.Show();
-	Refresh();
+  UI.PlaySound("CityStates_Panel_Open");
+  m_mode = MODE.Overview;
+  m_kScreenSlideAnim.Show();
+  Refresh();
 end
 
 
 -- ===========================================================================
---	LUA Event
---	Open up the screen for envoy sending.
---	iPlayer	(optional) the player number for the city state to focus on, if
---			-1 or nil it will show an overview list.
+--  LUA Event
+--  Open up the screen for envoy sending.
+--  iPlayer  (optional) the player number for the city state to focus on, if
+--      -1 or nil it will show an overview list.
 -- ===========================================================================
 function OnOpenSendEnvoys( iPlayer:number )
-	m_mode = MODE.SendEnvoys;
-	UI.PlaySound("CityStates_Panel_Open");
-	m_kScreenSlideAnim.Show();
-	Refresh();
+  m_mode = MODE.SendEnvoys;
+  UI.PlaySound("CityStates_Panel_Open");
+  m_kScreenSlideAnim.Show();
+  Refresh();
 
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID ~= -1) then
-		local localPlayer = Players[localPlayerID];
-		if (localPlayer ~= nil and localPlayer:GetInfluence() ~= nil and not localPlayer:GetInfluence():IsGivingTokensConsidered()) then
-			localPlayer:GetInfluence():SetGivingTokensConsidered(true);
-		end
-	end
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID ~= -1) then
+    local localPlayer = Players[localPlayerID];
+    if (localPlayer ~= nil and localPlayer:GetInfluence() ~= nil and not localPlayer:GetInfluence():IsGivingTokensConsidered()) then
+      localPlayer:GetInfluence():SetGivingTokensConsidered(true);
+    end
+  end
 end
 
 
 -- ===========================================================================
---	LUA EVENT
---	Open panel pointing to a specific City State
+--  LUA EVENT
+--  Open panel pointing to a specific City State
 -- ===========================================================================
 function OnRaiseMinorCivicsPanel( playerID:number )
-	OpenSingleViewCityState( playerID );
+  OpenSingleViewCityState( playerID );
 end
 
 -- ===========================================================================
---	Open panel pointing to a specific City State
+--  Open panel pointing to a specific City State
 -- ===========================================================================
 function OpenSingleViewCityState( playerID:number )
-	if m_mode == MODE.Overview or m_mode == MODE.SendEnvoys then
-		m_mode = MODE.EnvoySent;
-	end
+  if m_mode == MODE.Overview or m_mode == MODE.SendEnvoys then
+    m_mode = MODE.EnvoySent;
+  end
 
-	UI.PlaySound("CityStates_Panel_Open");
-	m_iCurrentCityState = playerID;
-	m_kScreenSlideAnim.Show();
-	Refresh();
-	LookAtCityState( playerID );
+  UI.PlaySound("CityStates_Panel_Open");
+  m_iCurrentCityState = playerID;
+  m_kScreenSlideAnim.Show();
+  Refresh();
+  LookAtCityState( playerID );
 end
 
 
 
 -- ===========================================================================
---	Obtain latest data and display it.
+--  Obtain latest data and display it.
 -- ===========================================================================
 function Refresh()
-	GetData();
-	if m_mode == MODE.Overview or m_mode == MODE.SendEnvoys then
-		ViewList();
-	else
-		-- If no city state is selected, then change to the overview.
-		if m_iCurrentCityState == -1 then
-			m_mode = MODE.Overview;
-			ViewList();
-		else
-			ViewCityState( m_iCurrentCityState );
-		end
-	end
+  GetData();
+  if m_mode == MODE.Overview or m_mode == MODE.SendEnvoys then
+    ViewList();
+  else
+    -- If no city state is selected, then change to the overview.
+    if m_iCurrentCityState == -1 then
+      m_mode = MODE.Overview;
+      ViewList();
+    else
+      ViewCityState( m_iCurrentCityState );
+    end
+  end
 end
 
 -- ===========================================================================
---	Helper to realize an envoy's contents and size of font use
+--  Helper to realize an envoy's contents and size of font use
 -- ===========================================================================
 function RealizeEnvoyToken( total:number, control:table )
-	if total < 10 then
-		control:SetFontSize(FONT_SIZE_SINGLE_DIGIT_ENVOYS);
-	elseif total < 100 then
-		control:SetFontSize(FONT_SIZE_TWO_DIGIT_ENVOYS);
-	else
-		control:SetFontSize(FONT_SIZE_THREE_DIGIT_ENVOYS);	-- So much envoy!
-	end
-	control:SetText( total );
+  if total < 10 then
+    control:SetFontSize(FONT_SIZE_SINGLE_DIGIT_ENVOYS);
+  elseif total < 100 then
+    control:SetFontSize(FONT_SIZE_TWO_DIGIT_ENVOYS);
+  else
+    control:SetFontSize(FONT_SIZE_THREE_DIGIT_ENVOYS);  -- So much envoy!
+  end
+  control:SetText( total );
 end
 
 -- ===========================================================================
 function RealizeListHeader()
-	local sum:number = SumEnvoyChanges();
+  local sum:number = SumEnvoyChanges();
 
-	if (m_kPlayerData.EnvoyTokens - sum) < 0 then
-		UI.DataError("Less envoy tokens than going into the deploy envoy.");
-	end
+  if (m_kPlayerData.EnvoyTokens - sum) < 0 then
+    UI.DataError("Less envoy tokens than going into the deploy envoy.");
+  end
 
-	local header:string = Locale.ToUpper(Locale.Lookup("LOC_CITY_STATES_OVERVIEW"));
-	if m_mode == MODE.SendEnvoys then
-		header = Locale.ToUpper( Locale.Lookup("LOC_CITY_STATES_SEND_ENVOYS", (m_kPlayerData.EnvoyTokens - sum)) );
-		header = header .. " " .. Locale.Lookup("LOC_CITY_STATES_SEND_ENVOY_AMOUNT", (m_kPlayerData.EnvoyTokens - sum)) .. " ";	--HACK: space on end due to textcontrol bug, see below
-	end
-	--TODO: Space after [ICON..] breaks smallcaps?! ??TRON: header="SEND ENVOYS (2[ICON_Envoy] )";
-	--print("Envoy Header:",header);
-	Controls.Header:SetText( header );
+  local header:string = Locale.ToUpper(Locale.Lookup("LOC_CITY_STATES_OVERVIEW"));
+  if m_mode == MODE.SendEnvoys then
+    header = Locale.ToUpper( Locale.Lookup("LOC_CITY_STATES_SEND_ENVOYS", (m_kPlayerData.EnvoyTokens - sum)) );
+    header = header .. " " .. Locale.Lookup("LOC_CITY_STATES_SEND_ENVOY_AMOUNT", (m_kPlayerData.EnvoyTokens - sum)) .. " ";  --HACK: space on end due to textcontrol bug, see below
+  end
+  --TODO: Space after [ICON..] breaks smallcaps?! ??TRON: header="SEND ENVOYS (2[ICON_Envoy] )";
+  --print("Envoy Header:",header);
+  Controls.Header:SetText( header );
 
-	local localPlayer = Players[Game.GetLocalPlayer()];
-	if (localPlayer == nil) then
-		return;
-	end
+  local localPlayer = Players[Game.GetLocalPlayer()];
+  if (localPlayer == nil) then
+    return;
+  end
 
-	local playerInfluence	:table	= localPlayer:GetInfluence();
-	local influenceBalance	:number	= Round(playerInfluence:GetPointsEarned(), 1);
-	local influenceRate		:number = Round(playerInfluence:GetPointsPerTurn(), 1);
-	local influenceThreshold:number	= playerInfluence:GetPointsThreshold();
-	local envoysPerThreshold:number = playerInfluence:GetTokensPerThreshold();
-	local currentEnvoys		:number = playerInfluence:GetTokensToGive();
+  local playerInfluence  :table  = localPlayer:GetInfluence();
+  local influenceBalance  :number  = Round(playerInfluence:GetPointsEarned(), 1);
+  local influenceRate    :number = Round(playerInfluence:GetPointsPerTurn(), 1);
+  local influenceThreshold:number  = playerInfluence:GetPointsThreshold();
+  local envoysPerThreshold:number = playerInfluence:GetTokensPerThreshold();
+  local currentEnvoys    :number = playerInfluence:GetTokensToGive();
 
-	local envoyDetails:string = Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_THRESHOLD", envoysPerThreshold, influenceThreshold);
-	Controls.EnvoyDetails:SetText(envoyDetails);
+  local envoyDetails:string = Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_THRESHOLD", envoysPerThreshold, influenceThreshold);
+  Controls.EnvoyDetails:SetText(envoyDetails);
 
-	local sTooltip:string = "";
-	if (currentEnvoys > 0) then
-		sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_ENVOYS", currentEnvoys);
-		sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
-	end
-	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_THRESHOLD", envoysPerThreshold, influenceThreshold);
-	sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
-	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_BALANCE", influenceBalance);
-	sTooltip = sTooltip .. "[NEWLINE]";
-	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_RATE", influenceRate);
-	sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
-	sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_SOURCES_HELP");
+  local sTooltip:string = "";
+  if (currentEnvoys > 0) then
+    sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_ENVOYS", currentEnvoys);
+    sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
+  end
+  sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_THRESHOLD", envoysPerThreshold, influenceThreshold);
+  sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
+  sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_BALANCE", influenceBalance);
+  sTooltip = sTooltip .. "[NEWLINE]";
+  sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_POINTS_RATE", influenceRate);
+  sTooltip = sTooltip .. "[NEWLINE][NEWLINE]";
+  sTooltip = sTooltip .. Locale.Lookup("LOC_TOP_PANEL_INFLUENCE_TOOLTIP_SOURCES_HELP");
 
-	local meterRatio = influenceBalance / influenceThreshold;
-	if (meterRatio < 0) then
-		meterRatio = 0;
-	elseif (meterRatio > 1) then
-		meterRatio = 1;
-	end
-	Controls.EnvoysMeter:SetPercent(meterRatio);
-	Controls.Envoys:SetToolTipString(sTooltip);
-	Controls.EnvoysStack:CalculateSize();
-	Controls.EnvoysStack:ReprocessAnchoring();
+  local meterRatio = influenceBalance / influenceThreshold;
+  if (meterRatio < 0) then
+    meterRatio = 0;
+  elseif (meterRatio > 1) then
+    meterRatio = 1;
+  end
+  Controls.EnvoysMeter:SetPercent(meterRatio);
+  Controls.Envoys:SetToolTipString(sTooltip);
+  Controls.EnvoysStack:CalculateSize();
+  Controls.EnvoysStack:ReprocessAnchoring();
 end
 
 -- ===========================================================================
---	Enable/Disable change buttons
+--  Enable/Disable change buttons
 -- ===========================================================================
 function RealizeEnvoyChangeButtons()
-	local sum:number = SumEnvoyChanges();
+  local sum:number = SumEnvoyChanges();
 
-	-- Enable/disable every button based on if any more tokens can be given out.
-	local totalLeft		:number = (m_kPlayerData.EnvoyTokens - sum);
-	local isMoreDisabled:boolean = not m_isLocalPlayerTurn or (totalLeft == 0);
-	local isLessDisabled:boolean = not m_isLocalPlayerTurn or (sum <= 0);
+  -- Enable/disable every button based on if any more tokens can be given out.
+  local totalLeft    :number = (m_kPlayerData.EnvoyTokens - sum);
+  local isMoreDisabled:boolean = not m_isLocalPlayerTurn or (totalLeft == 0);
+  local isLessDisabled:boolean = not m_isLocalPlayerTurn or (sum <= 0);
 
-	-- Likely going away so even if warring envoys can still be sent.
-	for iPlayer,inst in pairs( m_uiCityStateRows ) do
-		inst.EnvoyMoreButton:SetDisabled( isMoreDisabled or (not m_kCityStates[iPlayer].CanReceiveTokensFrom) );
-		inst.EnvoyLessButton:SetDisabled( isLessDisabled or (not m_kCityStates[iPlayer].CanReceiveTokensFrom) );
-		local amount:number = m_kEnvoyChanges[iPlayer];
-		inst.EnvoyLessButton:SetHide( amount == nil or amount == 0 );
-		if m_kCityStates[iPlayer].isAlive then
-			if m_kCityStates[iPlayer].CanReceiveTokensFrom then
-				inst.EnvoyMoreButton:SetToolTipString( Locale.Lookup("LOC_CITY_STATES_ADD_AN_ENVOY") );
-				inst.EnvoyLessButton:SetToolTipString( Locale.Lookup("LOC_CITY_STATES_REMOVE_AN_ENVOY") );
-				inst.Envoy:SetToolTipString( nil );
-			else
-				local tooltip:string = Locale.Lookup("LOC_CITY_STATES_CURRENTLY_AT_WAR");
-				inst.EnvoyMoreButton:SetToolTipString( tooltip );
-				inst.EnvoyLessButton:SetToolTipString( tooltip );
-				inst.Envoy:SetToolTipString( tooltip );
-			end
-		else
-			local tooltip:string = Locale.Lookup("LOC_CITY_STATES_DESTROYED_LONG");
-			inst.EnvoyMoreButton:SetToolTipString( tooltip );
-			inst.EnvoyLessButton:SetToolTipString( tooltip );
-			inst.Envoy:SetToolTipString( tooltip );
-		end
-	end
+  -- Likely going away so even if warring envoys can still be sent.
+  for iPlayer,inst in pairs( m_uiCityStateRows ) do
+    inst.EnvoyMoreButton:SetDisabled( isMoreDisabled or (not m_kCityStates[iPlayer].CanReceiveTokensFrom) );
+    inst.EnvoyLessButton:SetDisabled( isLessDisabled or (not m_kCityStates[iPlayer].CanReceiveTokensFrom) );
+    local amount:number = m_kEnvoyChanges[iPlayer];
+    inst.EnvoyLessButton:SetHide( amount == nil or amount == 0 );
+    if m_kCityStates[iPlayer].isAlive then
+      if m_kCityStates[iPlayer].CanReceiveTokensFrom then
+        inst.EnvoyMoreButton:SetToolTipString( Locale.Lookup("LOC_CITY_STATES_ADD_AN_ENVOY") );
+        inst.EnvoyLessButton:SetToolTipString( Locale.Lookup("LOC_CITY_STATES_REMOVE_AN_ENVOY") );
+        inst.Envoy:SetToolTipString( nil );
+      else
+        local tooltip:string = Locale.Lookup("LOC_CITY_STATES_CURRENTLY_AT_WAR");
+        inst.EnvoyMoreButton:SetToolTipString( tooltip );
+        inst.EnvoyLessButton:SetToolTipString( tooltip );
+        inst.Envoy:SetToolTipString( tooltip );
+      end
+    else
+      local tooltip:string = Locale.Lookup("LOC_CITY_STATES_DESTROYED_LONG");
+      inst.EnvoyMoreButton:SetToolTipString( tooltip );
+      inst.EnvoyLessButton:SetToolTipString( tooltip );
+      inst.Envoy:SetToolTipString( tooltip );
+    end
+  end
 
-	Controls.ConfirmButton:SetDisabled(not m_isLocalPlayerTurn or sum == 0);
+  Controls.ConfirmButton:SetDisabled(not m_isLocalPlayerTurn or sum == 0);
 end
 
 -- ===========================================================================
 function OnLessEnvoyTokens( iPlayer:number )
 
-	local amount :number = m_kEnvoyChanges[iPlayer];
-	if amount == nil then
-		amount = 0;
-	end
-	amount = amount - 1;
-	if amount < 0 then
-		-- Do nothing, below the initial value
-		m_kEnvoyChanges[iPlayer] = nil;
-		return;
-	end
-	m_kEnvoyChanges[iPlayer] = amount;
-	m_uiCityStateRows[iPlayer].EnvoyLessButton:SetDisabled( m_kEnvoyChanges[iPlayer] == 0 );
+  local amount :number = m_kEnvoyChanges[iPlayer];
+  if amount == nil then
+    amount = 0;
+  end
+  amount = amount - 1;
+  if amount < 0 then
+    -- Do nothing, below the initial value
+    m_kEnvoyChanges[iPlayer] = nil;
+    return;
+  end
+  m_kEnvoyChanges[iPlayer] = amount;
+  m_uiCityStateRows[iPlayer].EnvoyLessButton:SetDisabled( m_kEnvoyChanges[iPlayer] == 0 );
 
-	UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
+  UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
 
-	RealizeEnvoyChangeButtons();
-	RealizeEnvoyToken(m_kCityStates[iPlayer].Tokens + m_kEnvoyChanges[iPlayer], m_uiCityStateRows[iPlayer].EnvoyCount);
-	RealizeListHeader();
+  RealizeEnvoyChangeButtons();
+  RealizeEnvoyToken(m_kCityStates[iPlayer].Tokens + m_kEnvoyChanges[iPlayer], m_uiCityStateRows[iPlayer].EnvoyCount);
+  RealizeListHeader();
 end
 
 -- ===========================================================================
 function OnMoreEnvoyTokens( iPlayer:number )
 
-	local amount :number = m_kEnvoyChanges[iPlayer];
-	if amount == nil then
-		amount = 1;
-	else
-		amount = amount + 1;
-	end
-	m_kEnvoyChanges[iPlayer] = amount;
+  local amount :number = m_kEnvoyChanges[iPlayer];
+  if amount == nil then
+    amount = 1;
+  else
+    amount = amount + 1;
+  end
+  m_kEnvoyChanges[iPlayer] = amount;
 
-	UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
+  UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
 
-	RealizeEnvoyChangeButtons();
-	RealizeEnvoyToken( m_kCityStates[iPlayer].Tokens + m_kEnvoyChanges[iPlayer], m_uiCityStateRows[iPlayer].EnvoyCount);
-	RealizeListHeader();
+  RealizeEnvoyChangeButtons();
+  RealizeEnvoyToken( m_kCityStates[iPlayer].Tokens + m_kEnvoyChanges[iPlayer], m_uiCityStateRows[iPlayer].EnvoyCount);
+  RealizeListHeader();
 end
 
 -- ===========================================================================
---	Confirm where Envoy tokens are going
+--  Confirm where Envoy tokens are going
 -- ===========================================================================
 function OnConfirmPlacement()
-	local playerID		:number= Game.GetLocalPlayer();
-	local pLocalPlayer	:table = Players[playerID];
-	local sum			:number = SumEnvoyChanges();
-	local totalLeft		:number = (m_kPlayerData.EnvoyTokens - sum);
+  local playerID    :number= Game.GetLocalPlayer();
+  local pLocalPlayer  :table = Players[playerID];
+  local sum      :number = SumEnvoyChanges();
+  local totalLeft    :number = (m_kPlayerData.EnvoyTokens - sum);
 
-	if pLocalPlayer ~= nil then
-		for cityStatePlayerID,numTokens in pairs(m_kEnvoyChanges) do
-			for i=1,numTokens,1 do
-				local parameters:table = {};
-				parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = cityStatePlayerID;
-				UI.RequestPlayerOperation( playerID, PlayerOperations.GIVE_INFLUENCE_TOKEN, parameters);
-			end
-		end
-		m_kEnvoyChanges		= {};
-		m_kLastCityStates	= m_kCityStates;	-- Save last city states to check against once an update occurs
-		UI.PlaySound("Click_Confirm");
-		if totalLeft < 1 then					-- If no changes are left to be made, we're done here; goodbye.
-			Close();
-		end
-	else
-		UI.DataError("Unable to get a valid local player when confirming envoy tokens.");
-	end
+  if pLocalPlayer ~= nil then
+    for cityStatePlayerID,numTokens in pairs(m_kEnvoyChanges) do
+      for i=1,numTokens,1 do
+        local parameters:table = {};
+        parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = cityStatePlayerID;
+        UI.RequestPlayerOperation( playerID, PlayerOperations.GIVE_INFLUENCE_TOKEN, parameters);
+      end
+    end
+    m_kEnvoyChanges    = {};
+    m_kLastCityStates  = m_kCityStates;  -- Save last city states to check against once an update occurs
+    UI.PlaySound("Click_Confirm");
+    if totalLeft < 1 then          -- If no changes are left to be made, we're done here; goodbye.
+      Close();
+    end
+  else
+    UI.DataError("Unable to get a valid local player when confirming envoy tokens.");
+  end
 end
 
 -- ===========================================================================
---	UI Callback
+--  UI Callback
 -- ===========================================================================
 function OnEnvoySentClick()
-	m_mode = MODE.EnvoySent;
-	Refresh();
+  m_mode = MODE.EnvoySent;
+  Refresh();
 end
 
 -- ===========================================================================
---	UI Callback
+--  UI Callback
 -- ===========================================================================
 function OnInfluencedByClick()
-	m_mode = MODE.InfluencedBy;
-	Refresh();
+  m_mode = MODE.InfluencedBy;
+  Refresh();
 end
 
 -- ===========================================================================
---	UI Callback
+--  UI Callback
 -- ===========================================================================
 function OnQuestsClick()
-	m_mode = MODE.Quests;
-	Refresh();
+  m_mode = MODE.Quests;
+  Refresh();
 end
 
 -- ===========================================================================
---	Change from WAR to peace or peace to WAR with a City-State
+--  Change from WAR to peace or peace to WAR with a City-State
 -- ===========================================================================
 function OnChangeWarPeaceStatus( kCityState:table )
-	local iPlayer		:number = kCityState.iPlayer;
-	local localPlayerID :number = Game.GetLocalPlayer();
-	local pLocalPlayer	:table	= Players[localPlayerID];
+  local iPlayer    :number = kCityState.iPlayer;
+  local localPlayerID :number = Game.GetLocalPlayer();
+  local pLocalPlayer  :table  = Players[localPlayerID];
 
-	if pLocalPlayer ~= nil then
-		if kCityState.isAtWar then
-			local parameters :table = {};
-			parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = localPlayerID;
-			parameters[ PlayerOperations.PARAM_PLAYER_TWO ] = iPlayer;
-			UI.RequestPlayerOperation( localPlayerID, PlayerOperations.DIPLOMACY_MAKE_PEACE, parameters);
-		else
-			LuaEvents.CityStates_ConfirmWarDialog(localPlayerID, iPlayer, WarTypes.SURPRISE_WAR);
-		end
-	else
-		UI.DataError("Could not get local player to declare war on city state '"..kCityState.Name.."'.");
-	end
+  if pLocalPlayer ~= nil then
+    if kCityState.isAtWar then
+      local parameters :table = {};
+      parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = localPlayerID;
+      parameters[ PlayerOperations.PARAM_PLAYER_TWO ] = iPlayer;
+      UI.RequestPlayerOperation( localPlayerID, PlayerOperations.DIPLOMACY_MAKE_PEACE, parameters);
+    else
+      LuaEvents.CityStates_ConfirmWarDialog(localPlayerID, iPlayer, WarTypes.SURPRISE_WAR);
+    end
+  else
+    UI.DataError("Could not get local player to declare war on city state '"..kCityState.Name.."'.");
+  end
 end
 
 -- ===========================================================================
---	Levy the Military of a City-State
+--  Levy the Military of a City-State
 -- ===========================================================================
 function OnLevyMilitary( kCityState:table)
-	local iPlayer		:number = kCityState.iPlayer;
-	local localPlayerID :number = Game.GetLocalPlayer();
-	local pLocalPlayer	:table	= Players[localPlayerID];
+  local iPlayer    :number = kCityState.iPlayer;
+  local localPlayerID :number = Game.GetLocalPlayer();
+  local pLocalPlayer  :table  = Players[localPlayerID];
 
-	if pLocalPlayer ~= nil then
-		local parameters :table = {};
-		parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = iPlayer;
-		UI.RequestPlayerOperation(localPlayerID, PlayerOperations.LEVY_MILITARY, parameters);
-	else
-		UI.DataError("Could not get local player to levy military from city state '"..kCityState.Name.."'.");
-	end
+  if pLocalPlayer ~= nil then
+    local parameters :table = {};
+    parameters[ PlayerOperations.PARAM_PLAYER_ONE ] = iPlayer;
+    UI.RequestPlayerOperation(localPlayerID, PlayerOperations.LEVY_MILITARY, parameters);
+  else
+    UI.DataError("Could not get local player to levy military from city state '"..kCityState.Name.."'.");
+  end
 end
 
 
 -- ===========================================================================
 function AddCityStateRow( kCityState:table )
 
-	local kInst				:table = m_CityStateRowIM:GetInstance();
-	local textureOffsetX	:number;
-	local textureOffsetY	:number;
-	local textureSheet		:string;
-	local questToolTip		:string = Locale.Lookup("LOC_CITY_STATES_QUESTS");
-	local numQuests			:number = 0;
-	local cityStateName		:string = Locale.ToUpper( Locale.Lookup(kCityState.Name) .. (kCityState.isAlive and "" or "("..Locale.Lookup("LOC_CITY_STATES_DESTROYED")..")") );
+  local kInst        :table = m_CityStateRowIM:GetInstance();
+  local textureOffsetX  :number;
+  local textureOffsetY  :number;
+  local textureSheet    :string;
+  local questToolTip    :string = Locale.Lookup("LOC_CITY_STATES_QUESTS");
+  local numQuests      :number = 0;
+  local cityStateName    :string = Locale.ToUpper( Locale.Lookup(kCityState.Name) .. (kCityState.isAlive and "" or "("..Locale.Lookup("LOC_CITY_STATES_DESTROYED")..")") );
 
-	-- Set name, truncate if necessary
-	kInst.NameLabel:SetText( cityStateName );
-	local targetSize:number = (kInst.NameButton:GetSizeX() - 12);
-	TruncateStringWithTooltip(kInst.NameLabel, targetSize, cityStateName);
+  -- Set name, truncate if necessary
+  kInst.NameLabel:SetText( cityStateName );
+  local targetSize:number = (kInst.NameButton:GetSizeX() - 12);
+  TruncateStringWithTooltip(kInst.NameLabel, targetSize, cityStateName);
 
-	kInst.NameLabel:SetColor( kCityState.ColorSecondary );
-	kInst.NameButton:SetColor( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
-	kInst.NameButton:RegisterCallback( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
+  kInst.NameLabel:SetColor( kCityState.ColorSecondary );
+  kInst.NameButton:SetColor( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
+  kInst.NameButton:RegisterCallback( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
 
-	textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
-	kInst.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-	kInst.DiplomacyPip:SetToolTipString(tooltip);
+  textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
+  kInst.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+  kInst.DiplomacyPip:SetToolTipString(tooltip);
 
-	for _,kQuest in pairs( kCityState.Quests ) do
-		numQuests = numQuests + 1;
-		questToolTip = questToolTip .. "[NEWLINE]" .. kQuest.Callout .. kQuest.Name;
-	end
-	kInst.QuestIcon:SetHide(numQuests <= 0);
-	kInst.QuestIcon:SetToolTipString(questToolTip);
+  for _,kQuest in pairs( kCityState.Quests ) do
+    numQuests = numQuests + 1;
+    questToolTip = questToolTip .. "[NEWLINE]" .. kQuest.Callout .. kQuest.Name;
+  end
+  kInst.QuestIcon:SetHide(numQuests <= 0);
+  kInst.QuestIcon:SetToolTipString(questToolTip);
 
-	RealizeEnvoyToken( kCityState.Tokens, kInst.EnvoyCount);
-	kInst.EnvoyLessButton:SetDisabled( true );
-	kInst.EnvoyLessButton:SetHide( m_mode ~= MODE.SendEnvoys );
-	kInst.EnvoyMoreButton:SetHide( m_mode ~= MODE.SendEnvoys );
-	kInst.EnvoyLessButton:SetVoid1( kCityState.iPlayer );
-	kInst.EnvoyMoreButton:SetVoid1( kCityState.iPlayer );
-	kInst.EnvoyLessButton:RegisterCallback( Mouse.eLClick, OnLessEnvoyTokens );
-	kInst.EnvoyMoreButton:RegisterCallback( Mouse.eLClick, OnMoreEnvoyTokens );
+  RealizeEnvoyToken( kCityState.Tokens, kInst.EnvoyCount);
+  kInst.EnvoyLessButton:SetDisabled( true );
+  kInst.EnvoyLessButton:SetHide( m_mode ~= MODE.SendEnvoys );
+  kInst.EnvoyMoreButton:SetHide( m_mode ~= MODE.SendEnvoys );
+  kInst.EnvoyLessButton:SetVoid1( kCityState.iPlayer );
+  kInst.EnvoyMoreButton:SetVoid1( kCityState.iPlayer );
+  kInst.EnvoyLessButton:RegisterCallback( Mouse.eLClick, OnLessEnvoyTokens );
+  kInst.EnvoyMoreButton:RegisterCallback( Mouse.eLClick, OnMoreEnvoyTokens );
 
-	-- Get small icons
-	textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 26 );
+  -- Get small icons
+  textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 26 );
 
-	kInst.BonusImage1:SetTexture( kCityState.isBonus1 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
-	kInst.BonusImage1:SetToolTipString( kCityState.Bonuses[1].Title .."[NEWLINE]".. kCityState.Bonuses[1].Details );
+  kInst.BonusImage1:SetTexture( kCityState.isBonus1 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
+  kInst.BonusImage1:SetToolTipString( kCityState.Bonuses[1].Title .."[NEWLINE]".. kCityState.Bonuses[1].Details );
 
-	kInst.BonusIcon1:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-	kInst.BonusIcon1:SetColor( kCityState.isBonus1 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.BonusText1:SetColor( kCityState.isBonus1 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
-	kInst.BonusImage3:SetTexture( kCityState.isBonus3 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
-	kInst.BonusImage3:SetToolTipString( kCityState.Bonuses[3].Title .."[NEWLINE]".. kCityState.Bonuses[3].Details );
-	kInst.BonusIcon3:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-	kInst.BonusIcon3:SetColor( kCityState.isBonus3 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.BonusText3:SetColor( kCityState.isBonus3 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
-	kInst.BonusImage6:SetTexture( kCityState.isBonus6 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
-	kInst.BonusImage6:SetToolTipString( kCityState.Bonuses[6].Title .."[NEWLINE]".. kCityState.Bonuses[6].Details );
-	kInst.BonusIcon6:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-	kInst.BonusIcon6:SetColor( kCityState.isBonus6 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.BonusText6:SetColor( kCityState.isBonus6 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
-	kInst.BonusImageSuzerainOff:SetHide( kCityState.isBonusSuzerain );
-	kInst.BonusImageSuzerainOff:SetColor( COLOR_ICON_BONUS_OFF );
-	kInst.BonusImageSuzerainOn:SetHide( not kCityState.isBonusSuzerain );
-	kInst.BonusImageSuzerainOn:SetColor( COLOR_ICON_BONUS_ON );
-	kInst.BonusImageSuzerainOff:SetToolTipString( kCityState.Bonuses["Suzerain"].Title .."[NEWLINE]".. kCityState.Bonuses["Suzerain"].Details );
-	kInst.BonusImageSuzerainOn:SetToolTipString( kCityState.Bonuses["Suzerain"].Title .."[NEWLINE]".. kCityState.Bonuses["Suzerain"].Details );
-	kInst.BonusIconSuzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.BonusTextSuzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_TEXT_BONUS_OFF );
-	kInst.BonusTextSuzerain:SetText( kCityState.SuzerainTokensNeeded );
-	kInst.SuzerainLabel:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.Suzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.Suzerain:SetText( kCityState.SuzerainName );
+  kInst.BonusIcon1:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+  kInst.BonusIcon1:SetColor( kCityState.isBonus1 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.BonusText1:SetColor( kCityState.isBonus1 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
+  kInst.BonusImage3:SetTexture( kCityState.isBonus3 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
+  kInst.BonusImage3:SetToolTipString( kCityState.Bonuses[3].Title .."[NEWLINE]".. kCityState.Bonuses[3].Details );
+  kInst.BonusIcon3:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+  kInst.BonusIcon3:SetColor( kCityState.isBonus3 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.BonusText3:SetColor( kCityState.isBonus3 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
+  kInst.BonusImage6:SetTexture( kCityState.isBonus6 and "CityState_BonusSlotOn" or "CityState_BonusSlotOff" );
+  kInst.BonusImage6:SetToolTipString( kCityState.Bonuses[6].Title .."[NEWLINE]".. kCityState.Bonuses[6].Details );
+  kInst.BonusIcon6:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+  kInst.BonusIcon6:SetColor( kCityState.isBonus6 and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.BonusText6:SetColor( kCityState.isBonus6 and COLOR_TEXT_BONUS_ON or COLOR_TEXT_BONUS_OFF )
+  kInst.BonusImageSuzerainOff:SetHide( kCityState.isBonusSuzerain );
+  kInst.BonusImageSuzerainOff:SetColor( COLOR_ICON_BONUS_OFF );
+  kInst.BonusImageSuzerainOn:SetHide( not kCityState.isBonusSuzerain );
+  kInst.BonusImageSuzerainOn:SetColor( COLOR_ICON_BONUS_ON );
+  kInst.BonusImageSuzerainOff:SetToolTipString( kCityState.Bonuses["Suzerain"].Title .."[NEWLINE]".. kCityState.Bonuses["Suzerain"].Details );
+  kInst.BonusImageSuzerainOn:SetToolTipString( kCityState.Bonuses["Suzerain"].Title .."[NEWLINE]".. kCityState.Bonuses["Suzerain"].Details );
+  kInst.BonusIconSuzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.BonusTextSuzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_TEXT_BONUS_OFF );
+  kInst.BonusTextSuzerain:SetText( kCityState.SuzerainTokensNeeded );
+  kInst.SuzerainLabel:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.Suzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.Suzerain:SetText( kCityState.SuzerainName );
 
-	-- Begin CQUI Changes Marker
-	local localPlayerID = Game.GetLocalPlayer();
-	local secondHighestName :string = "";
-	local highestEnvoys :number = 0;
-	local secondHighestEnvoys :number = 0;
-	local secondHighestIsPlayer :boolean = false;
+  -- Begin CQUI Changes Marker
+  local localPlayerID = Game.GetLocalPlayer();
+  local secondHighestName :string = "";
+  local highestEnvoys :number = 0;
+  local secondHighestEnvoys :number = 0;
+  local secondHighestIsPlayer :boolean = false;
 
-	-- Iterate through all players that have influenced this city state
-	for iOtherPlayer,influence in pairs(kCityState.Influence) do
-		local pLocalPlayer	:table	= Players[localPlayerID];
-		local civName		:string = "LOCAL_CITY_STATES_UNKNOWN";
-		if (pLocalPlayer ~= nil) then
-			local pPlayerConfig :table = PlayerConfigurations[iOtherPlayer];
-			if (localPlayerID == iOtherPlayer) then
-				civName = Locale.Lookup("LOC_CITY_STATES_YOU");
-			elseif (pLocalPlayer:GetDiplomacy():HasMet(iOtherPlayer)) then
-				civName = pPlayerConfig:GetPlayerName();
-			end
-		end
-		-- Grab the second highest number of envoys plus the name of that civ. Prioritizes picking the player if there are ties.
-		if (influence > highestEnvoys) then
-		  highestEnvoys = influence;
-		elseif (influence >= secondHighestEnvoys and localPlayerID == iOtherPlayer) then
-		  secondHighestIsPlayer = true;
-			secondHighestEnvoys = influence;
-			secondHighestName = Locale.Lookup( civName );
-		elseif (influence > secondHighestEnvoys ) then
+  -- Iterate through all players that have influenced this city state
+  for iOtherPlayer,influence in pairs(kCityState.Influence) do
+    local pLocalPlayer  :table  = Players[localPlayerID];
+    local civName    :string = "LOCAL_CITY_STATES_UNKNOWN";
+    if (pLocalPlayer ~= nil) then
+      local pPlayerConfig :table = PlayerConfigurations[iOtherPlayer];
+      if (localPlayerID == iOtherPlayer) then
+        civName = Locale.Lookup("LOC_CITY_STATES_YOU");
+      elseif (pLocalPlayer:GetDiplomacy():HasMet(iOtherPlayer)) then
+        civName = pPlayerConfig:GetPlayerName();
+      end
+    end
+    -- Grab the second highest number of envoys plus the name of that civ. Prioritizes picking the player if there are ties.
+    if (influence > highestEnvoys) then
+      highestEnvoys = influence;
+    elseif (influence >= secondHighestEnvoys and localPlayerID == iOtherPlayer) then
+      secondHighestIsPlayer = true;
+      secondHighestEnvoys = influence;
+      secondHighestName = Locale.Lookup( civName );
+    elseif (influence > secondHighestEnvoys ) then
       secondHighestIsPlayer = false;
-			secondHighestEnvoys = influence;
-			secondHighestName = Locale.Lookup( civName );
-		end
-	end
+      secondHighestEnvoys = influence;
+      secondHighestName = Locale.Lookup( civName );
+    end
+  end
 
-	-- Add changes to the actual UI object placeholders, which are created in the CityStates.xml file
-	kInst.SecondHighestLabel:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	-- CQUI Note: SecondHighestLabel needs to be localized, but is hard coded for now
-	kInst.SecondHighestLabel:SetText( "2nd" );
-	kInst.SecondHighestName:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.SecondHighestName:SetText( secondHighestName );
-	kInst.SecondHighestEnvoys:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
-	kInst.SecondHighestEnvoys:SetText( secondHighestEnvoys );
-	-- End CQUI Changes Marker
+  -- Add changes to the actual UI object placeholders, which are created in the CityStates.xml file
+  kInst.SecondHighestLabel:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  -- CQUI Note: SecondHighestLabel needs to be localized, but is hard coded for now
+  kInst.SecondHighestLabel:SetText( "2nd" );
+  kInst.SecondHighestName:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.SecondHighestName:SetText( secondHighestName );
+  kInst.SecondHighestEnvoys:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+  kInst.SecondHighestEnvoys:SetText( secondHighestEnvoys );
+  -- End CQUI Changes Marker
 
-	kInst.LookAtButton:SetVoid1( kCityState.iPlayer );
-	kInst.LookAtButton:RegisterCallback( Mouse.eLClick, LookAtCityState );
+  kInst.LookAtButton:SetVoid1( kCityState.iPlayer );
+  kInst.LookAtButton:RegisterCallback( Mouse.eLClick, LookAtCityState );
 
-	kInst.Icon:SetIcon( "ICON_"..kCityState.CivType );
-	kInst.Icon:SetToolTipString( Locale.Lookup( GetTypeTooltip(kCityState) ));
-	kInst.Icon:SetColor( kCityState.ColorSecondary );
-	kInst.Button:RegisterCallback( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
+  kInst.Icon:SetIcon( "ICON_"..kCityState.CivType );
+  kInst.Icon:SetToolTipString( Locale.Lookup( GetTypeTooltip(kCityState) ));
+  kInst.Icon:SetColor( kCityState.ColorSecondary );
+  kInst.Button:RegisterCallback( Mouse.eLClick, function() OpenSingleViewCityState( kCityState.iPlayer ) end );
 
-	return kInst;
+  return kInst;
 end
 
 -- ===========================================================================
---	View a list of all the City States that are alive and have been met.
+--  View a list of all the City States that are alive and have been met.
 -- ===========================================================================
 function ViewList()
 
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID == -1) then
-		return;
-	end
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID == -1) then
+    return;
+  end
 
-	if (m_kPlayerData == nil or m_kPlayerData.EnvoyTokens == nil) then
-		return;
-	end
+  if (m_kPlayerData == nil or m_kPlayerData.EnvoyTokens == nil) then
+    return;
+  end
 
-	-- Last minute switch; if there are envoy tokens left and at least one City-State has
-	-- been met, then allow player to change the # of envoys sent.
-	local numMet:number = GetCityStatesMetNum();
-	if m_kPlayerData.EnvoyTokens > 0 and numMet > 0 then
-		m_mode = MODE.SendEnvoys;
-	else
-		m_mode = MODE.Overview;
-	end
-	Controls.NoneMet:SetHide( numMet > 0 );
+  -- Last minute switch; if there are envoy tokens left and at least one City-State has
+  -- been met, then allow player to change the # of envoys sent.
+  local numMet:number = GetCityStatesMetNum();
+  if m_kPlayerData.EnvoyTokens > 0 and numMet > 0 then
+    m_mode = MODE.SendEnvoys;
+  else
+    m_mode = MODE.Overview;
+  end
+  Controls.NoneMet:SetHide( numMet > 0 );
 
-	Controls.ListOfCityStates:SetHide( false );
-	Controls.SingleCityState:SetHide( true );
-	RealizeListHeader( m_kPlayerData.EnvoyTokens );
+  Controls.ListOfCityStates:SetHide( false );
+  Controls.SingleCityState:SetHide( true );
+  RealizeListHeader( m_kPlayerData.EnvoyTokens );
 
-	-- Top list
-	m_CityStateRowIM:ResetInstances();
-	m_uiCityStateRows = {};
-	for iPlayer, kCityState in pairs( m_kCityStates ) do
-		if kCityState.isHasMet then
-			local kInst :table = AddCityStateRow( kCityState );
-			m_uiCityStateRows[iPlayer] = kInst;
-		end
-	end
+  -- Top list
+  m_CityStateRowIM:ResetInstances();
+  m_uiCityStateRows = {};
+  for iPlayer, kCityState in pairs( m_kCityStates ) do
+    if kCityState.isHasMet then
+      local kInst :table = AddCityStateRow( kCityState );
+      m_uiCityStateRows[iPlayer] = kInst;
+    end
+  end
 
-	if m_mode == MODE.SendEnvoys then
-		Controls.BonusArea:SetHide( false );
+  if m_mode == MODE.SendEnvoys then
+    Controls.BonusArea:SetHide( false );
 
-		-- Looping again, adding bonuses.
-		m_BonusCityHeaderIM:ResetInstances();
-		m_BonusItemIM:ResetInstances();
-		for iPlayer, kCityState in pairs( m_kCityStates ) do
+    -- Looping again, adding bonuses.
+    m_BonusCityHeaderIM:ResetInstances();
+    m_BonusItemIM:ResetInstances();
+    for iPlayer, kCityState in pairs( m_kCityStates ) do
 
-			-- At least the simplest of bonuses?
-			if kCityState.isBonus1 then
-				local kHeader	:table = m_BonusCityHeaderIM:GetInstance();
-				kHeader.CityName:SetText( Locale.ToUpper(  kCityState.Name ) );
+      -- At least the simplest of bonuses?
+      if kCityState.isBonus1 then
+        local kHeader  :table = m_BonusCityHeaderIM:GetInstance();
+        kHeader.CityName:SetText( Locale.ToUpper(  kCityState.Name ) );
 
-				local kItem		:table = m_BonusItemIM:GetInstance();
-				local textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 50 );
-				kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-				kItem.Icon:SetColor( kCityState.ColorSecondary );
-				kItem.Title:SetColor( kCityState.ColorSecondary );
-				kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Title );
-				kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Details );
+        local kItem    :table = m_BonusItemIM:GetInstance();
+        local textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 50 );
+        kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+        kItem.Icon:SetColor( kCityState.ColorSecondary );
+        kItem.Title:SetColor( kCityState.ColorSecondary );
+        kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Title );
+        kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Details );
 
-				if kCityState.isBonus3 then
-					kItem		= m_BonusItemIM:GetInstance();
-					kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
-					kItem.Icon:SetColor( kCityState.ColorSecondary );
-					kItem.Title:SetColor( kCityState.ColorSecondary );
-					kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Title );
-					kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Details );
-				end
+        if kCityState.isBonus3 then
+          kItem    = m_BonusItemIM:GetInstance();
+          kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );  -- Same as above
+          kItem.Icon:SetColor( kCityState.ColorSecondary );
+          kItem.Title:SetColor( kCityState.ColorSecondary );
+          kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Title );
+          kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Details );
+        end
 
-				if kCityState.isBonus6 then
-					kItem		= m_BonusItemIM:GetInstance();
-					kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
-					kItem.Icon:SetColor( kCityState.ColorSecondary );
-					kItem.Title:SetColor( kCityState.ColorSecondary );
-					kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Title );
-					kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Details );
-				end
+        if kCityState.isBonus6 then
+          kItem    = m_BonusItemIM:GetInstance();
+          kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );  -- Same as above
+          kItem.Icon:SetColor( kCityState.ColorSecondary );
+          kItem.Title:SetColor( kCityState.ColorSecondary );
+          kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Title );
+          kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Details );
+        end
 
-				if kCityState.isBonusSuzerain then
-					kItem		= m_BonusItemIM:GetInstance();
-					textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas("ICON_ENVOY_BONUS_SUZERAIN", 50);
-					kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-					kItem.Icon:SetColor( kCityState.ColorSecondary );
-					kItem.Title:SetColor( kCityState.ColorSecondary );
-					TruncateStringWithTooltip(kItem.Title, MAX_BEFORE_TRUNC_SUZERAIN, Locale.Lookup(kCityState.Bonuses["Suzerain"].Title));
-					kItem.Details:SetText( kCityState.Bonuses["Suzerain"].Details );
-					local PADDING:number = 40;
-					kItem.Top:SetSizeY( kItem.Details:GetSizeY() + PADDING );
-				end
+        if kCityState.isBonusSuzerain then
+          kItem    = m_BonusItemIM:GetInstance();
+          textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas("ICON_ENVOY_BONUS_SUZERAIN", 50);
+          kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+          kItem.Icon:SetColor( kCityState.ColorSecondary );
+          kItem.Title:SetColor( kCityState.ColorSecondary );
+          TruncateStringWithTooltip(kItem.Title, MAX_BEFORE_TRUNC_SUZERAIN, Locale.Lookup(kCityState.Bonuses["Suzerain"].Title));
+          kItem.Details:SetText( kCityState.Bonuses["Suzerain"].Details );
+          local PADDING:number = 40;
+          kItem.Top:SetSizeY( kItem.Details:GetSizeY() + PADDING );
+        end
 
-			end
-		end
+      end
+    end
 
-		Controls.BonusStack:CalculateSize();
-		Controls.BonusScroll:CalculateSize();
-		Controls.BonusArea:ReprocessAnchoring();
+    Controls.BonusStack:CalculateSize();
+    Controls.BonusScroll:CalculateSize();
+    Controls.BonusArea:ReprocessAnchoring();
 
-		local bonusAreaY:number = Controls.BonusArea:GetSizeY();
-		Controls.CityStateScroll:SetSizeY( m_height - (264 + bonusAreaY ) );
+    local bonusAreaY:number = Controls.BonusArea:GetSizeY();
+    Controls.CityStateScroll:SetSizeY( m_height - (264 + bonusAreaY ) );
 
-	else
-		Controls.BonusArea:SetHide( true );
-		Controls.CityStateScroll:SetSizeY( m_height - 210 );
-	end
+  else
+    Controls.BonusArea:SetHide( true );
+    Controls.CityStateScroll:SetSizeY( m_height - 210 );
+  end
 
-	Controls.ConfirmFrame:SetHide( m_mode ~= MODE.SendEnvoys );
-	Controls.ConfirmButton:SetDisabled( true );
+  Controls.ConfirmFrame:SetHide( m_mode ~= MODE.SendEnvoys );
+  Controls.ConfirmButton:SetDisabled( true );
 
-	Controls.CityStateStack:CalculateSize();
-	Controls.CityStateScroll:CalculateSize();
+  Controls.CityStateStack:CalculateSize();
+  Controls.CityStateScroll:CalculateSize();
 
-	RealizeEnvoyChangeButtons();
+  RealizeEnvoyChangeButtons();
 end
 
 
 -- ===========================================================================
 function ColorizeBonusItem( isHaveBonus:boolean, pInst:table, kCityState:table)
-	pInst.Check:SetHide( not isHaveBonus );
-	if isHaveBonus then
-		pInst.Icon:SetColor( kCityState.ColorSecondary );
-		pInst.Title:SetColor( kCityState.ColorSecondary );
-		pInst.Details:SetColorByName("CityStateCS");
-	else
-		pInst.Icon:SetColorByName("CityStateDisabledCS");
-		pInst.Title:SetColorByName("CityStateDisabledCS");
-		pInst.Details:SetColorByName("CityStateDisabledCS");
-	end
+  pInst.Check:SetHide( not isHaveBonus );
+  if isHaveBonus then
+    pInst.Icon:SetColor( kCityState.ColorSecondary );
+    pInst.Title:SetColor( kCityState.ColorSecondary );
+    pInst.Details:SetColorByName("CityStateCS");
+  else
+    pInst.Icon:SetColorByName("CityStateDisabledCS");
+    pInst.Title:SetColorByName("CityStateDisabledCS");
+    pInst.Details:SetColorByName("CityStateDisabledCS");
+  end
 end
 
 -- ===========================================================================
---	View detailed information for a single City State
+--  View detailed information for a single City State
 -- ===========================================================================
 function ViewCityState( iPlayer:number )
 
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID == -1) then
-		return;
-	end
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID == -1) then
+    return;
+  end
 
-	-- Create a column of City-States on the left side so a player can click
-	-- and instantly view them.
-	m_CityStateColumnIM:ResetInstances();
-	m_uiCityStateRows = {};
-	for _, kCityState in pairs( m_kCityStates ) do
-		if kCityState.isHasMet then
-			local kInst :table = m_CityStateColumnIM:GetInstance();
-			kInst.Icon:SetIcon( "ICON_"..kCityState.CivType );
-			kInst.Icon:SetColor( kCityState.ColorSecondary );
-			kInst.Icon:SetToolTipString( Locale.Lookup(kCityState.Name) );
+  -- Create a column of City-States on the left side so a player can click
+  -- and instantly view them.
+  m_CityStateColumnIM:ResetInstances();
+  m_uiCityStateRows = {};
+  for _, kCityState in pairs( m_kCityStates ) do
+    if kCityState.isHasMet then
+      local kInst :table = m_CityStateColumnIM:GetInstance();
+      kInst.Icon:SetIcon( "ICON_"..kCityState.CivType );
+      kInst.Icon:SetColor( kCityState.ColorSecondary );
+      kInst.Icon:SetToolTipString( Locale.Lookup(kCityState.Name) );
 
-			kInst.IconButton:SetColor( kCityState.ColorPrimary );
-			kInst.IconButton:SetVoid1( kCityState.iPlayer );
-			kInst.IconButton:RegisterCallback( Mouse.eLClick, OpenSingleViewCityState );
+      kInst.IconButton:SetColor( kCityState.ColorPrimary );
+      kInst.IconButton:SetVoid1( kCityState.iPlayer );
+      kInst.IconButton:RegisterCallback( Mouse.eLClick, OpenSingleViewCityState );
 
-			textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
-			kInst.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-			kInst.DiplomacyPip:SetToolTipString(tooltip);
-		end
-	end
-	Controls.CityStateIconStack:CalculateSize();
+      textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
+      kInst.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+      kInst.DiplomacyPip:SetToolTipString(tooltip);
+    end
+  end
+  Controls.CityStateIconStack:CalculateSize();
 
-	-- Grab city state, and then sanity check.  (We did have an error where a liberated city wasn't updated in the
-	-- cache and so if a player clicked the banner it would immediately bail.)
-	local kCityState:table= m_kCityStates[iPlayer];
-	if kCityState == nil then
-		UI.DataError("Attempt to show details for CityState player #"..tostring(iPlayer)..", but that doesn't exist!");
+  -- Grab city state, and then sanity check.  (We did have an error where a liberated city wasn't updated in the
+  -- cache and so if a player clicked the banner it would immediately bail.)
+  local kCityState:table= m_kCityStates[iPlayer];
+  if kCityState == nil then
+    UI.DataError("Attempt to show details for CityState player #"..tostring(iPlayer)..", but that doesn't exist!");
 
-		-- Best attempt to salvage error is to show the list view.
-		m_mode = MODE.Overview;
-		ViewList();
-		return;
-	end
+    -- Best attempt to salvage error is to show the list view.
+    m_mode = MODE.Overview;
+    ViewList();
+    return;
+  end
 
-	Controls.ListOfCityStates:SetHide( true);
-	Controls.SingleCityState:SetHide( false );
+  Controls.ListOfCityStates:SetHide( true);
+  Controls.SingleCityState:SetHide( false );
 
-	Controls.CityStateTypeIcon:SetIcon("ICON_"..kCityState.CivType);
-	Controls.CityStateTypeIcon:SetColor( kCityState.ColorSecondary );
-	Controls.CityStateTypeIcon:SetToolTipString( Locale.Lookup( GetTypeTooltip(kCityState) ));
-	Controls.CityStateName:SetText( Locale.ToUpper(kCityState.Name) );
+  Controls.CityStateTypeIcon:SetIcon("ICON_"..kCityState.CivType);
+  Controls.CityStateTypeIcon:SetColor( kCityState.ColorSecondary );
+  Controls.CityStateTypeIcon:SetToolTipString( Locale.Lookup( GetTypeTooltip(kCityState) ));
+  Controls.CityStateName:SetText( Locale.ToUpper(kCityState.Name) );
 
-	local textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
-	Controls.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-	Controls.DiplomacyPip:SetToolTipString(tooltip);
+  local textureOffsetX, textureOffsetY, textureSheet, tooltip = GetRelationshipPipAtlasPieces( kCityState );
+  Controls.DiplomacyPip:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+  Controls.DiplomacyPip:SetToolTipString(tooltip);
 
-	local warPeaceTooltip:string = "";
-	if kCityState.isAtWar then
-		Controls.PeaceWarButton:SetText( Locale.Lookup("LOC_CITY_STATES_MAKE_PEACE") );
-		Controls.PeaceWarButton:SetDisabled( not kCityState.CanMakePeaceWith );
-		if not kCityState.CanMakePeaceWith then
-			warPeaceTooltip = warPeaceTooltip .. Locale.Lookup("LOC_CITY_STATES_TURNS_WAR", m_iTurnsOfWar + kCityState.iTurnChanged - Game.GetCurrentGameTurn() );
-		end
-	else
-		Controls.PeaceWarButton:SetText( Locale.Lookup("LOC_CITY_STATES_DECLARE_WAR_BUTTON") );
-		Controls.PeaceWarButton:SetDisabled( not kCityState.CanDeclareWarOn );
-		warPeaceTooltip = warPeaceTooltip .. Locale.Lookup("LOC_CITY_STATES_DECLARE_WAR_DETAILS");
-		if not kCityState.CanDeclareWarOn then
-			warPeaceTooltip = warPeaceTooltip .. " " .. Locale.Lookup("LOC_CITY_STATES_TURNS_PEACE", m_iTurnsOfPeace + kCityState.iTurnChanged - Game.GetCurrentGameTurn() );
-		end
-	end
-	Controls.PeaceWarButton:SetToolTipString( warPeaceTooltip );
-	Controls.PeaceWarButton:RegisterCallback( Mouse.eLClick, function() OnChangeWarPeaceStatus( kCityState ); end );
+  local warPeaceTooltip:string = "";
+  if kCityState.isAtWar then
+    Controls.PeaceWarButton:SetText( Locale.Lookup("LOC_CITY_STATES_MAKE_PEACE") );
+    Controls.PeaceWarButton:SetDisabled( not kCityState.CanMakePeaceWith );
+    if not kCityState.CanMakePeaceWith then
+      warPeaceTooltip = warPeaceTooltip .. Locale.Lookup("LOC_CITY_STATES_TURNS_WAR", m_iTurnsOfWar + kCityState.iTurnChanged - Game.GetCurrentGameTurn() );
+    end
+  else
+    Controls.PeaceWarButton:SetText( Locale.Lookup("LOC_CITY_STATES_DECLARE_WAR_BUTTON") );
+    Controls.PeaceWarButton:SetDisabled( not kCityState.CanDeclareWarOn );
+    warPeaceTooltip = warPeaceTooltip .. Locale.Lookup("LOC_CITY_STATES_DECLARE_WAR_DETAILS");
+    if not kCityState.CanDeclareWarOn then
+      warPeaceTooltip = warPeaceTooltip .. " " .. Locale.Lookup("LOC_CITY_STATES_TURNS_PEACE", m_iTurnsOfPeace + kCityState.iTurnChanged - Game.GetCurrentGameTurn() );
+    end
+  end
+  Controls.PeaceWarButton:SetToolTipString( warPeaceTooltip );
+  Controls.PeaceWarButton:RegisterCallback( Mouse.eLClick, function() OnChangeWarPeaceStatus( kCityState ); end );
 
-	Controls.LevyMilitaryButton:SetDisabled(not kCityState.CanLevyMilitary);
-	if kCityState.HasLevyActive and kCityState.IsLocalPlayerSuzerain then
-		local levyTooltip = Locale.Lookup("LOC_CITY_STATES_MILITARY_ALREADY_LEVIED");
-		Controls.LevyMilitaryButton:SetToolTipString(levyTooltip);
-	else
-		local levyTooltip = Locale.Lookup("LOC_CITY_STATES_LEVY_MILITARY_DETAILS", kCityState.LevyMilitaryCost, kCityState.LevyMilitaryTurnLimit);
-		Controls.LevyMilitaryButton:SetToolTipString(levyTooltip);
-	end
-	Controls.LevyMilitaryButton:RegisterCallback( Mouse.eLClick, function() OnLevyMilitary( kCityState ); end );
+  Controls.LevyMilitaryButton:SetDisabled(not kCityState.CanLevyMilitary);
+  if kCityState.HasLevyActive and kCityState.IsLocalPlayerSuzerain then
+    local levyTooltip = Locale.Lookup("LOC_CITY_STATES_MILITARY_ALREADY_LEVIED");
+    Controls.LevyMilitaryButton:SetToolTipString(levyTooltip);
+  else
+    local levyTooltip = Locale.Lookup("LOC_CITY_STATES_LEVY_MILITARY_DETAILS", kCityState.LevyMilitaryCost, kCityState.LevyMilitaryTurnLimit);
+    Controls.LevyMilitaryButton:SetToolTipString(levyTooltip);
+  end
+  Controls.LevyMilitaryButton:RegisterCallback( Mouse.eLClick, function() OnLevyMilitary( kCityState ); end );
 
-	Controls.TypeValue:SetText( GetTypeName(kCityState) );
-	Controls.PatronValue:SetText( kCityState.SuzerainName );
-	Controls.InfluencedByValue:SetText( Locale.Lookup("LOC_CITY_STATES_CIVILIZATIONS",table.count(kCityState.Influence)) );
-	Controls.EnvoysSentValue:SetText( tostring(kCityState.Tokens) );
-	Controls.QuestsValue:SetText( tostring(table.count(kCityState.Quests)) );
+  Controls.TypeValue:SetText( GetTypeName(kCityState) );
+  Controls.PatronValue:SetText( kCityState.SuzerainName );
+  Controls.InfluencedByValue:SetText( Locale.Lookup("LOC_CITY_STATES_CIVILIZATIONS",table.count(kCityState.Influence)) );
+  Controls.EnvoysSentValue:SetText( tostring(kCityState.Tokens) );
+  Controls.QuestsValue:SetText( tostring(table.count(kCityState.Quests)) );
 
-	if m_mode == MODE.EnvoySent then
-		-- Setup the buttons and what (sub) areas are shown/hidden.
-		Controls.EnvoysSentButton:SetSelected( true );
-		Controls.InfluencedByButton:SetSelected( false );
-		Controls.QuestsButton:SetSelected( false );
+  if m_mode == MODE.EnvoySent then
+    -- Setup the buttons and what (sub) areas are shown/hidden.
+    Controls.EnvoysSentButton:SetSelected( true );
+    Controls.InfluencedByButton:SetSelected( false );
+    Controls.QuestsButton:SetSelected( false );
 
-		Controls.EnvoysSentArea:SetHide( false );
-		Controls.InfluenceArea:SetHide( true );
-		Controls.QuestsArea:SetHide( true );
+    Controls.EnvoysSentArea:SetHide( false );
+    Controls.InfluenceArea:SetHide( true );
+    Controls.QuestsArea:SetHide( true );
 
-		Controls.EnvoysSentValue2:SetText( tostring(kCityState.Tokens) );
+    Controls.EnvoysSentValue2:SetText( tostring(kCityState.Tokens) );
 
-		m_EnvoysBonusCityHeaderIM:ResetInstances();
-		m_EnvoysBonusItemIM:ResetInstances();
+    m_EnvoysBonusCityHeaderIM:ResetInstances();
+    m_EnvoysBonusItemIM:ResetInstances();
 
-		local kHeader	:table = m_EnvoysBonusCityHeaderIM:GetInstance();
-		kHeader.CityName:SetText( Locale.ToUpper( Locale.Lookup("LOC_CITY_STATES_BONUSES",kCityState.Name)) );
+    local kHeader  :table = m_EnvoysBonusCityHeaderIM:GetInstance();
+    kHeader.CityName:SetText( Locale.ToUpper( Locale.Lookup("LOC_CITY_STATES_BONUSES",kCityState.Name)) );
 
-		-- At least the simplest of bonuses?
-		local kItem		:table = m_EnvoysBonusItemIM:GetInstance();
-		local textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 50 );
-		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-		kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Title );
-		kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Details );
-		ColorizeBonusItem( kCityState.isBonus1, kItem, kCityState );
+    -- At least the simplest of bonuses?
+    local kItem    :table = m_EnvoysBonusItemIM:GetInstance();
+    local textureOffsetX, textureOffsetY, textureSheet = GetBonusIconAtlasPieces( kCityState, 50 );
+    kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+    kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Title );
+    kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_FIRST_BONUS].Details );
+    ColorizeBonusItem( kCityState.isBonus1, kItem, kCityState );
 
-		kItem		= m_EnvoysBonusItemIM:GetInstance();
-		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
-		kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Title );
-		kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Details );
-		ColorizeBonusItem( kCityState.isBonus3, kItem, kCityState );
+    kItem    = m_EnvoysBonusItemIM:GetInstance();
+    kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );  -- Same as above
+    kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Title );
+    kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_SECOND_BONUS].Details );
+    ColorizeBonusItem( kCityState.isBonus3, kItem, kCityState );
 
-		kItem		= m_EnvoysBonusItemIM:GetInstance();
-		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );	-- Same as above
-		kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Title );
-		kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Details );
-		ColorizeBonusItem( kCityState.isBonus6, kItem, kCityState );
+    kItem    = m_EnvoysBonusItemIM:GetInstance();
+    kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );  -- Same as above
+    kItem.Title:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Title );
+    kItem.Details:SetText( kCityState.Bonuses[NUM_ENVOY_TOKENS_FOR_THIRD_BONUS].Details );
+    ColorizeBonusItem( kCityState.isBonus6, kItem, kCityState );
 
-		kItem		= m_EnvoysBonusItemIM:GetInstance();
-		textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas("ICON_ENVOY_BONUS_SUZERAIN", 50);
-		kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
-		TruncateStringWithTooltip(kItem.Title, MAX_BEFORE_TRUNC_SUZERAIN, Locale.Lookup(kCityState.Bonuses["Suzerain"].Title));
-		kItem.Details:SetText( kCityState.Bonuses["Suzerain"].Details );
+    kItem    = m_EnvoysBonusItemIM:GetInstance();
+    textureOffsetX, textureOffsetY, textureSheet = IconManager:FindIconAtlas("ICON_ENVOY_BONUS_SUZERAIN", 50);
+    kItem.Icon:SetTexture( textureOffsetX, textureOffsetY, textureSheet );
+    TruncateStringWithTooltip(kItem.Title, MAX_BEFORE_TRUNC_SUZERAIN, Locale.Lookup(kCityState.Bonuses["Suzerain"].Title));
+    kItem.Details:SetText( kCityState.Bonuses["Suzerain"].Details );
 
-		local PADDING:number = 40;
-		kItem.Top:SetSizeY( kItem.Details:GetSizeY() + PADDING );
+    local PADDING:number = 40;
+    kItem.Top:SetSizeY( kItem.Details:GetSizeY() + PADDING );
 
-		Controls.EnvoysBonusStack:CalculateSize();
-		Controls.EnvoysBonusScroll:CalculateSize();
+    Controls.EnvoysBonusStack:CalculateSize();
+    Controls.EnvoysBonusScroll:CalculateSize();
 
-		ColorizeBonusItem( kCityState.isBonusSuzerain, kItem, kCityState );
+    ColorizeBonusItem( kCityState.isBonusSuzerain, kItem, kCityState );
 
-	elseif m_mode == MODE.InfluencedBy then
-		-- Setup the buttons and what (sub) areas are shown/hidden.
-		Controls.EnvoysSentButton:SetSelected( false );
-		Controls.InfluencedByButton:SetSelected( true );
-		Controls.QuestsButton:SetSelected( false );
+  elseif m_mode == MODE.InfluencedBy then
+    -- Setup the buttons and what (sub) areas are shown/hidden.
+    Controls.EnvoysSentButton:SetSelected( false );
+    Controls.InfluencedByButton:SetSelected( true );
+    Controls.QuestsButton:SetSelected( false );
 
-		Controls.EnvoysSentArea:SetHide( true );
-		Controls.InfluenceArea:SetHide( false );
-		Controls.QuestsArea:SetHide( true );
+    Controls.EnvoysSentArea:SetHide( true );
+    Controls.InfluenceArea:SetHide( false );
+    Controls.QuestsArea:SetHide( true );
 
-		m_InfluenceRowIM:ResetInstances();
+    m_InfluenceRowIM:ResetInstances();
 
-		-- First determine the large # of envoy tokens given for influence so
-		-- there can be a max for the ratio to set the bar.
-		local largestAmount:number = 0;
-		for iOtherPlayer,influence in pairs(kCityState.Influence) do
-			if influence > largestAmount then
-				largestAmount = influence;
-			end
-		end
+    -- First determine the large # of envoy tokens given for influence so
+    -- there can be a max for the ratio to set the bar.
+    local largestAmount:number = 0;
+    for iOtherPlayer,influence in pairs(kCityState.Influence) do
+      if influence > largestAmount then
+        largestAmount = influence;
+      end
+    end
 
-		-- Ensure highest influenced civilizations are at the top of the list
-		local kSortTable:table = {};
-		function SortHighestFirst(a, b)
-			local aOrder = kSortTable[ tostring( a ) ];
-			local bOrder = kSortTable[ tostring( b ) ];
-			if aOrder == nil then return false; end
-			if bOrder == nil then return true; end
-			return aOrder.influence > bOrder.influence;
-		end
+    -- Ensure highest influenced civilizations are at the top of the list
+    local kSortTable:table = {};
+    function SortHighestFirst(a, b)
+      local aOrder = kSortTable[ tostring( a ) ];
+      local bOrder = kSortTable[ tostring( b ) ];
+      if aOrder == nil then return false; end
+      if bOrder == nil then return true; end
+      return aOrder.influence > bOrder.influence;
+    end
 
-		-- Generate the information for each City-State
-		for iOtherPlayer,influence in pairs(kCityState.Influence) do
-			local kItem			:table	= m_InfluenceRowIM:GetInstance();
-			local pLocalPlayer	:table	= Players[localPlayerID];
-			local civName		:string = "LOCAL_CITY_STATES_UNKNOWN";
-			if (pLocalPlayer ~= nil) then
-				local pPlayerConfig :table = PlayerConfigurations[iOtherPlayer];
-				if (localPlayerID == iOtherPlayer) then
-					civName = Locale.Lookup(pPlayerConfig:GetPlayerName()) .. " (" .. Locale.Lookup("LOC_CITY_STATES_YOU") .. ")";
-				elseif (pLocalPlayer:GetDiplomacy():HasMet(iOtherPlayer)) then
-					civName = pPlayerConfig:GetPlayerName();
-				end
-			end
-			kItem.CityName:SetText( Locale.ToUpper(civName) );
-			kItem.AmountBar:SetPercent( influence / largestAmount);
-			kItem.Amount:SetText( tostring(influence) );
-			kSortTable[ tostring(kItem.GetTopControl()) ] = { influence = influence };	-- Store for sorting.
-		end
-		Controls.InfluenceStack:SortChildren( SortHighestFirst )
+    -- Generate the information for each City-State
+    for iOtherPlayer,influence in pairs(kCityState.Influence) do
+      local kItem      :table  = m_InfluenceRowIM:GetInstance();
+      local pLocalPlayer  :table  = Players[localPlayerID];
+      local civName    :string = "LOCAL_CITY_STATES_UNKNOWN";
+      if (pLocalPlayer ~= nil) then
+        local pPlayerConfig :table = PlayerConfigurations[iOtherPlayer];
+        if (localPlayerID == iOtherPlayer) then
+          civName = Locale.Lookup(pPlayerConfig:GetPlayerName()) .. " (" .. Locale.Lookup("LOC_CITY_STATES_YOU") .. ")";
+        elseif (pLocalPlayer:GetDiplomacy():HasMet(iOtherPlayer)) then
+          civName = pPlayerConfig:GetPlayerName();
+        end
+      end
+      kItem.CityName:SetText( Locale.ToUpper(civName) );
+      kItem.AmountBar:SetPercent( influence / largestAmount);
+      kItem.Amount:SetText( tostring(influence) );
+      kSortTable[ tostring(kItem.GetTopControl()) ] = { influence = influence };  -- Store for sorting.
+    end
+    Controls.InfluenceStack:SortChildren( SortHighestFirst )
 
-	elseif m_mode == MODE.Quests then
-		-- Setup the buttons and what (sub) areas are shown/hidden.
-		Controls.EnvoysSentButton:SetSelected( false );
-		Controls.InfluencedByButton:SetSelected( false );
-		Controls.QuestsButton:SetSelected( true );
+  elseif m_mode == MODE.Quests then
+    -- Setup the buttons and what (sub) areas are shown/hidden.
+    Controls.EnvoysSentButton:SetSelected( false );
+    Controls.InfluencedByButton:SetSelected( false );
+    Controls.QuestsButton:SetSelected( true );
 
-		Controls.EnvoysSentArea:SetHide( true );
-		Controls.InfluenceArea:SetHide( true );
-		Controls.QuestsArea:SetHide( false );
+    Controls.EnvoysSentArea:SetHide( true );
+    Controls.InfluenceArea:SetHide( true );
+    Controls.QuestsArea:SetHide( false );
 
-		m_QuestsIM:ResetInstances();
-		for _,kQuest in pairs( kCityState.Quests ) do
-			local kItem:table = m_QuestsIM:GetInstance();
-			kItem.Title:SetString( kQuest.Name );
-			kItem.Description:SetString( kQuest.Description );
-			kItem.Reward:SetString( kQuest.Reward );
-			kItem.Callout:SetString( kQuest.Callout );
-		end
+    m_QuestsIM:ResetInstances();
+    for _,kQuest in pairs( kCityState.Quests ) do
+      local kItem:table = m_QuestsIM:GetInstance();
+      kItem.Title:SetString( kQuest.Name );
+      kItem.Description:SetString( kQuest.Description );
+      kItem.Reward:SetString( kQuest.Reward );
+      kItem.Callout:SetString( kQuest.Callout );
+    end
 
-		Controls.QuestsStack:CalculateSize();
-		Controls.QuestsScroll:CalculateSize();
+    Controls.QuestsStack:CalculateSize();
+    Controls.QuestsScroll:CalculateSize();
 
-	else
-		UI.DataError("City-States in an unhandled mode '"..tostring(m_mode).."' when attempting to view a single City-State.");
-		return;
-	end
+  else
+    UI.DataError("City-States in an unhandled mode '"..tostring(m_mode).."' when attempting to view a single City-State.");
+    return;
+  end
 
-	Controls.SingleViewStack:CalculateSize();
+  Controls.SingleViewStack:CalculateSize();
 end
 
 
 -- ===========================================================================
---	Obtain data on city states
+--  Obtain data on city states
 -- ===========================================================================
 function GetData()
 
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID == -1) then
-		return;
-	end
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID == -1) then
+    return;
+  end
 
-	m_kCityStates = {};		-- Clear any previous data
-	m_kPlayerData = {};
-	m_kEnvoyChanges = {};
+  m_kCityStates = {};    -- Clear any previous data
+  m_kPlayerData = {};
+  m_kEnvoyChanges = {};
 
-	-- Collect information about current player
-	local pLocalPlayer			:table = Players[localPlayerID];
-	local isCanGiveInfluence	:boolean = false;
-	local pLocalPlayerInfluence	:table = pLocalPlayer:GetInfluence();
-	local envoyTokensAvailable	:number = 0;
-	if pLocalPlayerInfluence ~= nil then
-		envoyTokensAvailable = pLocalPlayerInfluence:GetTokensToGive();
-		if pLocalPlayerInfluence:CanGiveInfluence() and envoyTokensAvailable > 0 then
-			isCanGiveInfluence = true;
-		end
-	end
+  -- Collect information about current player
+  local pLocalPlayer      :table = Players[localPlayerID];
+  local isCanGiveInfluence  :boolean = false;
+  local pLocalPlayerInfluence  :table = pLocalPlayer:GetInfluence();
+  local envoyTokensAvailable  :number = 0;
+  if pLocalPlayerInfluence ~= nil then
+    envoyTokensAvailable = pLocalPlayerInfluence:GetTokensToGive();
+    if pLocalPlayerInfluence:CanGiveInfluence() and envoyTokensAvailable > 0 then
+      isCanGiveInfluence = true;
+    end
+  end
 
-	-- Build player specific data for interacting with CityStates
-	m_kPlayerData = {
-		EnvoyTokens = envoyTokensAvailable
-	}
+  -- Build player specific data for interacting with CityStates
+  m_kPlayerData = {
+    EnvoyTokens = envoyTokensAvailable
+  }
 
-	local isNewBonusAchieved:boolean = false;
+  local isNewBonusAchieved:boolean = false;
 
-	-- Every player that is in this game...
-	for i, pPlayer in ipairs(PlayerManager.GetAliveMinors()) do
-		local iPlayer = pPlayer:GetID();
-		local isCanReceiveInfluence		:boolean= false;
-		local envoyTokens				:number	= 0;
-		local envoyTokensMostReceived	:number	= 0;
-		local kInfluence				:table	= {};
-		local suzerainID				:number	= -1;
-		local pPlayerInfluence			:table	= pPlayer:GetInfluence();
-		if pPlayerInfluence ~= nil then
-			isCanReceiveInfluence	= pPlayerInfluence:CanReceiveInfluence();
-			envoyTokens				= pPlayerInfluence:GetTokensReceived(pLocalPlayer:GetID());
-			envoyTokensMostReceived = pPlayerInfluence:GetMostTokensReceived();
-			suzerainID				= pPlayerInfluence:GetSuzerain();
+  -- Every player that is in this game...
+  for i, pPlayer in ipairs(PlayerManager.GetAliveMinors()) do
+    local iPlayer = pPlayer:GetID();
+    local isCanReceiveInfluence    :boolean= false;
+    local envoyTokens        :number  = 0;
+    local envoyTokensMostReceived  :number  = 0;
+    local kInfluence        :table  = {};
+    local suzerainID        :number  = -1;
+    local pPlayerInfluence      :table  = pPlayer:GetInfluence();
+    if pPlayerInfluence ~= nil then
+      isCanReceiveInfluence  = pPlayerInfluence:CanReceiveInfluence();
+      envoyTokens        = pPlayerInfluence:GetTokensReceived(pLocalPlayer:GetID());
+      envoyTokensMostReceived = pPlayerInfluence:GetMostTokensReceived();
+      suzerainID        = pPlayerInfluence:GetSuzerain();
 
-			-- Take this CityState and compare against others to determine influence information.
-			for _, iInfluencePlayer in ipairs(PlayerManager.GetAliveMajorIDs()) do
-				local tokensReceived :number = pPlayerInfluence:GetTokensReceived( iInfluencePlayer );
-				if tokensReceived > 0 then
-					kInfluence[iInfluencePlayer] = tokensReceived;
-				end
-			end
+      -- Take this CityState and compare against others to determine influence information.
+      for _, iInfluencePlayer in ipairs(PlayerManager.GetAliveMajorIDs()) do
+        local tokensReceived :number = pPlayerInfluence:GetTokensReceived( iInfluencePlayer );
+        if tokensReceived > 0 then
+          kInfluence[iInfluencePlayer] = tokensReceived;
+        end
+      end
 
-		end
+    end
 
-		-- For all players (other than ourselves) and can receive influence (only CityStates)...
-		if iPlayer ~= pLocalPlayer:GetID() and isCanReceiveInfluence then
-			local primaryColor, secondaryColor = UI.GetPlayerColors( iPlayer );
+    -- For all players (other than ourselves) and can receive influence (only CityStates)...
+    if iPlayer ~= pLocalPlayer:GetID() and isCanReceiveInfluence then
+      local primaryColor, secondaryColor = UI.GetPlayerColors( iPlayer );
 
-			local suzerainName:string = Locale.Lookup("LOC_CITY_STATES_NONE");
-			if suzerainID ~=-1 then
-				if (suzerainID == localPlayerID) then
-					local pPlayerConfig :table = PlayerConfigurations[suzerainID];
-					suzerainName = Locale.Lookup("LOC_CITY_STATES_YOU");
-				elseif pLocalPlayer:GetDiplomacy():HasMet(suzerainID) then
-					local pPlayerConfig :table = PlayerConfigurations[suzerainID];
-					suzerainName = Locale.Lookup(pPlayerConfig:GetPlayerName());
-				else
-					suzerainName = Locale.Lookup("LOCAL_CITY_STATES_UNKNOWN");
-				end
-			end
+      local suzerainName:string = Locale.Lookup("LOC_CITY_STATES_NONE");
+      if suzerainID ~=-1 then
+        if (suzerainID == localPlayerID) then
+          local pPlayerConfig :table = PlayerConfigurations[suzerainID];
+          suzerainName = Locale.Lookup("LOC_CITY_STATES_YOU");
+        elseif pLocalPlayer:GetDiplomacy():HasMet(suzerainID) then
+          local pPlayerConfig :table = PlayerConfigurations[suzerainID];
+          suzerainName = Locale.Lookup(pPlayerConfig:GetPlayerName());
+        else
+          suzerainName = Locale.Lookup("LOCAL_CITY_STATES_UNKNOWN");
+        end
+      end
 
-			local cityStateType	:string = "";
-			local leader		:string = PlayerConfigurations[ iPlayer ]:GetLeaderTypeName();
-			local leaderInfo	:table	= GameInfo.Leaders[leader];
-			if leaderInfo == nil or leaderInfo.InheritFrom == nil then
-				UI.DataError("Cannot determine leader type for player #"..tostring( iPlayer ));
-				cityStateType = "unknown";
-			elseif (leader == "LEADER_MINOR_CIV_SCIENTIFIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_SCIENTIFIC") then
-				cityStateType = "SCIENTIFIC";
-			elseif (leader == "LEADER_MINOR_CIV_RELIGIOUS" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_RELIGIOUS") then
-				cityStateType = "RELIGIOUS";
-			elseif (leader == "LEADER_MINOR_CIV_TRADE" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_TRADE") then
-				cityStateType = "TRADE";
-			elseif (leader == "LEADER_MINOR_CIV_CULTURAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_CULTURAL") then
-				cityStateType = "CULTURE";
-			elseif (leader == "LEADER_MINOR_CIV_MILITARISTIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_MILITARISTIC") then
-				cityStateType = "MILITARISTIC";
-			elseif (leader == "LEADER_MINOR_CIV_INDUSTRIAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_INDUSTRIAL") then
-				cityStateType = "INDUSTRIAL";
-			end
+      local cityStateType  :string = "";
+      local leader    :string = PlayerConfigurations[ iPlayer ]:GetLeaderTypeName();
+      local leaderInfo  :table  = GameInfo.Leaders[leader];
+      if leaderInfo == nil or leaderInfo.InheritFrom == nil then
+        UI.DataError("Cannot determine leader type for player #"..tostring( iPlayer ));
+        cityStateType = "unknown";
+      elseif (leader == "LEADER_MINOR_CIV_SCIENTIFIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_SCIENTIFIC") then
+        cityStateType = "SCIENTIFIC";
+      elseif (leader == "LEADER_MINOR_CIV_RELIGIOUS" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_RELIGIOUS") then
+        cityStateType = "RELIGIOUS";
+      elseif (leader == "LEADER_MINOR_CIV_TRADE" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_TRADE") then
+        cityStateType = "TRADE";
+      elseif (leader == "LEADER_MINOR_CIV_CULTURAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_CULTURAL") then
+        cityStateType = "CULTURE";
+      elseif (leader == "LEADER_MINOR_CIV_MILITARISTIC" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_MILITARISTIC") then
+        cityStateType = "MILITARISTIC";
+      elseif (leader == "LEADER_MINOR_CIV_INDUSTRIAL" or leaderInfo.InheritFrom == "LEADER_MINOR_CIV_INDUSTRIAL") then
+        cityStateType = "INDUSTRIAL";
+      end
 
-			local leader	:string = PlayerConfigurations[iPlayer]:GetLeaderTypeName();
-			local civType	:string = GameInfo.CivilizationLeaders[leader].CivilizationType;
+      local leader  :string = PlayerConfigurations[iPlayer]:GetLeaderTypeName();
+      local civType  :string = GameInfo.CivilizationLeaders[leader].CivilizationType;
 
-			local iPlayerDiploState :number = pPlayer:GetDiplomaticAI():GetDiplomaticStateIndex( localPlayerID );
-			local diplomaticState	:string = nil;
-			if iPlayerDiploState ~= -1 then
-				diplomaticState = GameInfo.DiplomaticStates[iPlayerDiploState].StateType;
-			end
+      local iPlayerDiploState :number = pPlayer:GetDiplomaticAI():GetDiplomaticStateIndex( localPlayerID );
+      local diplomaticState  :string = nil;
+      if iPlayerDiploState ~= -1 then
+        diplomaticState = GameInfo.DiplomaticStates[iPlayerDiploState].StateType;
+      end
 
 
-			local kCityState :table		= {
-				iPlayer					= pPlayer:GetID(),
-				Bonuses					= {},
-				CanDeclareWarOn			= pLocalPlayer:GetDiplomacy():CanDeclareWarOn( iPlayer ),
-				CanLevyMilitary			= pLocalPlayer:GetInfluence():CanLevyMilitary( iPlayer ),
-				CanMakePeaceWith		= pLocalPlayer:GetDiplomacy():CanMakePeaceWith( iPlayer ),
-				CanReceiveTokensFrom	= pLocalPlayer:GetInfluence():CanGiveTokensToPlayer( iPlayer ),
-				ColorPrimary			= primaryColor,
-				ColorSecondary			= secondaryColor,
-				CivType					= civType,
-				DiplomaticState			= diplomaticState,
-				Government				= pPlayer:GetCulture():GetCurrentGovernment(),
-				Influence				= kInfluence,
-				Name					= PlayerConfigurations[iPlayer]:GetCivilizationShortDescription(),
-				isAlive					= pPlayer:IsAlive(),
-				isAtWar					= pLocalPlayer:GetDiplomacy():IsAtWarWith( iPlayer ),
-				isBonus1				= (envoyTokens >= NUM_ENVOY_TOKENS_FOR_FIRST_BONUS),	-- WARNING: Inferring game rules to set bonus thresholds.
-				isBonus3				= (envoyTokens >= NUM_ENVOY_TOKENS_FOR_SECOND_BONUS),	-- WARNING: Inferring game rules to set bonus thresholds.
-				isBonus6				= (envoyTokens >= NUM_ENVOY_TOKENS_FOR_THIRD_BONUS),	-- WARNING: Inferring game rules to set bonus thresholds.
-				isBonusSuzerain			= (suzerainID == localPlayerID),
-				isHasMet				= pLocalPlayer:GetDiplomacy():HasMet( iPlayer ),
-				iScore					= pPlayer:GetDiplomaticAI():GetDiplomaticScore( localPlayerID ),
-				iState					= iPlayerDiploState,
-				iTurnChanged			= pLocalPlayer:GetDiplomacy():GetAtWarChangeTurn( iPlayer ),
-				iVisibility				= pLocalPlayer:GetDiplomacy():GetVisibilityOn( iPlayer ),
-				iGameScore				= pPlayer:GetScore(),
-				LevyMilitaryCost		= pLocalPlayer:GetInfluence():GetLevyMilitaryCost( iPlayer ),
-				LevyMilitaryTurnLimit	= pPlayer:GetInfluence():GetLevyTurnLimit(),
-				HasLevyActive			= (pPlayer:GetInfluence():GetLevyTurnCounter() >= 0),
-				IsLocalPlayerSuzerain	= (pLocalPlayer:GetID() == suzerainID),
-				Quests					= GetQuests( iPlayer ),
-				SuzerainID				= suzerainID,
-				SuzerainName			= suzerainName,
-				SuzerainTokensNeeded	= envoyTokensMostReceived,
-				Tokens					= envoyTokens,
-				TokensMostReceived		= envoyTokensMostReceived,
-				Type					= cityStateType,
-			};
+      local kCityState :table    = {
+        iPlayer          = pPlayer:GetID(),
+        Bonuses          = {},
+        CanDeclareWarOn      = pLocalPlayer:GetDiplomacy():CanDeclareWarOn( iPlayer ),
+        CanLevyMilitary      = pLocalPlayer:GetInfluence():CanLevyMilitary( iPlayer ),
+        CanMakePeaceWith    = pLocalPlayer:GetDiplomacy():CanMakePeaceWith( iPlayer ),
+        CanReceiveTokensFrom  = pLocalPlayer:GetInfluence():CanGiveTokensToPlayer( iPlayer ),
+        ColorPrimary      = primaryColor,
+        ColorSecondary      = secondaryColor,
+        CivType          = civType,
+        DiplomaticState      = diplomaticState,
+        Government        = pPlayer:GetCulture():GetCurrentGovernment(),
+        Influence        = kInfluence,
+        Name          = PlayerConfigurations[iPlayer]:GetCivilizationShortDescription(),
+        isAlive          = pPlayer:IsAlive(),
+        isAtWar          = pLocalPlayer:GetDiplomacy():IsAtWarWith( iPlayer ),
+        isBonus1        = (envoyTokens >= NUM_ENVOY_TOKENS_FOR_FIRST_BONUS),  -- WARNING: Inferring game rules to set bonus thresholds.
+        isBonus3        = (envoyTokens >= NUM_ENVOY_TOKENS_FOR_SECOND_BONUS),  -- WARNING: Inferring game rules to set bonus thresholds.
+        isBonus6        = (envoyTokens >= NUM_ENVOY_TOKENS_FOR_THIRD_BONUS),  -- WARNING: Inferring game rules to set bonus thresholds.
+        isBonusSuzerain      = (suzerainID == localPlayerID),
+        isHasMet        = pLocalPlayer:GetDiplomacy():HasMet( iPlayer ),
+        iScore          = pPlayer:GetDiplomaticAI():GetDiplomaticScore( localPlayerID ),
+        iState          = iPlayerDiploState,
+        iTurnChanged      = pLocalPlayer:GetDiplomacy():GetAtWarChangeTurn( iPlayer ),
+        iVisibility        = pLocalPlayer:GetDiplomacy():GetVisibilityOn( iPlayer ),
+        iGameScore        = pPlayer:GetScore(),
+        LevyMilitaryCost    = pLocalPlayer:GetInfluence():GetLevyMilitaryCost( iPlayer ),
+        LevyMilitaryTurnLimit  = pPlayer:GetInfluence():GetLevyTurnLimit(),
+        HasLevyActive      = (pPlayer:GetInfluence():GetLevyTurnCounter() >= 0),
+        IsLocalPlayerSuzerain  = (pLocalPlayer:GetID() == suzerainID),
+        Quests          = GetQuests( iPlayer ),
+        SuzerainID        = suzerainID,
+        SuzerainName      = suzerainName,
+        SuzerainTokensNeeded  = envoyTokensMostReceived,
+        Tokens          = envoyTokens,
+        TokensMostReceived    = envoyTokensMostReceived,
+        Type          = cityStateType,
+      };
 
-			-- Make and changes to tokens needed based on range and who (if anyone) is Suzerain
-			if kCityState.SuzerainTokensNeeded < MIN_ENVOY_TOKENS_SUZERAIN then
-				kCityState.SuzerainTokensNeeded = MIN_ENVOY_TOKENS_SUZERAIN
-			elseif not kCityState.isBonusSuzerain then
-				kCityState.SuzerainTokensNeeded = kCityState.SuzerainTokensNeeded + 1;
-			end
+      -- Make and changes to tokens needed based on range and who (if anyone) is Suzerain
+      if kCityState.SuzerainTokensNeeded < MIN_ENVOY_TOKENS_SUZERAIN then
+        kCityState.SuzerainTokensNeeded = MIN_ENVOY_TOKENS_SUZERAIN
+      elseif not kCityState.isBonusSuzerain then
+        kCityState.SuzerainTokensNeeded = kCityState.SuzerainTokensNeeded + 1;
+      end
 
-			-- Obtain bonus text:
-			local title:string, details:string = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_FIRST_BONUS );
-			kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_FIRST_BONUS ] = { Title = title, Details = details }
-			if kCityState.isBonus1 then
-				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus1 then
-					isNewBonusAchieved = true;
-				end
-			end
-			title, details = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_SECOND_BONUS );
-			kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_SECOND_BONUS ] = { Title = title, Details = details }
-			if kCityState.isBonus3 then
-				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus3 then
-					isNewBonusAchieved = true;
-				end
-			end
-			title, details = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_THIRD_BONUS );
-			kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_THIRD_BONUS ] = { Title = title, Details = details }
-			if kCityState.isBonus6 then
-				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus6 then
-					isNewBonusAchieved = true;
-				end
-			end
-			details = GetSuzerainBonusText( iPlayer );
-			kCityState.Bonuses["Suzerain"] = {
-				Title = Locale.Lookup("LOC_CITY_STATES_SUZERAIN_ENVOYS"),
-				Details = details
-				}
-			if kCityState.isBonusSuzerain then
-				if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonusSuzerain then
-					isNewBonusAchieved = true;
-				end
-			end
+      -- Obtain bonus text:
+      local title:string, details:string = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_FIRST_BONUS );
+      kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_FIRST_BONUS ] = { Title = title, Details = details }
+      if kCityState.isBonus1 then
+        if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus1 then
+          isNewBonusAchieved = true;
+        end
+      end
+      title, details = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_SECOND_BONUS );
+      kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_SECOND_BONUS ] = { Title = title, Details = details }
+      if kCityState.isBonus3 then
+        if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus3 then
+          isNewBonusAchieved = true;
+        end
+      end
+      title, details = GetBonusText( iPlayer, NUM_ENVOY_TOKENS_FOR_THIRD_BONUS );
+      kCityState.Bonuses[ NUM_ENVOY_TOKENS_FOR_THIRD_BONUS ] = { Title = title, Details = details }
+      if kCityState.isBonus6 then
+        if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonus6 then
+          isNewBonusAchieved = true;
+        end
+      end
+      details = GetSuzerainBonusText( iPlayer );
+      kCityState.Bonuses["Suzerain"] = {
+        Title = Locale.Lookup("LOC_CITY_STATES_SUZERAIN_ENVOYS"),
+        Details = details
+        }
+      if kCityState.isBonusSuzerain then
+        if m_kLastCityStates ~= nil and not m_kLastCityStates[iPlayer].isBonusSuzerain then
+          isNewBonusAchieved = true;
+        end
+      end
 
-			-- Save to master table
-			m_kCityStates[iPlayer] = kCityState;
-		end
-	end
+      -- Save to master table
+      m_kCityStates[iPlayer] = kCityState;
+    end
+  end
 
-	-- Play sound if any city state just achieved a bonus.
-	if isNewBonusAchieved then
-		UI.PlaySound("Receive_Envoy_Bonus");
-	end
+  -- Play sound if any city state just achieved a bonus.
+  if isNewBonusAchieved then
+    UI.PlaySound("Receive_Envoy_Bonus");
+  end
 
-	-- Clear previous cached city states items and store currect.
-	m_kLastCityStates = nil;
+  -- Clear previous cached city states items and store currect.
+  m_kLastCityStates = nil;
 end
 
 
 -- ===========================================================================
---	UI EVENT
+--  UI EVENT
 -- ===========================================================================
 function OnInputHandler( input:table )
-	--if m_mode == MODE.EnvoySent or m_mode == MODE.InfluencedBy or m_mode == MODE.Quests then
-	return m_kScreenSlideAnim.OnInputHandler( input );
+  --if m_mode == MODE.EnvoySent or m_mode == MODE.InfluencedBy or m_mode == MODE.Quests then
+  return m_kScreenSlideAnim.OnInputHandler( input );
 end
 
 -- ===========================================================================
---	UI EVENT
+--  UI EVENT
 -- ===========================================================================
 function OnInit(isReload:boolean)
-	if isReload then
-		LuaEvents.GameDebug_GetValues(RELOAD_CACHE_ID);
-	end
+  if isReload then
+    LuaEvents.GameDebug_GetValues(RELOAD_CACHE_ID);
+  end
 end
 
 -- ===========================================================================
---	UI EVENT
+--  UI EVENT
 -- ===========================================================================
 function OnShutdown()
-	LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "isHidden", ContextPtr:IsHidden());
-	LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "m_mode", m_mode);
-	LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "m_iCurrentCityState", m_iCurrentCityState);
+  LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "isHidden", ContextPtr:IsHidden());
+  LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "m_mode", m_mode);
+  LuaEvents.GameDebug_AddValue(RELOAD_CACHE_ID, "m_iCurrentCityState", m_iCurrentCityState);
 end
 
 -- ===========================================================================
---	LUA EVENT
---	Reload support
+--  LUA EVENT
+--  Reload support
 -- ===========================================================================
 function OnGameDebugReturn(context:string, contextTable:table)
-	if context == RELOAD_CACHE_ID then
-		if contextTable["m_mode"] ~= nil				then m_mode = contextTable["m_mode"]; end
-		if contextTable["m_iCurrentCityState"] ~= nil	then m_iCurrentCityState = contextTable["m_iCurrentCityState"]; end
-		if contextTable["isHidden"] ~= nil and not contextTable["isHidden"] then
-			if		m_mode == MODE.Overview then OpenOverview();
-			elseif	m_mode == MODE.SendEnvoys then OnOpenSendEnvoys();
-			elseif	m_mode == MODE.EnvoySent or m_mode == MODE.InfluencedBy or m_mode == MODE.Quests then
-				m_kScreenSlideAnim.Show();
-				Refresh();
-			end
-		end
-	end
+  if context == RELOAD_CACHE_ID then
+    if contextTable["m_mode"] ~= nil        then m_mode = contextTable["m_mode"]; end
+    if contextTable["m_iCurrentCityState"] ~= nil  then m_iCurrentCityState = contextTable["m_iCurrentCityState"]; end
+    if contextTable["isHidden"] ~= nil and not contextTable["isHidden"] then
+      if    m_mode == MODE.Overview then OpenOverview();
+      elseif  m_mode == MODE.SendEnvoys then OnOpenSendEnvoys();
+      elseif  m_mode == MODE.EnvoySent or m_mode == MODE.InfluencedBy or m_mode == MODE.Quests then
+        m_kScreenSlideAnim.Show();
+        Refresh();
+      end
+    end
+  end
 end
 
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnCityLiberated(playerID:number, cityID:number)
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID == -1) then
-		return;
-	end
-	Refresh();
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID == -1) then
+    return;
+  end
+  Refresh();
 end
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnDiplomacyDeclareWar(firstPlayerID, secondPlayerID)
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID ~= nil) then
-		if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
-			m_kEnvoyChanges = {}; -- Zero out any pending envoy choices
-		end
-	end
-	Refresh();
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID ~= nil) then
+    if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
+      m_kEnvoyChanges = {}; -- Zero out any pending envoy choices
+    end
+  end
+  Refresh();
 end
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnDiplomacyMakePeace(firstPlayerID, secondPlayerID)
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID ~= nil) then
-		if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
-			m_kEnvoyChanges = {}; -- Zero out any pending envoy choices
-		end
-	end
-	Refresh();
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID ~= nil) then
+    if (localPlayerID == firstPlayerID or localPlayerID == secondPlayerID) then
+      m_kEnvoyChanges = {}; -- Zero out any pending envoy choices
+    end
+  end
+  Refresh();
 end
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnInfluenceChanged()
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID == -1) then
-		return;
-	end
-	Refresh();
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID == -1) then
+    return;
+  end
+  Refresh();
 end
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnInfluenceGiven()
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID == -1) then
-		return;
-	end
-	Refresh();
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID == -1) then
+    return;
+  end
+  Refresh();
 end
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
-	if eNewMode == InterfaceModeTypes.VIEW_MODAL_LENS then
-		Close();
-	end
+  if eNewMode == InterfaceModeTypes.VIEW_MODAL_LENS then
+    Close();
+  end
 end
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnQuestChanged()
-	local localPlayerID = Game.GetLocalPlayer();
-	if (localPlayerID == -1) then
-		return;
-	end
-	Refresh();
+  local localPlayerID = Game.GetLocalPlayer();
+  if (localPlayerID == -1) then
+    return;
+  end
+  Refresh();
 end
 
 -- ===========================================================================
---	Game Event
+--  Game Event
 -- ===========================================================================
 function OnUpdateUI( type:number, tag:string, iData1:number, iData2:number, strData1:string)
-	m_kScreenSlideAnim.OnUpdateUI( type, tag, iData1, iData2, strData1 );
-	if type == SystemUpdateUI.ScreenResize then
-		Resize();
-	end
+  m_kScreenSlideAnim.OnUpdateUI( type, tag, iData1, iData2, strData1 );
+  if type == SystemUpdateUI.ScreenResize then
+    Resize();
+  end
 end
 
 -- ===========================================================================
 function Resize()
-	_, m_height = UIManager:GetScreenSizeVal();
+  _, m_height = UIManager:GetScreenSizeVal();
 
-	local subMenuY:number = Controls.SubMenu:GetSizeY();
+  local subMenuY:number = Controls.SubMenu:GetSizeY();
 
-	Controls.EnvoysSentArea:SetSizeY( m_height - (360+subMenuY) );
-	Controls.InfluenceArea:SetSizeY( m_height - (360+subMenuY));
-	Controls.QuestsArea:SetSizeY( m_height - (360+subMenuY));
+  Controls.EnvoysSentArea:SetSizeY( m_height - (360+subMenuY) );
+  Controls.InfluenceArea:SetSizeY( m_height - (360+subMenuY));
+  Controls.QuestsArea:SetSizeY( m_height - (360+subMenuY));
 
-	Controls.EnvoysBonusScroll:SetSizeY( m_height - (424+subMenuY));
-	Controls.InfluenceScroll:SetSizeY( m_height - (424+subMenuY));
-	Controls.QuestsScroll:SetSizeY( m_height - (424+subMenuY));
+  Controls.EnvoysBonusScroll:SetSizeY( m_height - (424+subMenuY));
+  Controls.InfluenceScroll:SetSizeY( m_height - (424+subMenuY));
+  Controls.QuestsScroll:SetSizeY( m_height - (424+subMenuY));
 end
 
 -- ===========================================================================
---	Player Turn Events
+--  Player Turn Events
 -- ===========================================================================
 function OnLocalPlayerTurnBegin()
-	m_isLocalPlayerTurn = true;
-	if not ContextPtr:IsHidden() then
-		Refresh();
-	end
+  m_isLocalPlayerTurn = true;
+  if not ContextPtr:IsHidden() then
+    Refresh();
+  end
 end
 function OnLocalPlayerTurnEnd()
-	m_isLocalPlayerTurn = false;
-	if not ContextPtr:IsHidden() then
-		Refresh();
-	end
+  m_isLocalPlayerTurn = false;
+  if not ContextPtr:IsHidden() then
+    Refresh();
+  end
 end
 
 -- ===========================================================================
---	Initialize
+--  Initialize
 -- ===========================================================================
 function Initialize()
 
-	-- Check:
-	if	NUM_ENVOY_TOKENS_FOR_FIRST_BONUS   == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS or
-		NUM_ENVOY_TOKENS_FOR_SECOND_BONUS  == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS	or
-		NUM_ENVOY_TOKENS_FOR_FIRST_BONUS   == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then
-		alert("At least 2 city state bonuses have the same value, this will cause issues!");
-	end
+  -- Check:
+  if  NUM_ENVOY_TOKENS_FOR_FIRST_BONUS   == NUM_ENVOY_TOKENS_FOR_SECOND_BONUS or
+    NUM_ENVOY_TOKENS_FOR_SECOND_BONUS  == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS  or
+    NUM_ENVOY_TOKENS_FOR_FIRST_BONUS   == NUM_ENVOY_TOKENS_FOR_THIRD_BONUS then
+    alert("At least 2 city state bonuses have the same value, this will cause issues!");
+  end
 
-	m_kScreenSlideAnim = CreateScreenAnimation( Controls.SlideAnim );
+  m_kScreenSlideAnim = CreateScreenAnimation( Controls.SlideAnim );
 
-	-- UI Callbacks
-	Controls.CloseListButton:RegisterCallback( Mouse.eLClick, OnClose );
-	Controls.CloseBackButton:RegisterCallback( Mouse.eLClick, OnBackClose );
-	Controls.Title:SetText(Locale.ToUpper(Locale.Lookup("LOC_CITY_STATES_TITLE")));
-	Controls.ConfirmButton:RegisterCallback( Mouse.eLClick, OnConfirmPlacement );
-	Controls.EnvoysSentButton:RegisterCallback( Mouse.eLClick, OnEnvoySentClick );
-	Controls.InfluencedByButton:RegisterCallback( Mouse.eLClick, OnInfluencedByClick );
-	Controls.QuestsButton:RegisterCallback( Mouse.eLClick, OnQuestsClick );
+  -- UI Callbacks
+  Controls.CloseListButton:RegisterCallback( Mouse.eLClick, OnClose );
+  Controls.CloseBackButton:RegisterCallback( Mouse.eLClick, OnBackClose );
+  Controls.Title:SetText(Locale.ToUpper(Locale.Lookup("LOC_CITY_STATES_TITLE")));
+  Controls.ConfirmButton:RegisterCallback( Mouse.eLClick, OnConfirmPlacement );
+  Controls.EnvoysSentButton:RegisterCallback( Mouse.eLClick, OnEnvoySentClick );
+  Controls.InfluencedByButton:RegisterCallback( Mouse.eLClick, OnInfluencedByClick );
+  Controls.QuestsButton:RegisterCallback( Mouse.eLClick, OnQuestsClick );
 
-	-- UI Events
-	ContextPtr:SetInitHandler( OnInit );
-	ContextPtr:SetInputHandler(OnInputHandler, true);
-	ContextPtr:SetShutdown( OnShutdown );
+  -- UI Events
+  ContextPtr:SetInitHandler( OnInit );
+  ContextPtr:SetInputHandler(OnInputHandler, true);
+  ContextPtr:SetShutdown( OnShutdown );
 
-	-- Game Events
-	Events.CityLiberated.Add( OnCityLiberated );
-	Events.DiplomacyDeclareWar.Add( OnDiplomacyDeclareWar );
-	Events.DiplomacyMakePeace.Add( OnDiplomacyMakePeace );
-	Events.InfluenceChanged.Add( OnInfluenceChanged );
-	Events.InfluenceGiven.Add( OnInfluenceGiven );
-	Events.InterfaceModeChanged.Add( OnInterfaceModeChanged );
-	Events.QuestChanged.Add( OnQuestChanged );
-	Events.SystemUpdateUI.Add( OnUpdateUI );
-	Events.LocalPlayerTurnBegin.Add(OnLocalPlayerTurnBegin);
-	Events.LocalPlayerTurnEnd.Add(OnLocalPlayerTurnEnd);
-	Events.LocalPlayerChanged.Add(OnClose);
+  -- Game Events
+  Events.CityLiberated.Add( OnCityLiberated );
+  Events.DiplomacyDeclareWar.Add( OnDiplomacyDeclareWar );
+  Events.DiplomacyMakePeace.Add( OnDiplomacyMakePeace );
+  Events.InfluenceChanged.Add( OnInfluenceChanged );
+  Events.InfluenceGiven.Add( OnInfluenceGiven );
+  Events.InterfaceModeChanged.Add( OnInterfaceModeChanged );
+  Events.QuestChanged.Add( OnQuestChanged );
+  Events.SystemUpdateUI.Add( OnUpdateUI );
+  Events.LocalPlayerTurnBegin.Add(OnLocalPlayerTurnBegin);
+  Events.LocalPlayerTurnEnd.Add(OnLocalPlayerTurnEnd);
+  Events.LocalPlayerChanged.Add(OnClose);
 
-	-- LUA Events
-	LuaEvents.CityBannerManager_RaiseMinorCivPanel.Add( OnRaiseMinorCivicsPanel );
-	LuaEvents.GameDebug_Return.Add( OnGameDebugReturn );
-	LuaEvents.NotificationPanel_OpenCityStatesSendEnvoys.Add( OnOpenSendEnvoys );
-	LuaEvents.PartialScreenHooks_OpenCityStates.Add( OnOpenCityStates );
-	LuaEvents.PartialScreenHooks_CloseCityStates.Add( OnCloseCityStates );
-	LuaEvents.PartialScreenHooks_CloseAllExcept.Add( OnCloseAllExcept );
-	LuaEvents.WorldRankings_CloseCityStates.Add( OnClose );
+  -- LUA Events
+  LuaEvents.CityBannerManager_RaiseMinorCivPanel.Add( OnRaiseMinorCivicsPanel );
+  LuaEvents.GameDebug_Return.Add( OnGameDebugReturn );
+  LuaEvents.NotificationPanel_OpenCityStatesSendEnvoys.Add( OnOpenSendEnvoys );
+  LuaEvents.PartialScreenHooks_OpenCityStates.Add( OnOpenCityStates );
+  LuaEvents.PartialScreenHooks_CloseCityStates.Add( OnCloseCityStates );
+  LuaEvents.PartialScreenHooks_CloseAllExcept.Add( OnCloseAllExcept );
+  LuaEvents.WorldRankings_CloseCityStates.Add( OnClose );
 
-	Resize();
-	m_mode = MODE.Overview;
+  Resize();
+  m_mode = MODE.Overview;
 end
 Initialize();

--- a/UI/PartialScreens/CityStates.lua
+++ b/UI/PartialScreens/CityStates.lua
@@ -1,4 +1,4 @@
-﻿-- ===========================================================================
+-- ===========================================================================
 --	CityStates "Rundown" partial-screen
 --
 --	su·ze·rain (noun)
@@ -797,6 +797,49 @@ function AddCityStateRow( kCityState:table )
 	kInst.SuzerainLabel:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
 	kInst.Suzerain:SetColor( kCityState.isBonusSuzerain and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
 	kInst.Suzerain:SetText( kCityState.SuzerainName );
+
+	-- Begin CQUI Changes Marker
+	local localPlayerID = Game.GetLocalPlayer();
+	local secondHighestName :string = "";
+	local highestEnvoys :number = 0;
+	local secondHighestEnvoys :number = 0;
+	local secondHighestIsPlayer :boolean = false;
+
+	-- Iterate through all players that have influenced this city state
+	for iOtherPlayer,influence in pairs(kCityState.Influence) do
+		local pLocalPlayer	:table	= Players[localPlayerID];
+		local civName		:string = "LOCAL_CITY_STATES_UNKNOWN";
+		if (pLocalPlayer ~= nil) then
+			local pPlayerConfig :table = PlayerConfigurations[iOtherPlayer];
+			if (localPlayerID == iOtherPlayer) then
+				civName = Locale.Lookup("LOC_CITY_STATES_YOU");
+			elseif (pLocalPlayer:GetDiplomacy():HasMet(iOtherPlayer)) then
+				civName = pPlayerConfig:GetPlayerName();
+			end
+		end
+		-- Grab the second highest number of envoys plus the name of that civ. Prioritizes picking the player if there are ties.
+		if (influence > highestEnvoys) then
+		  highestEnvoys = influence;
+		elseif (influence >= secondHighestEnvoys and localPlayerID == iOtherPlayer) then
+		  secondHighestIsPlayer = true;
+			secondHighestEnvoys = influence;
+			secondHighestName = Locale.Lookup( civName );
+		elseif (influence > secondHighestEnvoys ) then
+      secondHighestIsPlayer = false;
+			secondHighestEnvoys = influence;
+			secondHighestName = Locale.Lookup( civName );
+		end
+	end
+
+	-- Add changes to the actual UI object placeholders, which are created in the CityStates.xml file
+	kInst.SecondHighestLabel:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	-- CQUI Note: SecondHighestLabel needs to be localized, but is hard coded for now
+	kInst.SecondHighestLabel:SetText( "2nd" );
+	kInst.SecondHighestName:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.SecondHighestName:SetText( secondHighestName );
+	kInst.SecondHighestEnvoys:SetColor( secondHighestIsPlayer and kCityState.ColorSecondary or COLOR_ICON_BONUS_OFF );
+	kInst.SecondHighestEnvoys:SetText( secondHighestEnvoys );
+	-- End CQUI Changes Marker
 
 	kInst.LookAtButton:SetVoid1( kCityState.iPlayer );
 	kInst.LookAtButton:RegisterCallback( Mouse.eLClick, LookAtCityState );

--- a/UI/PartialScreens/CityStates.xml
+++ b/UI/PartialScreens/CityStates.xml
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Context xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="..\..\..\..\..\CivTech\Libs\ForgeUI\ForgeUI_Assets\Controls.xsd">
+
+	<SlideAnim						ID="SlideAnim"					Anchor="R,T"									Size="514,full"				Start="-514,27" End="-1,27" Cycle="Once"	Speed="3.4" Function="OutSine" Stopped="1" >
+
+    <Grid																				Anchor="R,T"									Size="parent,parent+5"	Texture="Controls_BannerWide" SliceTextureSize="514,Sli" StretchMode="Tile" ConsumeMouse="1" >
+      <Image Texture="Controls_GradientSmall" Size="22,parent" AnchorSide="O,I" Anchor="L,T" Color="0,0,0,255" Rotate="90" Offset="-2,0"/>
+    </Grid>
+
+		<!-- List view of CityStates -->
+		<Container					ID="ListOfCityStates"																	Size="parent,parent">
+			<Grid							ID="HeaderBG"																					Size="parent,165"			Texture="Controls_TitleBarDark" SliceCorner="21,17" SliceTextureSize="42,34">
+				<Image																																Size="parent,parent"	Texture="Controls_Gradient_HalfRadial" Color="170,176,180,90" FlipY="1" />
+				<Grid																		Anchor="C,T"	Offset="22,60"	Size="396,58"					Texture="Controls_DecoFrame" SliceCorner="20,19" SliceTextureSize="40,38" Color="30,43,52,255">
+					<Label				ID="Header"							Anchor="C,C"  Offset="0,-7"													Style="CityStateHeaderText"		String="{LOC_CITY_STATES_OVERVIEW:upper}" />
+					<Label				ID="EnvoyDetails"				Anchor="C,C"	Offset="0,14"													Style="CityStateColumnHeaderText" String=""/>
+					<Container		ID="Envoys"						  Anchor="R,C"	AutoSize="H"		Size="24,24"					ToolTip="LOC_TOP_PANEL_INFLUENCE" Offset="5,2">
+						<Stack			ID="EnvoysStack"				Anchor="L,C"	Offset="0,-2"		StackGrowth="Right" >
+							<Image	  ID="EnvoysBacking"																		Size="24,24"					Texture="Controls_MeterTinyBacking">
+								<Label													Anchor="L,C"	Offset="1,1"		Style="FontNormal14"	ColorSet="TopBarValueCS" String="[ICON_Envoy]" />
+								<Meter  ID="EnvoysMeter"				Speed="1" Follow="1"					Size="24,24"					Texture="Controls_MeterTinyFill" />
+							</Image>
+						</Stack>
+					</Container>
+				</Grid>
+				<Image																								Offset="4,50"		Size="76,76"					Texture="CityStateOverview"/>
+				<Grid						ID="TitleBG"						Anchor="R,T"	Offset="-50,-2"	Size="600,74"					Texture="Controls_BannerHeaderRed" SliceCorner="371,0" SliceSize="1,74" SliceTextureSize="426,74">
+					<Label				ID="Title"							Anchor="L,T"	Offset="42,15"	Style="WorldRankingsTitle" />
+				</Grid>
+				<Container			ID="AllCityStates"																		Size="parent,parent" >
+					<Button				ID="CloseListButton"		Anchor="R,T"	Offset="0,56"		Style="CloseButtonSmall" />
+				</Container>
+				<Grid																		Anchor="L,B"	Offset="14,6"		Size="160,28"					Style="CityStateColumnHeaderGrid">
+					<Label																Anchor="L,C"  Offset="10,0"													Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_CITY_STATE" />
+				</Grid>
+				<Grid																		Anchor="L,B"	Offset="176,6"	Size="90,28"					Style="CityStateColumnHeaderGrid">
+					<Label																Anchor="C,C"																				Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_ENVOYS" />
+				</Grid>
+				<Grid																		Anchor="L,B"	Offset="268,6"	Size="198,28"					Style="CityStateColumnHeaderGrid">
+					<Label																Anchor="L,C"	Offset="10,0"													Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_BONUSES_EARNED" />
+				</Grid>
+			</Grid>
+
+			<ScrollPanel			ID="CityStateScroll"									Offset="12,164" Size="490,parent-174"				Vertical="1" AutoScrollBar="1">
+				<Stack					ID="CityStateStack"			Anchor="L,T"	Offset="0,1"		StackPadding="4" />
+				<ScrollBar															Anchor="R,C"	Offset="-1,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
+			</ScrollPanel>
+
+			<Label						ID="NoneMet"						Anchor="C,C"	Offset="0,50"		Align="Center" Style="FontFlair20" String="LOC_CITY_STATES_NONE_MET" Hidden="1"/>
+
+			<Grid							ID="BonusArea"					Anchor="L,B"	Offset="0,70"		Size="parent,parent-570"		Texture="Controls_Glow"					SliceCorner="90,90" SliceTextureSize="179,178"	Color="0,0,0,255" Hidden="1" >
+				<Grid						ID="BonusDecoLeft"										Offset="20,45"	Size="18,parent-50"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="30,36,40,255"   />
+				<Grid						ID="BonusDecoRight"			Anchor="R,T"	Offset="20,45"	Size="18,parent-50"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="30,36,40,255" SliceStart="20,0" />
+
+				<Grid						ID="BonusHeader"											Offset="0,0"		Size="parent,40"						Texture="Controls_TitleBarDark"	SliceCorner="21,17"	SliceTextureSize="42,34" >
+					<Image																															Size="parent,parent"				Texture="Controls_Gradient_HalfRadial"																					Color="170,176,180,35" />
+					<Label				ID="SubHeader"					Anchor="C,C"	Offset="0,3"																Style="FontFlair24"		Color0="170,176,180" String="{LOC_CITY_STATES_BONUSES_EARNED:upper}" SmallCaps="30" SmallCapsType="EveryWord" />
+				</Grid>
+				<ScrollPanel		ID="BonusScroll"											Offset="50,39"	Size="400,parent-39"				Vertical="1" >
+					<Stack				ID="BonusStack"					Anchor="L,T"	Offset="0,1"		StackPadding="4" />
+					<ScrollBar														Anchor="R,C"	Offset="10,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
+				</ScrollPanel>
+			</Grid>
+
+			<Grid																			Anchor="C,B"	Offset="1,-4"		Size="parent+5,32"					Texture="Controls_BannerBottom" SliceCorner="18,2" SliceTextureSize="37,32" />
+
+			<Grid							ID="ConfirmFrame"				Anchor="C,B"	Offset="0,10"		Size="parent-30,60"					Texture="Controls_ConfirmFrame" SliceCorner="38,30" SliceTextureSize="76,60" Hidden="1" >
+				<GridButton			ID="ConfirmButton"			Anchor="C,C"	Offset="0,-1"		Size="parent-70,41"					Texture="Controls_Confirm"			SliceCorner="40,20" SliceTextureSize="80,41" StateOffsetIncrement="0,41" String="LOC_CITY_STATES_CONFIRM_PLACEMENT"  Style="FontNormal16" />
+			</Grid>
+		</Container>
+
+		<!-- Individual CityState View -->
+		<Container						ID="SingleCityState"																	Size="parent,parent">
+			<Image																			Anchor="R,B"	Offset="3,0"		Size="47,239"								Texture="Diplomacy_RibbonBottom.dds" />
+			<Image																			Anchor="R,T"	Offset="3,0"		Size="47,parent-32"					Texture="Diplomacy_Ribbon.dds">
+				<Stack						ID="CityStateIconStack"								Offset="4,70"		StackGrowth="Bottom"				Padding="8" />
+			</Image>
+			<Grid																											Offset="3,70"		Size="parent-55,parent-70"	Style="DiplomacyInfoWindowGrid">
+				<Grid																																		Size="parent,165"						Style="DiplomacyInfoHeaderGrid" />
+				<Button						ID="CloseBackButton"		Anchor="R,T"									Style="BackButtonSmall" />
+				<Image																		Anchor="C,T"	Offset="0,-21"															Texture="Diplomacy_PortraitBacking" />
+				<Image																		Anchor="C,T"	Offset="0,-56"															Texture="CityState_HeaderCircle" />
+				<Image						ID="CityStateTypeIcon"	Anchor="C,T"	Offset="-1,-58"	Size="64,64"								Texture="CivSymbols64" />
+				<Image																		Anchor="C,T"	Offset="0,-64"															Texture="Diplomacy_YouIndicatorLarge" >
+					<Image					ID="DiplomacyPip"				Anchor="L,B"									Size="23,23"								Texture="Diplomacy_RelationshipPips" />
+				</Image>
+				<Label																		Anchor="C,T"	Offset="0,25"		Style="FontFlair16"					SmallCaps="26" SmallCapsType="EveryWord" String="{LOC_CITY_STATES_CITY_STATE:upper}" />
+				<Label						ID="CityStateName"			Anchor="C,T"	Offset="0,47"		Style="FontFlair24"					SmallCaps="30" SmallCapsType="EveryWord" String="$CityStateName$" />
+
+				<Stack						ID="SingleViewStack"									Offset="1,80"		StackGrowth="Bottom">
+					<Stack					ID="SubMenu"													Offset="1,0"		StackGrowth="Bottom"				StackPadding="-8">
+						<!-- TODO: REmove, using Back button
+						<GridButton		ID="SendAnEnvoyButton"																Size="parent-4,41"					Style="CityStateSubMenuButton" String="LOC_CITY_STATES_SEND_AN_ENVOY"/>
+						-->
+						<GridButton		ID="PeaceWarButton"																		Size="parent-4,41"					Style="CityStateSubMenuButton" String="LOC_CITY_STATES_MAKE_PEACE"/>
+						<GridButton		ID="LevyMilitaryButton"																Size="parent-4,41"					Style="CityStateSubMenuButton" String="LOC_CITY_STATES_LEVY_MILITARY_BUTTON"/>
+					</Stack>
+					<Grid																		Anchor="C,T"	Offset="0,0"		Size="parent-10,40"					Texture="Controls_TitleBarDark"	SliceCorner="21,17"	SliceTextureSize="42,34">
+						<Image																															Size="parent,parent"				Texture="Controls_Gradient_HalfRadial"																					Color="170,176,180,35" />
+						<Label																Anchor="C,C"	Offset="0,3"																Style="FontFlair24"		Color0="170,176,180" String="{LOC_CITY_STATES_REPORT:upper}" SmallCaps="30" SmallCapsType="EveryWord" />
+					</Grid>
+					<Box						ID="ReportArea"					Anchor="C,T"	Offset="0,0"		Size="parent-10,120"				Color="40,50,60,255">
+						<Box											  					Anchor="L,T"	Offset="1,1"		Size="parent-2,parent-2"		Color="3,4,5,255" />
+						<Image																Anchor="L,T"	Offset="1,1"		Size="parent-2,parent-2"		Texture="Controls_Gradient"																											Color="30,40,50,255" >
+							<Grid				ID="ReportDecoLeft"										Offset="5,5"		Size="18,parent-10"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="50,56,70,255"   />
+							<Grid				ID="ReportDecoRight"		Anchor="R,T"	Offset="5,5"		Size="20,parent-10"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="50,56,70,255" SliceStart="21,0" />
+							<Label															Anchor="R,T"	Offset="230,10"															Style="CityStateTextLabel"	String="LOC_CITY_STATES_TYPE" />
+							<Label			ID="TypeValue"					Anchor="L,T"	Offset="230,10"															Style="CityStateTextValue"	String="$TypeValue$" />
+							<Label															Anchor="R,T"	Offset="230,31"															Style="CityStateTextLabel"	String="LOC_CITY_STATES_SUZERAIN_LIST" />
+							<Label			ID="PatronValue"				Anchor="L,T"	Offset="230,31"															Style="CityStateTextValue"	String="$PatronValue$" />
+							<GridButton	ID="EnvoysSentButton"		Anchor="R,T"	Offset="224,50"	Size="170,21"								Style="CityStateTinyButton" String="LOC_CITY_STATES_ENVOYS_SENT" />
+							<Label			ID="EnvoysSentValue"		Anchor="L,T"	Offset="230,52"															Style="CityStateTextValue"	String="$EnvoysSentValue$" />
+							<GridButton	ID="InfluencedByButton"	Anchor="R,T"	Offset="224,71"	Size="170,21"								Style="CityStateTinyButton" String="LOC_CITY_STATES_INFLUENCED_BY" />
+							<Label			ID="InfluencedByValue"	Anchor="L,T"	Offset="230,73"															Style="CityStateTextValue"	String="$InfluencedByValue$" />
+							<GridButton	ID="QuestsButton"				Anchor="R,T"	Offset="224,92"	Size="170,21"								Style="CityStateTinyButton" String="LOC_CITY_STATES_QUESTS" />
+							<Label			ID="QuestsValue"				Anchor="L,T"	Offset="230,94"															Style="CityStateTextValue"	String="$QuestsValue$" />
+						</Image>
+					</Box>
+					<Container			ID="EnvoysSentArea"																		Size="parent,200" >
+						<Grid																								Offset="10,10"	Size="parent-20,40"					Style="CityStateStatHeader" >
+							<Label															Anchor="C,C"																							Style="FontFlair28"					String="LOC_CITY_STATES_ENVOYS_SENT" Color="170,176,180" />
+							<Container													Anchor="R,C"	Offset="17,1"		Size="1,1">
+								<Label		ID="EnvoysSentValue2"		Anchor="C,C"																							Style="FontFlair28"					String="0" Color="170,176,180" />
+							</Container>
+						</Grid>
+						<ScrollPanel	ID="EnvoysBonusScroll"								Offset="7,60"		Size="parent-25,265"				Vertical="1">
+							<Stack			ID="EnvoysBonusStack"		Anchor="L,T"	Offset="0,1"		StackPadding="4" />
+							<ScrollBar													Anchor="R,C"	Offset="0,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
+						</ScrollPanel>
+					</Container>
+					<Container			ID="InfluenceArea"																		Size="parent,200" Hidden="1">
+						<Grid																								Offset="10,10"	Size="parent-20,40"					Style="CityStateHeader" >
+							<Label															Anchor="C,C"																							Style="CityStateHeaderText"					String="{LOC_CITY_STATES_ENVOYS_INFLUENCE_BY_CIVILIZATION:upper}" />
+						</Grid>
+						<ScrollPanel	ID="InfluenceScroll"									Offset="7,60"		Size="parent-15,265"				Vertical="1">
+							<Stack			ID="InfluenceStack"			Anchor="L,T"	Offset="0,1"		StackPadding="4" />
+							<ScrollBar													Anchor="R,C"	Offset="4,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
+						</ScrollPanel>
+					</Container>
+					<Container			ID="QuestsArea"																				Size="parent,200"	Hidden="1" >
+						<Grid																								Offset="10,10"	Size="parent-20,40"					Style="CityStateHeader" >
+							<Label															Anchor="C,C"																							Style="CityStateHeaderText"					String="{LOC_CITY_STATES_AVAILABLE_QUESTS:upper}" />
+						</Grid>
+						<ScrollPanel	ID="QuestsScroll"											Offset="7,60"		Size="parent-15,265"				Vertical="1" >
+							<Stack			ID="QuestsStack"				Anchor="L,T"	Offset="0,1"		StackPadding="20" />
+							<ScrollBar													Anchor="R,C"	Offset="-12,0"	AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
+						</ScrollPanel>
+					</Container>
+				</Stack>
+			</Grid>
+		</Container>
+
+	</SlideAnim>
+
+
+	<!-- ==================================================================	-->
+	<!--	Instances																													-->
+	<!-- ==================================================================	-->
+
+	<Instance				Name="CityStateRowInstance">
+		<GridButton		ID="CityStateBase"																			Size="parent,48"			Style="SubContainer4" Color="59,62,63,255" >
+			<BoxButton  ID="Button"								Anchor="L,C"	Offset="8,0"		Size="40,40"					Color="0,0,0,0">
+				<Image    ID="Icon"									Anchor="L,C"									Size="36,36"					Texture="CivSymbols36" />
+				<Image		ID="DiplomacyPip"					Anchor="L,B"	Offset="-10,-6"	Size="23,23"								Texture="Diplomacy_RelationshipPips" />
+				<Label    ID="QuestIcon"            Anchor="L,T"  Offset="-9,0"  String="[ICON_CityStateQuest]" />
+			</BoxButton>
+
+			<GridButton ID="NameButton"													Offset="42,9"		Size="126,33" Texture="Controls_CityBannerSmall" SliceCorner="14,9" SliceSize="5,4" SliceTextureSize="33,28" Color="50,50,50,255">
+				<Label		ID="NameLabel"						Anchor="C,C"	Offset="0,-2"		Style="FontFlair11"		SmallCaps="16" SmallCapsStyle="EveryWord"					String="Name"/>
+			</GridButton>
+
+			<Image      ID="Envoy"								Anchor="L,C"	Offset="190,0"	Size="40,40"					Texture="Controls_CircleRim40">
+				<Button		ID="EnvoyLessButton"			Anchor="L,C"	Offset="-6,0"		Size="34,34"					Texture="Controls_Stepper" AnchorSide="O,I" FlipX="1" />
+				<Button		ID="EnvoyMoreButton"			Anchor="R,C"	Offset="-6,0"		Size="34,34"					Texture="Controls_Stepper" AnchorSide="O,I" />
+				<Label		ID="EnvoyCount"						Anchor="C,C"	Offset="-1,1"		String="0"						Style="FontFlairLua"				Color="160,160,160,240" />
+			</Image>
+
+			<Image			ID="BonusImage1"					Anchor="L,C"	Offset="256,0"	Size="29,42"					Texture="CityState_BonusSlotOff" >
+				<Label		ID="BonusText1"						Anchor="R,T"	Offset="3,2"													Style="FontNormal12"							String="1" />
+				<Image		ID="BonusIcon1"						Anchor="C,B"									Size="26,26"					Texture="EnvoyBonuses26"					TextureOffset="104,0"	/>
+			</Image>
+			<Image			ID="BonusImage3"					Anchor="L,C"	Offset="286,0"	Size="29,42"					Texture="CityState_BonusSlotOn">
+				<Label		ID="BonusText3"						Anchor="R,T"	Offset="3,2"													Style="FontNormal12"							String="3" />
+				<Image		ID="BonusIcon3"						Anchor="C,B"									Size="26,26"					Texture="EnvoyBonuses26"					TextureOffset="104,0"	/>
+			</Image>
+			<Image			ID="BonusImage6"					Anchor="L,C"	Offset="316,0"	Size="29,42"					Texture="CityState_BonusSlotOn">
+				<Label		ID="BonusText6"						Anchor="R,T"	Offset="3,2"													Style="FontNormal12"							String="6" />
+				<Image		ID="BonusIcon6"						Anchor="C,B"									Size="26,26"					Texture="EnvoyBonuses26"					TextureOffset="104,0"	/>
+			</Image>
+			<Container														Anchor="L,C"	Offset="346,0"	Size="108,42">
+				<Grid			ID="BonusImageSuzerainOff"															Size="parent,parent"	Texture="CityState_BonusSlotBigOff" SliceCorner="31,21" SliceTextureSize="34,42"	/>
+				<Grid			ID="BonusImageSuzerainOn"																Size="parent,parent"	Texture="CityState_BonusSlotBigOn"	SliceCorner="31,21" SliceTextureSize="34,42"		/>
+				<Label		ID="BonusTextSuzerain"		Anchor="R,T"	Offset="4,2"													Style="FontNormal12"								String="4" />
+				<Image		ID="BonusIconSuzerain"		Anchor="L,B"	Offset="2,0"		Size="26,26"					Texture="EnvoyBonuses26"						TextureOffset="156,0"	/>
+				<Label		ID="SuzerainLabel"				Anchor="L,B"	Offset="32,14"												Style="FontNormal12"								String="LOC_CITY_STATES_SUZERAIN" />
+				<Label		ID="Suzerain"							Anchor="L,B"	Offset="32,2"													Style="FontNormal12"								String="LOC_CITY_STATES_NONE" />
+			</Container>
+
+			<Button			ID="LookAtButton"					Anchor="R,C"	Offset="10,-7"		Size="23,31"					Texture="Controls_ShowMe"					StateOffsetIncrement="0,0"	ToolTip="LOC_CITY_STATES_LOOK_AT" />
+
+			<Label			ID="TypeLabel"						Anchor="L,C"	Offset="125,0"												Style="FontNormal16"	Hidden="1"	String="[ICON_Faith]Religious" Note="DEPRECATED" />
+			<Label			ID="QuestsLabel"					Anchor="L,C"	Offset="250,0"												Style="FontNormal16"	Hidden="1"	String="[COLOR_GREEN]![ENDCOLOR]"/>
+			<GridButton ID="GiveTokenButton"			Anchor="L,C"	Offset="270,0"	Size="140,32"					Style="MainButton"		Hidden="1"	String="Send Envoy"/>
+			<Label			ID="CurrentTokensLabel"		Anchor="L,C"	Offset="415,0"												Style="FontNormal16"	Hidden="1"	String="Current Tokens"/>
+			<Label			ID="TypeBonusLabel"				Anchor="L,C"	Offset="510,0"												Style="FontNormal16"	Hidden="1"	String="Next Bonus"/>
+			<Label			ID="UniqueBonusLabel"			Anchor="L,C"	Offset="620,0"												Style="FontNormal16"	Hidden="1"	String="Most Tokens Y/N?"/>
+			<!--
+			<GridButton ID="LevyMilitaryButton"		Anchor="R,C"	Offset="150,0"	Size="140,32"					Style="MainButton"		Hidden="1"	String="Levy Military"/>
+			<GridButton ID="ChangeWarStateButton" Anchor="R,C"	Offset="0,0"		Size="140,32"					Style="MainButton"		Hidden="1"	String="Declare War!"/>
+			-->
+		</GridButton>
+	</Instance>
+
+	<Instance				Name="BonusCityHeaderInstance">
+		<Container		ID="Top"			Anchor="L,C" AutoSize="H" Size="parent,16" >
+			<Grid											Anchor="C,C"							Size="parent,8" Texture="Controls_Div2"  SliceCorner="27,4" SliceTextureSize="54,8" Color="27,40,48,255" />
+			<Image										Anchor="C,C"							Size="parent,16"			Texture="Controls_Glow"		Color="0,0,0,255" StretchMode="Fill" />
+			<Label			ID="CityName" Anchor="C,C" String="$City$" Style="FontFlair14" SmallCaps="18" SmallCapsType="EveryWord" 	Color="255,255,255,120" />
+		</Container>
+	</Instance>
+
+	<Instance				Name="BonusItemOnInstance">
+		<Grid					ID="Top"			Anchor="L,T"									Size="parent,72"				Texture="CityState_BonusFrameOn" SliceCorner="65,29" SliceTextureSize="74,58" >
+			<Image			ID="Icon"			Anchor="L,T"	Offset="4,5"		Size="50,50"						Texture="EnvoyBonuses50"			/>
+			<Label			ID="Title"		Anchor="L,T"	Offset="70,6"														Style="FontNormal14"	String="$BonusTitle$ - GameCore does not expose this yet." />
+			<Container															Offset="55,0"		Size="parent-55,parent"	>
+				<Label		ID="Details"	Anchor="L,T"	Offset="25,24"	WrapWidth="320"					Style="FontNormal14"	String="$Details$ - GameCore does not expose this yet." ColorSet="CityStateCS" />
+			</Container>
+			<Label			ID="Check"		Anchor="R,T"	Offset="8,10" String="[ICON_Checkmark]" Hidden="1" />
+		</Grid>
+	</Instance>
+
+	<Instance				Name="CityStateIconInstance">
+		<Container		ID="Top"					Anchor="L,C"									Size="40,40" >
+			<Button			ID="IconButton"		Anchor="C,C"									Size="44,44"								Texture="CircleBacking44" NoStateChange="1">
+				<Image		ID="Icon"					Anchor="C,C"									Size="44,44"	/>
+				<Image		ID="DiplomacyPip"	Anchor="L,B"	Offset="-8,-8"	Size="23,23"								Texture="Diplomacy_RelationshipPips" />
+			</Button>
+		</Container>
+	</Instance>
+
+	<Instance				Name="InfluenceRowInstance">
+		<Container		ID="Top"					Anchor="L,C" Offset="10,0" Size="parent-24,30" >
+			<Label			ID="CityName"			Anchor="L,T" String="$City$" Style="FontFlair14" SmallCaps="18" SmallCapsType="EveryWord" 	ColorSet="CityStateCS" />
+			<Bar				ID="AmountBar"		Anchor="L,B"									Size="parent-40,16" Direction="Right" FGColor="200,190,169" Percent="1.0" />
+			<Stack												Anchor="R,B" Offset="0,-4" StackGrowth="Left">
+				<!-- TODO: non-font icon version<Image Icon="" /> -->
+				<Label		ID="Amount"				Style="FontFlair24" String="0" Color="200,190,169,255" />
+				<Label											Style="FontFlair24" String="[Icon_Envoy]" Color="200,190,169,255" />
+			</Stack>
+		</Container>
+	</Instance>
+
+	<Instance				Name="QuestInstance">
+		<Container		ID="Top"							Anchor="L,C" AutoSize="V"		Size="parent-15,24" >
+			<Image																												Size="42,33" Texture="CityStateQuest42">
+				<Label		ID="Callout"					Anchor="C,T"	Offset="0,3" String="[ICON_Government]" Style="FontNormal16" Color="10,20,30,200" />
+			</Image>
+			<Stack			StackGrowth="Bottom" StackPadding="2">
+				<Label		ID="Title"													Offset="45,0"												Style="FontFlair16"			String="$Title$"				ColorSet="CityStateCS" />
+				<Label		ID="Description"										Offset="45,0"	WrapWidth="parent-35"	Style="FontNormal14"		String="$Description$"	Color="255,255,255,255"/>
+				<Grid																					Offset="0,5"	Size="parent,20"			Style="SubContainer4"		Color="25,33,38,255">
+					<Label												Anchor="L,C"	Offset="18,0"												Style="FontNormal14"		String="LOC_CITY_STATES_REWARD" ColorSet="CityStateCS" />
+					<Label	ID="Reward"						Anchor="R,C"	Offset="8,0"												Style="FontNormal14"		String="$Reward$"								ColorSet="CityStateCS" />
+				</Grid>
+			</Stack>
+		</Container>
+	</Instance>
+
+
+</Context>

--- a/UI/PartialScreens/CityStates.xml
+++ b/UI/PartialScreens/CityStates.xml
@@ -1,275 +1,275 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Context xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="..\..\..\..\..\CivTech\Libs\ForgeUI\ForgeUI_Assets\Controls.xsd">
 
-	<SlideAnim						ID="SlideAnim"					Anchor="R,T"									Size="514,full"				Start="-514,27" End="-1,27" Cycle="Once"	Speed="3.4" Function="OutSine" Stopped="1" >
+  <SlideAnim            ID="SlideAnim"          Anchor="R,T"                  Size="514,full"        Start="-514,27" End="-1,27" Cycle="Once"  Speed="3.4" Function="OutSine" Stopped="1" >
 
-    <Grid																				Anchor="R,T"									Size="parent,parent+5"	Texture="Controls_BannerWide" SliceTextureSize="514,Sli" StretchMode="Tile" ConsumeMouse="1" >
+    <Grid                                        Anchor="R,T"                  Size="parent,parent+5"  Texture="Controls_BannerWide" SliceTextureSize="514,Sli" StretchMode="Tile" ConsumeMouse="1" >
       <Image Texture="Controls_GradientSmall" Size="22,parent" AnchorSide="O,I" Anchor="L,T" Color="0,0,0,255" Rotate="90" Offset="-2,0"/>
     </Grid>
 
-		<!-- List view of CityStates -->
-		<Container					ID="ListOfCityStates"																	Size="parent,parent">
-			<Grid							ID="HeaderBG"																					Size="parent,165"			Texture="Controls_TitleBarDark" SliceCorner="21,17" SliceTextureSize="42,34">
-				<Image																																Size="parent,parent"	Texture="Controls_Gradient_HalfRadial" Color="170,176,180,90" FlipY="1" />
-				<Grid																		Anchor="C,T"	Offset="22,60"	Size="396,58"					Texture="Controls_DecoFrame" SliceCorner="20,19" SliceTextureSize="40,38" Color="30,43,52,255">
-					<Label				ID="Header"							Anchor="C,C"  Offset="0,-7"													Style="CityStateHeaderText"		String="{LOC_CITY_STATES_OVERVIEW:upper}" />
-					<Label				ID="EnvoyDetails"				Anchor="C,C"	Offset="0,14"													Style="CityStateColumnHeaderText" String=""/>
-					<Container		ID="Envoys"						  Anchor="R,C"	AutoSize="H"		Size="24,24"					ToolTip="LOC_TOP_PANEL_INFLUENCE" Offset="5,2">
-						<Stack			ID="EnvoysStack"				Anchor="L,C"	Offset="0,-2"		StackGrowth="Right" >
-							<Image	  ID="EnvoysBacking"																		Size="24,24"					Texture="Controls_MeterTinyBacking">
-								<Label													Anchor="L,C"	Offset="1,1"		Style="FontNormal14"	ColorSet="TopBarValueCS" String="[ICON_Envoy]" />
-								<Meter  ID="EnvoysMeter"				Speed="1" Follow="1"					Size="24,24"					Texture="Controls_MeterTinyFill" />
-							</Image>
-						</Stack>
-					</Container>
-				</Grid>
-				<Image																								Offset="4,50"		Size="76,76"					Texture="CityStateOverview"/>
-				<Grid						ID="TitleBG"						Anchor="R,T"	Offset="-50,-2"	Size="600,74"					Texture="Controls_BannerHeaderRed" SliceCorner="371,0" SliceSize="1,74" SliceTextureSize="426,74">
-					<Label				ID="Title"							Anchor="L,T"	Offset="42,15"	Style="WorldRankingsTitle" />
-				</Grid>
-				<Container			ID="AllCityStates"																		Size="parent,parent" >
-					<Button				ID="CloseListButton"		Anchor="R,T"	Offset="0,56"		Style="CloseButtonSmall" />
-				</Container>
-				<Grid																		Anchor="L,B"	Offset="14,6"		Size="160,28"					Style="CityStateColumnHeaderGrid">
-					<Label																Anchor="L,C"  Offset="10,0"													Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_CITY_STATE" />
-				</Grid>
-				<Grid																		Anchor="L,B"	Offset="176,6"	Size="90,28"					Style="CityStateColumnHeaderGrid">
-					<Label																Anchor="C,C"																				Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_ENVOYS" />
-				</Grid>
-				<Grid																		Anchor="L,B"	Offset="268,6"	Size="198,28"					Style="CityStateColumnHeaderGrid">
-					<Label																Anchor="L,C"	Offset="10,0"													Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_BONUSES_EARNED" />
-				</Grid>
-			</Grid>
+    <!-- List view of CityStates -->
+    <Container          ID="ListOfCityStates"                                  Size="parent,parent">
+      <Grid              ID="HeaderBG"                                          Size="parent,165"      Texture="Controls_TitleBarDark" SliceCorner="21,17" SliceTextureSize="42,34">
+        <Image                                                                Size="parent,parent"  Texture="Controls_Gradient_HalfRadial" Color="170,176,180,90" FlipY="1" />
+        <Grid                                    Anchor="C,T"  Offset="22,60"  Size="396,58"          Texture="Controls_DecoFrame" SliceCorner="20,19" SliceTextureSize="40,38" Color="30,43,52,255">
+          <Label        ID="Header"              Anchor="C,C"  Offset="0,-7"                          Style="CityStateHeaderText"    String="{LOC_CITY_STATES_OVERVIEW:upper}" />
+          <Label        ID="EnvoyDetails"        Anchor="C,C"  Offset="0,14"                          Style="CityStateColumnHeaderText" String=""/>
+          <Container    ID="Envoys"              Anchor="R,C"  AutoSize="H"    Size="24,24"          ToolTip="LOC_TOP_PANEL_INFLUENCE" Offset="5,2">
+            <Stack      ID="EnvoysStack"        Anchor="L,C"  Offset="0,-2"    StackGrowth="Right" >
+              <Image    ID="EnvoysBacking"                                    Size="24,24"          Texture="Controls_MeterTinyBacking">
+                <Label                          Anchor="L,C"  Offset="1,1"    Style="FontNormal14"  ColorSet="TopBarValueCS" String="[ICON_Envoy]" />
+                <Meter  ID="EnvoysMeter"        Speed="1" Follow="1"          Size="24,24"          Texture="Controls_MeterTinyFill" />
+              </Image>
+            </Stack>
+          </Container>
+        </Grid>
+        <Image                                                Offset="4,50"    Size="76,76"          Texture="CityStateOverview"/>
+        <Grid            ID="TitleBG"            Anchor="R,T"  Offset="-50,-2"  Size="600,74"          Texture="Controls_BannerHeaderRed" SliceCorner="371,0" SliceSize="1,74" SliceTextureSize="426,74">
+          <Label        ID="Title"              Anchor="L,T"  Offset="42,15"  Style="WorldRankingsTitle" />
+        </Grid>
+        <Container      ID="AllCityStates"                                    Size="parent,parent" >
+          <Button        ID="CloseListButton"    Anchor="R,T"  Offset="0,56"    Style="CloseButtonSmall" />
+        </Container>
+        <Grid                                    Anchor="L,B"  Offset="14,6"    Size="160,28"          Style="CityStateColumnHeaderGrid">
+          <Label                                Anchor="L,C"  Offset="10,0"                          Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_CITY_STATE" />
+        </Grid>
+        <Grid                                    Anchor="L,B"  Offset="176,6"  Size="90,28"          Style="CityStateColumnHeaderGrid">
+          <Label                                Anchor="C,C"                                        Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_ENVOYS" />
+        </Grid>
+        <Grid                                    Anchor="L,B"  Offset="268,6"  Size="198,28"          Style="CityStateColumnHeaderGrid">
+          <Label                                Anchor="L,C"  Offset="10,0"                          Style="CityStateColumnHeaderText" String="LOC_CITY_STATES_BONUSES_EARNED" />
+        </Grid>
+      </Grid>
 
-			<ScrollPanel			ID="CityStateScroll"									Offset="12,164" Size="490,parent-174"				Vertical="1" AutoScrollBar="1">
-				<Stack					ID="CityStateStack"			Anchor="L,T"	Offset="0,1"		StackPadding="4" />
-				<ScrollBar															Anchor="R,C"	Offset="-1,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
-			</ScrollPanel>
+      <ScrollPanel      ID="CityStateScroll"                  Offset="12,164" Size="490,parent-174"        Vertical="1" AutoScrollBar="1">
+        <Stack          ID="CityStateStack"      Anchor="L,T"  Offset="0,1"    StackPadding="4" />
+        <ScrollBar                              Anchor="R,C"  Offset="-1,0"    AnchorSide="O,I"            Style="ScrollVerticalBarAlt" />
+      </ScrollPanel>
 
-			<Label						ID="NoneMet"						Anchor="C,C"	Offset="0,50"		Align="Center" Style="FontFlair20" String="LOC_CITY_STATES_NONE_MET" Hidden="1"/>
+      <Label            ID="NoneMet"            Anchor="C,C"  Offset="0,50"    Align="Center" Style="FontFlair20" String="LOC_CITY_STATES_NONE_MET" Hidden="1"/>
 
-			<Grid							ID="BonusArea"					Anchor="L,B"	Offset="0,70"		Size="parent,parent-570"		Texture="Controls_Glow"					SliceCorner="90,90" SliceTextureSize="179,178"	Color="0,0,0,255" Hidden="1" >
-				<Grid						ID="BonusDecoLeft"										Offset="20,45"	Size="18,parent-50"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="30,36,40,255"   />
-				<Grid						ID="BonusDecoRight"			Anchor="R,T"	Offset="20,45"	Size="18,parent-50"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="30,36,40,255" SliceStart="20,0" />
+      <Grid              ID="BonusArea"          Anchor="L,B"  Offset="0,70"    Size="parent,parent-570"    Texture="Controls_Glow"          SliceCorner="90,90" SliceTextureSize="179,178"  Color="0,0,0,255" Hidden="1" >
+        <Grid            ID="BonusDecoLeft"                    Offset="20,45"  Size="18,parent-50"          Texture="Controls_Deco"          SliceCorner="9,24"  SliceTextureSize="18,49"    Color="30,36,40,255"   />
+        <Grid            ID="BonusDecoRight"      Anchor="R,T"  Offset="20,45"  Size="18,parent-50"          Texture="Controls_Deco"          SliceCorner="9,24"  SliceTextureSize="18,49"    Color="30,36,40,255" SliceStart="20,0" />
 
-				<Grid						ID="BonusHeader"											Offset="0,0"		Size="parent,40"						Texture="Controls_TitleBarDark"	SliceCorner="21,17"	SliceTextureSize="42,34" >
-					<Image																															Size="parent,parent"				Texture="Controls_Gradient_HalfRadial"																					Color="170,176,180,35" />
-					<Label				ID="SubHeader"					Anchor="C,C"	Offset="0,3"																Style="FontFlair24"		Color0="170,176,180" String="{LOC_CITY_STATES_BONUSES_EARNED:upper}" SmallCaps="30" SmallCapsType="EveryWord" />
-				</Grid>
-				<ScrollPanel		ID="BonusScroll"											Offset="50,39"	Size="400,parent-39"				Vertical="1" >
-					<Stack				ID="BonusStack"					Anchor="L,T"	Offset="0,1"		StackPadding="4" />
-					<ScrollBar														Anchor="R,C"	Offset="10,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
-				</ScrollPanel>
-			</Grid>
+        <Grid            ID="BonusHeader"                      Offset="0,0"    Size="parent,40"            Texture="Controls_TitleBarDark"  SliceCorner="21,17"  SliceTextureSize="42,34" >
+          <Image                                                              Size="parent,parent"        Texture="Controls_Gradient_HalfRadial"                                          Color="170,176,180,35" />
+          <Label        ID="SubHeader"          Anchor="C,C"  Offset="0,3"                                Style="FontFlair24"    Color0="170,176,180" String="{LOC_CITY_STATES_BONUSES_EARNED:upper}" SmallCaps="30" SmallCapsType="EveryWord" />
+        </Grid>
+        <ScrollPanel    ID="BonusScroll"                      Offset="50,39"  Size="400,parent-39"        Vertical="1" >
+          <Stack        ID="BonusStack"          Anchor="L,T"  Offset="0,1"    StackPadding="4" />
+          <ScrollBar                            Anchor="R,C"  Offset="10,0"    AnchorSide="O,I"            Style="ScrollVerticalBarAlt" />
+        </ScrollPanel>
+      </Grid>
 
-			<Grid																			Anchor="C,B"	Offset="1,-4"		Size="parent+5,32"					Texture="Controls_BannerBottom" SliceCorner="18,2" SliceTextureSize="37,32" />
+      <Grid                                      Anchor="C,B"  Offset="1,-4"    Size="parent+5,32"          Texture="Controls_BannerBottom" SliceCorner="18,2" SliceTextureSize="37,32" />
 
-			<Grid							ID="ConfirmFrame"				Anchor="C,B"	Offset="0,10"		Size="parent-30,60"					Texture="Controls_ConfirmFrame" SliceCorner="38,30" SliceTextureSize="76,60" Hidden="1" >
-				<GridButton			ID="ConfirmButton"			Anchor="C,C"	Offset="0,-1"		Size="parent-70,41"					Texture="Controls_Confirm"			SliceCorner="40,20" SliceTextureSize="80,41" StateOffsetIncrement="0,41" String="LOC_CITY_STATES_CONFIRM_PLACEMENT"  Style="FontNormal16" />
-			</Grid>
-		</Container>
+      <Grid              ID="ConfirmFrame"        Anchor="C,B"  Offset="0,10"    Size="parent-30,60"          Texture="Controls_ConfirmFrame" SliceCorner="38,30" SliceTextureSize="76,60" Hidden="1" >
+        <GridButton      ID="ConfirmButton"      Anchor="C,C"  Offset="0,-1"    Size="parent-70,41"          Texture="Controls_Confirm"      SliceCorner="40,20" SliceTextureSize="80,41" StateOffsetIncrement="0,41" String="LOC_CITY_STATES_CONFIRM_PLACEMENT"  Style="FontNormal16" />
+      </Grid>
+    </Container>
 
-		<!-- Individual CityState View -->
-		<Container						ID="SingleCityState"																	Size="parent,parent">
-			<Image																			Anchor="R,B"	Offset="3,0"		Size="47,239"								Texture="Diplomacy_RibbonBottom.dds" />
-			<Image																			Anchor="R,T"	Offset="3,0"		Size="47,parent-32"					Texture="Diplomacy_Ribbon.dds">
-				<Stack						ID="CityStateIconStack"								Offset="4,70"		StackGrowth="Bottom"				Padding="8" />
-			</Image>
-			<Grid																											Offset="3,70"		Size="parent-55,parent-70"	Style="DiplomacyInfoWindowGrid">
-				<Grid																																		Size="parent,165"						Style="DiplomacyInfoHeaderGrid" />
-				<Button						ID="CloseBackButton"		Anchor="R,T"									Style="BackButtonSmall" />
-				<Image																		Anchor="C,T"	Offset="0,-21"															Texture="Diplomacy_PortraitBacking" />
-				<Image																		Anchor="C,T"	Offset="0,-56"															Texture="CityState_HeaderCircle" />
-				<Image						ID="CityStateTypeIcon"	Anchor="C,T"	Offset="-1,-58"	Size="64,64"								Texture="CivSymbols64" />
-				<Image																		Anchor="C,T"	Offset="0,-64"															Texture="Diplomacy_YouIndicatorLarge" >
-					<Image					ID="DiplomacyPip"				Anchor="L,B"									Size="23,23"								Texture="Diplomacy_RelationshipPips" />
-				</Image>
-				<Label																		Anchor="C,T"	Offset="0,25"		Style="FontFlair16"					SmallCaps="26" SmallCapsType="EveryWord" String="{LOC_CITY_STATES_CITY_STATE:upper}" />
-				<Label						ID="CityStateName"			Anchor="C,T"	Offset="0,47"		Style="FontFlair24"					SmallCaps="30" SmallCapsType="EveryWord" String="$CityStateName$" />
+    <!-- Individual CityState View -->
+    <Container            ID="SingleCityState"                                  Size="parent,parent">
+      <Image                                      Anchor="R,B"  Offset="3,0"    Size="47,239"                Texture="Diplomacy_RibbonBottom.dds" />
+      <Image                                      Anchor="R,T"  Offset="3,0"    Size="47,parent-32"          Texture="Diplomacy_Ribbon.dds">
+        <Stack            ID="CityStateIconStack"                Offset="4,70"    StackGrowth="Bottom"        Padding="8" />
+      </Image>
+      <Grid                                                      Offset="3,70"    Size="parent-55,parent-70"  Style="DiplomacyInfoWindowGrid">
+        <Grid                                                                    Size="parent,165"            Style="DiplomacyInfoHeaderGrid" />
+        <Button            ID="CloseBackButton"    Anchor="R,T"                  Style="BackButtonSmall" />
+        <Image                                    Anchor="C,T"  Offset="0,-21"                              Texture="Diplomacy_PortraitBacking" />
+        <Image                                    Anchor="C,T"  Offset="0,-56"                              Texture="CityState_HeaderCircle" />
+        <Image            ID="CityStateTypeIcon"  Anchor="C,T"  Offset="-1,-58"  Size="64,64"                Texture="CivSymbols64" />
+        <Image                                    Anchor="C,T"  Offset="0,-64"                              Texture="Diplomacy_YouIndicatorLarge" >
+          <Image          ID="DiplomacyPip"        Anchor="L,B"                  Size="23,23"                Texture="Diplomacy_RelationshipPips" />
+        </Image>
+        <Label                                    Anchor="C,T"  Offset="0,25"    Style="FontFlair16"          SmallCaps="26" SmallCapsType="EveryWord" String="{LOC_CITY_STATES_CITY_STATE:upper}" />
+        <Label            ID="CityStateName"      Anchor="C,T"  Offset="0,47"    Style="FontFlair24"          SmallCaps="30" SmallCapsType="EveryWord" String="$CityStateName$" />
 
-				<Stack						ID="SingleViewStack"									Offset="1,80"		StackGrowth="Bottom">
-					<Stack					ID="SubMenu"													Offset="1,0"		StackGrowth="Bottom"				StackPadding="-8">
-						<!-- TODO: REmove, using Back button
-						<GridButton		ID="SendAnEnvoyButton"																Size="parent-4,41"					Style="CityStateSubMenuButton" String="LOC_CITY_STATES_SEND_AN_ENVOY"/>
-						-->
-						<GridButton		ID="PeaceWarButton"																		Size="parent-4,41"					Style="CityStateSubMenuButton" String="LOC_CITY_STATES_MAKE_PEACE"/>
-						<GridButton		ID="LevyMilitaryButton"																Size="parent-4,41"					Style="CityStateSubMenuButton" String="LOC_CITY_STATES_LEVY_MILITARY_BUTTON"/>
-					</Stack>
-					<Grid																		Anchor="C,T"	Offset="0,0"		Size="parent-10,40"					Texture="Controls_TitleBarDark"	SliceCorner="21,17"	SliceTextureSize="42,34">
-						<Image																															Size="parent,parent"				Texture="Controls_Gradient_HalfRadial"																					Color="170,176,180,35" />
-						<Label																Anchor="C,C"	Offset="0,3"																Style="FontFlair24"		Color0="170,176,180" String="{LOC_CITY_STATES_REPORT:upper}" SmallCaps="30" SmallCapsType="EveryWord" />
-					</Grid>
-					<Box						ID="ReportArea"					Anchor="C,T"	Offset="0,0"		Size="parent-10,120"				Color="40,50,60,255">
-						<Box											  					Anchor="L,T"	Offset="1,1"		Size="parent-2,parent-2"		Color="3,4,5,255" />
-						<Image																Anchor="L,T"	Offset="1,1"		Size="parent-2,parent-2"		Texture="Controls_Gradient"																											Color="30,40,50,255" >
-							<Grid				ID="ReportDecoLeft"										Offset="5,5"		Size="18,parent-10"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="50,56,70,255"   />
-							<Grid				ID="ReportDecoRight"		Anchor="R,T"	Offset="5,5"		Size="20,parent-10"					Texture="Controls_Deco"					SliceCorner="9,24"	SliceTextureSize="18,49"		Color="50,56,70,255" SliceStart="21,0" />
-							<Label															Anchor="R,T"	Offset="230,10"															Style="CityStateTextLabel"	String="LOC_CITY_STATES_TYPE" />
-							<Label			ID="TypeValue"					Anchor="L,T"	Offset="230,10"															Style="CityStateTextValue"	String="$TypeValue$" />
-							<Label															Anchor="R,T"	Offset="230,31"															Style="CityStateTextLabel"	String="LOC_CITY_STATES_SUZERAIN_LIST" />
-							<Label			ID="PatronValue"				Anchor="L,T"	Offset="230,31"															Style="CityStateTextValue"	String="$PatronValue$" />
-							<GridButton	ID="EnvoysSentButton"		Anchor="R,T"	Offset="224,50"	Size="170,21"								Style="CityStateTinyButton" String="LOC_CITY_STATES_ENVOYS_SENT" />
-							<Label			ID="EnvoysSentValue"		Anchor="L,T"	Offset="230,52"															Style="CityStateTextValue"	String="$EnvoysSentValue$" />
-							<GridButton	ID="InfluencedByButton"	Anchor="R,T"	Offset="224,71"	Size="170,21"								Style="CityStateTinyButton" String="LOC_CITY_STATES_INFLUENCED_BY" />
-							<Label			ID="InfluencedByValue"	Anchor="L,T"	Offset="230,73"															Style="CityStateTextValue"	String="$InfluencedByValue$" />
-							<GridButton	ID="QuestsButton"				Anchor="R,T"	Offset="224,92"	Size="170,21"								Style="CityStateTinyButton" String="LOC_CITY_STATES_QUESTS" />
-							<Label			ID="QuestsValue"				Anchor="L,T"	Offset="230,94"															Style="CityStateTextValue"	String="$QuestsValue$" />
-						</Image>
-					</Box>
-					<Container			ID="EnvoysSentArea"																		Size="parent,200" >
-						<Grid																								Offset="10,10"	Size="parent-20,40"					Style="CityStateStatHeader" >
-							<Label															Anchor="C,C"																							Style="FontFlair28"					String="LOC_CITY_STATES_ENVOYS_SENT" Color="170,176,180" />
-							<Container													Anchor="R,C"	Offset="17,1"		Size="1,1">
-								<Label		ID="EnvoysSentValue2"		Anchor="C,C"																							Style="FontFlair28"					String="0" Color="170,176,180" />
-							</Container>
-						</Grid>
-						<ScrollPanel	ID="EnvoysBonusScroll"								Offset="7,60"		Size="parent-25,265"				Vertical="1">
-							<Stack			ID="EnvoysBonusStack"		Anchor="L,T"	Offset="0,1"		StackPadding="4" />
-							<ScrollBar													Anchor="R,C"	Offset="0,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
-						</ScrollPanel>
-					</Container>
-					<Container			ID="InfluenceArea"																		Size="parent,200" Hidden="1">
-						<Grid																								Offset="10,10"	Size="parent-20,40"					Style="CityStateHeader" >
-							<Label															Anchor="C,C"																							Style="CityStateHeaderText"					String="{LOC_CITY_STATES_ENVOYS_INFLUENCE_BY_CIVILIZATION:upper}" />
-						</Grid>
-						<ScrollPanel	ID="InfluenceScroll"									Offset="7,60"		Size="parent-15,265"				Vertical="1">
-							<Stack			ID="InfluenceStack"			Anchor="L,T"	Offset="0,1"		StackPadding="4" />
-							<ScrollBar													Anchor="R,C"	Offset="4,0"		AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
-						</ScrollPanel>
-					</Container>
-					<Container			ID="QuestsArea"																				Size="parent,200"	Hidden="1" >
-						<Grid																								Offset="10,10"	Size="parent-20,40"					Style="CityStateHeader" >
-							<Label															Anchor="C,C"																							Style="CityStateHeaderText"					String="{LOC_CITY_STATES_AVAILABLE_QUESTS:upper}" />
-						</Grid>
-						<ScrollPanel	ID="QuestsScroll"											Offset="7,60"		Size="parent-15,265"				Vertical="1" >
-							<Stack			ID="QuestsStack"				Anchor="L,T"	Offset="0,1"		StackPadding="20" />
-							<ScrollBar													Anchor="R,C"	Offset="-12,0"	AnchorSide="O,I"						Style="ScrollVerticalBarAlt" />
-						</ScrollPanel>
-					</Container>
-				</Stack>
-			</Grid>
-		</Container>
+        <Stack            ID="SingleViewStack"                  Offset="1,80"    StackGrowth="Bottom">
+          <Stack          ID="SubMenu"                          Offset="1,0"    StackGrowth="Bottom"        StackPadding="-8">
+            <!-- TODO: REmove, using Back button
+            <GridButton    ID="SendAnEnvoyButton"                                Size="parent-4,41"          Style="CityStateSubMenuButton" String="LOC_CITY_STATES_SEND_AN_ENVOY"/>
+            -->
+            <GridButton    ID="PeaceWarButton"                                    Size="parent-4,41"          Style="CityStateSubMenuButton" String="LOC_CITY_STATES_MAKE_PEACE"/>
+            <GridButton    ID="LevyMilitaryButton"                                Size="parent-4,41"          Style="CityStateSubMenuButton" String="LOC_CITY_STATES_LEVY_MILITARY_BUTTON"/>
+          </Stack>
+          <Grid                                    Anchor="C,T"  Offset="0,0"    Size="parent-10,40"          Texture="Controls_TitleBarDark"  SliceCorner="21,17"  SliceTextureSize="42,34">
+            <Image                                                              Size="parent,parent"        Texture="Controls_Gradient_HalfRadial"                                          Color="170,176,180,35" />
+            <Label                                Anchor="C,C"  Offset="0,3"                                Style="FontFlair24"    Color0="170,176,180" String="{LOC_CITY_STATES_REPORT:upper}" SmallCaps="30" SmallCapsType="EveryWord" />
+          </Grid>
+          <Box            ID="ReportArea"          Anchor="C,T"  Offset="0,0"    Size="parent-10,120"        Color="40,50,60,255">
+            <Box                                  Anchor="L,T"  Offset="1,1"    Size="parent-2,parent-2"    Color="3,4,5,255" />
+            <Image                                Anchor="L,T"  Offset="1,1"    Size="parent-2,parent-2"    Texture="Controls_Gradient"                                                      Color="30,40,50,255" >
+              <Grid        ID="ReportDecoLeft"                    Offset="5,5"    Size="18,parent-10"          Texture="Controls_Deco"          SliceCorner="9,24"  SliceTextureSize="18,49"    Color="50,56,70,255"   />
+              <Grid        ID="ReportDecoRight"    Anchor="R,T"  Offset="5,5"    Size="20,parent-10"          Texture="Controls_Deco"          SliceCorner="9,24"  SliceTextureSize="18,49"    Color="50,56,70,255" SliceStart="21,0" />
+              <Label                              Anchor="R,T"  Offset="230,10"                              Style="CityStateTextLabel"  String="LOC_CITY_STATES_TYPE" />
+              <Label      ID="TypeValue"          Anchor="L,T"  Offset="230,10"                              Style="CityStateTextValue"  String="$TypeValue$" />
+              <Label                              Anchor="R,T"  Offset="230,31"                              Style="CityStateTextLabel"  String="LOC_CITY_STATES_SUZERAIN_LIST" />
+              <Label      ID="PatronValue"        Anchor="L,T"  Offset="230,31"                              Style="CityStateTextValue"  String="$PatronValue$" />
+              <GridButton  ID="EnvoysSentButton"    Anchor="R,T"  Offset="224,50"  Size="170,21"                Style="CityStateTinyButton" String="LOC_CITY_STATES_ENVOYS_SENT" />
+              <Label      ID="EnvoysSentValue"    Anchor="L,T"  Offset="230,52"                              Style="CityStateTextValue"  String="$EnvoysSentValue$" />
+              <GridButton  ID="InfluencedByButton"  Anchor="R,T"  Offset="224,71"  Size="170,21"                Style="CityStateTinyButton" String="LOC_CITY_STATES_INFLUENCED_BY" />
+              <Label      ID="InfluencedByValue"  Anchor="L,T"  Offset="230,73"                              Style="CityStateTextValue"  String="$InfluencedByValue$" />
+              <GridButton  ID="QuestsButton"        Anchor="R,T"  Offset="224,92"  Size="170,21"                Style="CityStateTinyButton" String="LOC_CITY_STATES_QUESTS" />
+              <Label      ID="QuestsValue"        Anchor="L,T"  Offset="230,94"                              Style="CityStateTextValue"  String="$QuestsValue$" />
+            </Image>
+          </Box>
+          <Container      ID="EnvoysSentArea"                                    Size="parent,200" >
+            <Grid                                                Offset="10,10"  Size="parent-20,40"          Style="CityStateStatHeader" >
+              <Label                              Anchor="C,C"                                              Style="FontFlair28"          String="LOC_CITY_STATES_ENVOYS_SENT" Color="170,176,180" />
+              <Container                          Anchor="R,C"  Offset="17,1"    Size="1,1">
+                <Label    ID="EnvoysSentValue2"    Anchor="C,C"                                              Style="FontFlair28"          String="0" Color="170,176,180" />
+              </Container>
+            </Grid>
+            <ScrollPanel  ID="EnvoysBonusScroll"                Offset="7,60"    Size="parent-25,265"        Vertical="1">
+              <Stack      ID="EnvoysBonusStack"    Anchor="L,T"  Offset="0,1"    StackPadding="4" />
+              <ScrollBar                          Anchor="R,C"  Offset="0,0"    AnchorSide="O,I"            Style="ScrollVerticalBarAlt" />
+            </ScrollPanel>
+          </Container>
+          <Container      ID="InfluenceArea"                                    Size="parent,200" Hidden="1">
+            <Grid                                                Offset="10,10"  Size="parent-20,40"          Style="CityStateHeader" >
+              <Label                              Anchor="C,C"                                              Style="CityStateHeaderText"          String="{LOC_CITY_STATES_ENVOYS_INFLUENCE_BY_CIVILIZATION:upper}" />
+            </Grid>
+            <ScrollPanel  ID="InfluenceScroll"                  Offset="7,60"    Size="parent-15,265"        Vertical="1">
+              <Stack      ID="InfluenceStack"      Anchor="L,T"  Offset="0,1"    StackPadding="4" />
+              <ScrollBar                          Anchor="R,C"  Offset="4,0"    AnchorSide="O,I"            Style="ScrollVerticalBarAlt" />
+            </ScrollPanel>
+          </Container>
+          <Container      ID="QuestsArea"                                        Size="parent,200"  Hidden="1" >
+            <Grid                                                Offset="10,10"  Size="parent-20,40"          Style="CityStateHeader" >
+              <Label                              Anchor="C,C"                                              Style="CityStateHeaderText"          String="{LOC_CITY_STATES_AVAILABLE_QUESTS:upper}" />
+            </Grid>
+            <ScrollPanel  ID="QuestsScroll"                      Offset="7,60"    Size="parent-15,265"        Vertical="1" >
+              <Stack      ID="QuestsStack"        Anchor="L,T"  Offset="0,1"    StackPadding="20" />
+              <ScrollBar                          Anchor="R,C"  Offset="-12,0"  AnchorSide="O,I"            Style="ScrollVerticalBarAlt" />
+            </ScrollPanel>
+          </Container>
+        </Stack>
+      </Grid>
+    </Container>
 
-	</SlideAnim>
+  </SlideAnim>
 
 
-	<!-- ==================================================================	-->
-	<!--	Instances																													-->
-	<!-- ==================================================================	-->
+  <!-- ==================================================================  -->
+  <!--  Instances                                                          -->
+  <!-- ==================================================================  -->
 
-	<Instance				Name="CityStateRowInstance">
-		<GridButton		ID="CityStateBase"																			Size="parent,48"			Style="SubContainer4" Color="59,62,63,255" >
-			<BoxButton  ID="Button"								Anchor="L,C"	Offset="8,0"		Size="40,40"					Color="0,0,0,0">
-				<Image    ID="Icon"									Anchor="L,C"									Size="36,36"					Texture="CivSymbols36" />
-				<Image		ID="DiplomacyPip"					Anchor="L,B"	Offset="-10,-6"	Size="23,23"								Texture="Diplomacy_RelationshipPips" />
-				<Label    ID="QuestIcon"            Anchor="L,T"  Offset="-9,0"  String="[ICON_CityStateQuest]" />
-			</BoxButton>
+  <Instance        Name="CityStateRowInstance">
+    <GridButton    ID="CityStateBase"                                      Size="parent,48"      Style="SubContainer4" Color="59,62,63,255" >
+      <BoxButton  ID="Button"                Anchor="L,C"  Offset="8,0"    Size="40,40"          Color="0,0,0,0">
+        <Image    ID="Icon"                  Anchor="L,C"                  Size="36,36"          Texture="CivSymbols36" />
+        <Image    ID="DiplomacyPip"          Anchor="L,B"  Offset="-10,-6"  Size="23,23"                Texture="Diplomacy_RelationshipPips" />
+        <Label    ID="QuestIcon"            Anchor="L,T"  Offset="-9,0"  String="[ICON_CityStateQuest]" />
+      </BoxButton>
 
-			<GridButton ID="NameButton"													Offset="42,9"		Size="126,33" Texture="Controls_CityBannerSmall" SliceCorner="14,9" SliceSize="5,4" SliceTextureSize="33,28" Color="50,50,50,255">
-				<Label		ID="NameLabel"						Anchor="C,C"	Offset="0,-2"		Style="FontFlair11"		SmallCaps="16" SmallCapsStyle="EveryWord"					String="Name"/>
-			</GridButton>
+      <GridButton ID="NameButton"                          Offset="42,9"    Size="126,33" Texture="Controls_CityBannerSmall" SliceCorner="14,9" SliceSize="5,4" SliceTextureSize="33,28" Color="50,50,50,255">
+        <Label    ID="NameLabel"            Anchor="C,C"  Offset="0,-2"    Style="FontFlair11"    SmallCaps="16" SmallCapsStyle="EveryWord"          String="Name"/>
+      </GridButton>
 
-			<Image      ID="Envoy"								Anchor="L,C"	Offset="190,0"	Size="40,40"					Texture="Controls_CircleRim40">
-				<Button		ID="EnvoyLessButton"			Anchor="L,C"	Offset="-6,0"		Size="34,34"					Texture="Controls_Stepper" AnchorSide="O,I" FlipX="1" />
-				<Button		ID="EnvoyMoreButton"			Anchor="R,C"	Offset="-6,0"		Size="34,34"					Texture="Controls_Stepper" AnchorSide="O,I" />
-				<Label		ID="EnvoyCount"						Anchor="C,C"	Offset="-1,1"		String="0"						Style="FontFlairLua"				Color="160,160,160,240" />
-			</Image>
+      <Image      ID="Envoy"                Anchor="L,C"  Offset="190,0"  Size="40,40"          Texture="Controls_CircleRim40">
+        <Button    ID="EnvoyLessButton"      Anchor="L,C"  Offset="-6,0"    Size="34,34"          Texture="Controls_Stepper" AnchorSide="O,I" FlipX="1" />
+        <Button    ID="EnvoyMoreButton"      Anchor="R,C"  Offset="-6,0"    Size="34,34"          Texture="Controls_Stepper" AnchorSide="O,I" />
+        <Label    ID="EnvoyCount"            Anchor="C,C"  Offset="-1,1"    String="0"            Style="FontFlairLua"        Color="160,160,160,240" />
+      </Image>
 
-			<Image			ID="BonusImage1"					Anchor="L,C"	Offset="256,0"	Size="29,42"					Texture="CityState_BonusSlotOff" >
-				<Label		ID="BonusText1"						Anchor="R,T"	Offset="3,2"													Style="FontNormal12"							String="1" />
-				<Image		ID="BonusIcon1"						Anchor="C,B"									Size="26,26"					Texture="EnvoyBonuses26"					TextureOffset="104,0"	/>
-			</Image>
-			<Image			ID="BonusImage3"					Anchor="L,C"	Offset="286,0"	Size="29,42"					Texture="CityState_BonusSlotOn">
-				<Label		ID="BonusText3"						Anchor="R,T"	Offset="3,2"													Style="FontNormal12"							String="3" />
-				<Image		ID="BonusIcon3"						Anchor="C,B"									Size="26,26"					Texture="EnvoyBonuses26"					TextureOffset="104,0"	/>
-			</Image>
-			<Image			ID="BonusImage6"					Anchor="L,C"	Offset="316,0"	Size="29,42"					Texture="CityState_BonusSlotOn">
-				<Label		ID="BonusText6"						Anchor="R,T"	Offset="3,2"													Style="FontNormal12"							String="6" />
-				<Image		ID="BonusIcon6"						Anchor="C,B"									Size="26,26"					Texture="EnvoyBonuses26"					TextureOffset="104,0"	/>
-			</Image>
-			<!-- CQUI Note: The size of the container below was changed from 108 to 120 in order to fix a spacing issue. -->
-			<Container														Anchor="L,C"	Offset="346,0"	Size="120,42">
-				<Grid			ID="BonusImageSuzerainOff"															Size="parent,parent"	Texture="CityState_BonusSlotBigOff" SliceCorner="31,21" SliceTextureSize="34,42"	/>
-				<Grid			ID="BonusImageSuzerainOn"																Size="parent,parent"	Texture="CityState_BonusSlotBigOn"	SliceCorner="31,21" SliceTextureSize="34,42"		/>
-				<Label		ID="BonusTextSuzerain"		Anchor="R,T"	Offset="4,2"													Style="FontNormal12"								String="4" />
-				<Image		ID="BonusIconSuzerain"		Anchor="L,T"	Offset="2,0"		Size="26,26"					Texture="EnvoyBonuses26"						TextureOffset="156,0"	/>
-				<Label    ID="SecondHighestLabel"   Anchor="L,B"  Offset="3,0"                          Style="FontNormal12" />
-				<Label		ID="SuzerainLabel"				Anchor="L,T"	Offset="32,14"												Style="FontNormal12"								String="LOC_CITY_STATES_SUZERAIN" />
-				<Label		ID="Suzerain"							Anchor="L,T"	Offset="32,2"													Style="FontNormal12"								String="LOC_CITY_STATES_NONE" />
-				<Label    ID="SecondHighestName"    Anchor="L,B"  Offset="32,0"                         Style="FontNormal12" />
-				<Label    ID="SecondHighestEnvoys"  Anchor="R,B"  Offset="4,0"                          Style="FontNormal12" />
-			</Container>
+      <Image      ID="BonusImage1"          Anchor="L,C"  Offset="256,0"  Size="29,42"          Texture="CityState_BonusSlotOff" >
+        <Label    ID="BonusText1"            Anchor="R,T"  Offset="3,2"                          Style="FontNormal12"              String="1" />
+        <Image    ID="BonusIcon1"            Anchor="C,B"                  Size="26,26"          Texture="EnvoyBonuses26"          TextureOffset="104,0"  />
+      </Image>
+      <Image      ID="BonusImage3"          Anchor="L,C"  Offset="286,0"  Size="29,42"          Texture="CityState_BonusSlotOn">
+        <Label    ID="BonusText3"            Anchor="R,T"  Offset="3,2"                          Style="FontNormal12"              String="3" />
+        <Image    ID="BonusIcon3"            Anchor="C,B"                  Size="26,26"          Texture="EnvoyBonuses26"          TextureOffset="104,0"  />
+      </Image>
+      <Image      ID="BonusImage6"          Anchor="L,C"  Offset="316,0"  Size="29,42"          Texture="CityState_BonusSlotOn">
+        <Label    ID="BonusText6"            Anchor="R,T"  Offset="3,2"                          Style="FontNormal12"              String="6" />
+        <Image    ID="BonusIcon6"            Anchor="C,B"                  Size="26,26"          Texture="EnvoyBonuses26"          TextureOffset="104,0"  />
+      </Image>
+      <!-- CQUI Note: The size of the container below was changed from 108 to 120 in order to fix a spacing issue. -->
+      <Container                            Anchor="L,C"  Offset="346,0"  Size="120,42">
+        <Grid      ID="BonusImageSuzerainOff"                              Size="parent,parent"  Texture="CityState_BonusSlotBigOff" SliceCorner="31,21" SliceTextureSize="34,42"  />
+        <Grid      ID="BonusImageSuzerainOn"                                Size="parent,parent"  Texture="CityState_BonusSlotBigOn"  SliceCorner="31,21" SliceTextureSize="34,42"    />
+        <Label    ID="BonusTextSuzerain"    Anchor="R,T"  Offset="4,2"                          Style="FontNormal12"                String="4" />
+        <Image    ID="BonusIconSuzerain"    Anchor="L,T"  Offset="2,0"    Size="26,26"          Texture="EnvoyBonuses26"            TextureOffset="156,0"  />
+        <Label    ID="SecondHighestLabel"   Anchor="L,B"  Offset="3,0"                          Style="FontNormal12" />
+        <Label    ID="SuzerainLabel"        Anchor="L,T"  Offset="32,14"                        Style="FontNormal12"                String="LOC_CITY_STATES_SUZERAIN" />
+        <Label    ID="Suzerain"              Anchor="L,T"  Offset="32,2"                          Style="FontNormal12"                String="LOC_CITY_STATES_NONE" />
+        <Label    ID="SecondHighestName"    Anchor="L,B"  Offset="32,0"                         Style="FontNormal12" />
+        <Label    ID="SecondHighestEnvoys"  Anchor="R,B"  Offset="4,0"                          Style="FontNormal12" />
+      </Container>
 
-			<Button			ID="LookAtButton"					Anchor="R,C"	Offset="3,-7"		Size="23,31"					Texture="Controls_ShowMe"					StateOffsetIncrement="0,0"	ToolTip="LOC_CITY_STATES_LOOK_AT" />
+      <Button      ID="LookAtButton"          Anchor="R,C"  Offset="3,-7"    Size="23,31"          Texture="Controls_ShowMe"          StateOffsetIncrement="0,0"  ToolTip="LOC_CITY_STATES_LOOK_AT" />
 
-			<Label			ID="TypeLabel"						Anchor="L,C"	Offset="125,0"												Style="FontNormal16"	Hidden="1"	String="[ICON_Faith]Religious" Note="DEPRECATED" />
-			<Label			ID="QuestsLabel"					Anchor="L,C"	Offset="250,0"												Style="FontNormal16"	Hidden="1"	String="[COLOR_GREEN]![ENDCOLOR]"/>
-			<GridButton ID="GiveTokenButton"			Anchor="L,C"	Offset="270,0"	Size="140,32"					Style="MainButton"		Hidden="1"	String="Send Envoy"/>
-			<Label			ID="CurrentTokensLabel"		Anchor="L,C"	Offset="415,0"												Style="FontNormal16"	Hidden="1"	String="Current Tokens"/>
-			<Label			ID="TypeBonusLabel"				Anchor="L,C"	Offset="510,0"												Style="FontNormal16"	Hidden="1"	String="Next Bonus"/>
-			<Label			ID="UniqueBonusLabel"			Anchor="L,C"	Offset="620,0"												Style="FontNormal16"	Hidden="1"	String="Most Tokens Y/N?"/>
-			<!--
-			<GridButton ID="LevyMilitaryButton"		Anchor="R,C"	Offset="150,0"	Size="140,32"					Style="MainButton"		Hidden="1"	String="Levy Military"/>
-			<GridButton ID="ChangeWarStateButton" Anchor="R,C"	Offset="0,0"		Size="140,32"					Style="MainButton"		Hidden="1"	String="Declare War!"/>
-			-->
-		</GridButton>
-	</Instance>
+      <Label      ID="TypeLabel"            Anchor="L,C"  Offset="125,0"                        Style="FontNormal16"  Hidden="1"  String="[ICON_Faith]Religious" Note="DEPRECATED" />
+      <Label      ID="QuestsLabel"          Anchor="L,C"  Offset="250,0"                        Style="FontNormal16"  Hidden="1"  String="[COLOR_GREEN]![ENDCOLOR]"/>
+      <GridButton ID="GiveTokenButton"      Anchor="L,C"  Offset="270,0"  Size="140,32"          Style="MainButton"    Hidden="1"  String="Send Envoy"/>
+      <Label      ID="CurrentTokensLabel"    Anchor="L,C"  Offset="415,0"                        Style="FontNormal16"  Hidden="1"  String="Current Tokens"/>
+      <Label      ID="TypeBonusLabel"        Anchor="L,C"  Offset="510,0"                        Style="FontNormal16"  Hidden="1"  String="Next Bonus"/>
+      <Label      ID="UniqueBonusLabel"      Anchor="L,C"  Offset="620,0"                        Style="FontNormal16"  Hidden="1"  String="Most Tokens Y/N?"/>
+      <!--
+      <GridButton ID="LevyMilitaryButton"    Anchor="R,C"  Offset="150,0"  Size="140,32"          Style="MainButton"    Hidden="1"  String="Levy Military"/>
+      <GridButton ID="ChangeWarStateButton" Anchor="R,C"  Offset="0,0"    Size="140,32"          Style="MainButton"    Hidden="1"  String="Declare War!"/>
+      -->
+    </GridButton>
+  </Instance>
 
-	<Instance				Name="BonusCityHeaderInstance">
-		<Container		ID="Top"			Anchor="L,C" AutoSize="H" Size="parent,16" >
-			<Grid											Anchor="C,C"							Size="parent,8" Texture="Controls_Div2"  SliceCorner="27,4" SliceTextureSize="54,8" Color="27,40,48,255" />
-			<Image										Anchor="C,C"							Size="parent,16"			Texture="Controls_Glow"		Color="0,0,0,255" StretchMode="Fill" />
-			<Label			ID="CityName" Anchor="C,C" String="$City$" Style="FontFlair14" SmallCaps="18" SmallCapsType="EveryWord" 	Color="255,255,255,120" />
-		</Container>
-	</Instance>
+  <Instance        Name="BonusCityHeaderInstance">
+    <Container    ID="Top"      Anchor="L,C" AutoSize="H" Size="parent,16" >
+      <Grid                      Anchor="C,C"              Size="parent,8" Texture="Controls_Div2"  SliceCorner="27,4" SliceTextureSize="54,8" Color="27,40,48,255" />
+      <Image                    Anchor="C,C"              Size="parent,16"      Texture="Controls_Glow"    Color="0,0,0,255" StretchMode="Fill" />
+      <Label      ID="CityName" Anchor="C,C" String="$City$" Style="FontFlair14" SmallCaps="18" SmallCapsType="EveryWord"   Color="255,255,255,120" />
+    </Container>
+  </Instance>
 
-	<Instance				Name="BonusItemOnInstance">
-		<Grid					ID="Top"			Anchor="L,T"									Size="parent,72"				Texture="CityState_BonusFrameOn" SliceCorner="65,29" SliceTextureSize="74,58" >
-			<Image			ID="Icon"			Anchor="L,T"	Offset="4,5"		Size="50,50"						Texture="EnvoyBonuses50"			/>
-			<Label			ID="Title"		Anchor="L,T"	Offset="70,6"														Style="FontNormal14"	String="$BonusTitle$ - GameCore does not expose this yet." />
-			<Container															Offset="55,0"		Size="parent-55,parent"	>
-				<Label		ID="Details"	Anchor="L,T"	Offset="25,24"	WrapWidth="320"					Style="FontNormal14"	String="$Details$ - GameCore does not expose this yet." ColorSet="CityStateCS" />
-			</Container>
-			<Label			ID="Check"		Anchor="R,T"	Offset="8,10" String="[ICON_Checkmark]" Hidden="1" />
-		</Grid>
-	</Instance>
+  <Instance        Name="BonusItemOnInstance">
+    <Grid          ID="Top"      Anchor="L,T"                  Size="parent,72"        Texture="CityState_BonusFrameOn" SliceCorner="65,29" SliceTextureSize="74,58" >
+      <Image      ID="Icon"      Anchor="L,T"  Offset="4,5"    Size="50,50"            Texture="EnvoyBonuses50"      />
+      <Label      ID="Title"    Anchor="L,T"  Offset="70,6"                            Style="FontNormal14"  String="$BonusTitle$ - GameCore does not expose this yet." />
+      <Container                              Offset="55,0"    Size="parent-55,parent"  >
+        <Label    ID="Details"  Anchor="L,T"  Offset="25,24"  WrapWidth="320"          Style="FontNormal14"  String="$Details$ - GameCore does not expose this yet." ColorSet="CityStateCS" />
+      </Container>
+      <Label      ID="Check"    Anchor="R,T"  Offset="8,10" String="[ICON_Checkmark]" Hidden="1" />
+    </Grid>
+  </Instance>
 
-	<Instance				Name="CityStateIconInstance">
-		<Container		ID="Top"					Anchor="L,C"									Size="40,40" >
-			<Button			ID="IconButton"		Anchor="C,C"									Size="44,44"								Texture="CircleBacking44" NoStateChange="1">
-				<Image		ID="Icon"					Anchor="C,C"									Size="44,44"	/>
-				<Image		ID="DiplomacyPip"	Anchor="L,B"	Offset="-8,-8"	Size="23,23"								Texture="Diplomacy_RelationshipPips" />
-			</Button>
-		</Container>
-	</Instance>
+  <Instance        Name="CityStateIconInstance">
+    <Container    ID="Top"          Anchor="L,C"                  Size="40,40" >
+      <Button      ID="IconButton"    Anchor="C,C"                  Size="44,44"                Texture="CircleBacking44" NoStateChange="1">
+        <Image    ID="Icon"          Anchor="C,C"                  Size="44,44"  />
+        <Image    ID="DiplomacyPip"  Anchor="L,B"  Offset="-8,-8"  Size="23,23"                Texture="Diplomacy_RelationshipPips" />
+      </Button>
+    </Container>
+  </Instance>
 
-	<Instance				Name="InfluenceRowInstance">
-		<Container		ID="Top"					Anchor="L,C" Offset="10,0" Size="parent-24,30" >
-			<Label			ID="CityName"			Anchor="L,T" String="$City$" Style="FontFlair14" SmallCaps="18" SmallCapsType="EveryWord" 	ColorSet="CityStateCS" />
-			<Bar				ID="AmountBar"		Anchor="L,B"									Size="parent-40,16" Direction="Right" FGColor="200,190,169" Percent="1.0" />
-			<Stack												Anchor="R,B" Offset="0,-4" StackGrowth="Left">
-				<!-- TODO: non-font icon version<Image Icon="" /> -->
-				<Label		ID="Amount"				Style="FontFlair24" String="0" Color="200,190,169,255" />
-				<Label											Style="FontFlair24" String="[Icon_Envoy]" Color="200,190,169,255" />
-			</Stack>
-		</Container>
-	</Instance>
+  <Instance        Name="InfluenceRowInstance">
+    <Container    ID="Top"          Anchor="L,C" Offset="10,0" Size="parent-24,30" >
+      <Label      ID="CityName"      Anchor="L,T" String="$City$" Style="FontFlair14" SmallCaps="18" SmallCapsType="EveryWord"   ColorSet="CityStateCS" />
+      <Bar        ID="AmountBar"    Anchor="L,B"                  Size="parent-40,16" Direction="Right" FGColor="200,190,169" Percent="1.0" />
+      <Stack                        Anchor="R,B" Offset="0,-4" StackGrowth="Left">
+        <!-- TODO: non-font icon version<Image Icon="" /> -->
+        <Label    ID="Amount"        Style="FontFlair24" String="0" Color="200,190,169,255" />
+        <Label                      Style="FontFlair24" String="[Icon_Envoy]" Color="200,190,169,255" />
+      </Stack>
+    </Container>
+  </Instance>
 
-	<Instance				Name="QuestInstance">
-		<Container		ID="Top"							Anchor="L,C" AutoSize="V"		Size="parent-15,24" >
-			<Image																												Size="42,33" Texture="CityStateQuest42">
-				<Label		ID="Callout"					Anchor="C,T"	Offset="0,3" String="[ICON_Government]" Style="FontNormal16" Color="10,20,30,200" />
-			</Image>
-			<Stack			StackGrowth="Bottom" StackPadding="2">
-				<Label		ID="Title"													Offset="45,0"												Style="FontFlair16"			String="$Title$"				ColorSet="CityStateCS" />
-				<Label		ID="Description"										Offset="45,0"	WrapWidth="parent-35"	Style="FontNormal14"		String="$Description$"	Color="255,255,255,255"/>
-				<Grid																					Offset="0,5"	Size="parent,20"			Style="SubContainer4"		Color="25,33,38,255">
-					<Label												Anchor="L,C"	Offset="18,0"												Style="FontNormal14"		String="LOC_CITY_STATES_REWARD" ColorSet="CityStateCS" />
-					<Label	ID="Reward"						Anchor="R,C"	Offset="8,0"												Style="FontNormal14"		String="$Reward$"								ColorSet="CityStateCS" />
-				</Grid>
-			</Stack>
-		</Container>
-	</Instance>
+  <Instance        Name="QuestInstance">
+    <Container    ID="Top"              Anchor="L,C" AutoSize="V"    Size="parent-15,24" >
+      <Image                                                        Size="42,33" Texture="CityStateQuest42">
+        <Label    ID="Callout"          Anchor="C,T"  Offset="0,3" String="[ICON_Government]" Style="FontNormal16" Color="10,20,30,200" />
+      </Image>
+      <Stack      StackGrowth="Bottom" StackPadding="2">
+        <Label    ID="Title"                          Offset="45,0"                        Style="FontFlair16"      String="$Title$"        ColorSet="CityStateCS" />
+        <Label    ID="Description"                    Offset="45,0"  WrapWidth="parent-35"  Style="FontNormal14"    String="$Description$"  Color="255,255,255,255"/>
+        <Grid                                          Offset="0,5"  Size="parent,20"      Style="SubContainer4"    Color="25,33,38,255">
+          <Label                        Anchor="L,C"  Offset="18,0"                        Style="FontNormal14"    String="LOC_CITY_STATES_REWARD" ColorSet="CityStateCS" />
+          <Label  ID="Reward"            Anchor="R,C"  Offset="8,0"                        Style="FontNormal14"    String="$Reward$"                ColorSet="CityStateCS" />
+        </Grid>
+      </Stack>
+    </Container>
+  </Instance>
 
 
 </Context>

--- a/UI/PartialScreens/CityStates.xml
+++ b/UI/PartialScreens/CityStates.xml
@@ -187,16 +187,20 @@
 				<Label		ID="BonusText6"						Anchor="R,T"	Offset="3,2"													Style="FontNormal12"							String="6" />
 				<Image		ID="BonusIcon6"						Anchor="C,B"									Size="26,26"					Texture="EnvoyBonuses26"					TextureOffset="104,0"	/>
 			</Image>
-			<Container														Anchor="L,C"	Offset="346,0"	Size="108,42">
+			<!-- CQUI Note: The size of the container below was changed from 108 to 120 in order to fix a spacing issue. -->
+			<Container														Anchor="L,C"	Offset="346,0"	Size="120,42">
 				<Grid			ID="BonusImageSuzerainOff"															Size="parent,parent"	Texture="CityState_BonusSlotBigOff" SliceCorner="31,21" SliceTextureSize="34,42"	/>
 				<Grid			ID="BonusImageSuzerainOn"																Size="parent,parent"	Texture="CityState_BonusSlotBigOn"	SliceCorner="31,21" SliceTextureSize="34,42"		/>
 				<Label		ID="BonusTextSuzerain"		Anchor="R,T"	Offset="4,2"													Style="FontNormal12"								String="4" />
-				<Image		ID="BonusIconSuzerain"		Anchor="L,B"	Offset="2,0"		Size="26,26"					Texture="EnvoyBonuses26"						TextureOffset="156,0"	/>
-				<Label		ID="SuzerainLabel"				Anchor="L,B"	Offset="32,14"												Style="FontNormal12"								String="LOC_CITY_STATES_SUZERAIN" />
-				<Label		ID="Suzerain"							Anchor="L,B"	Offset="32,2"													Style="FontNormal12"								String="LOC_CITY_STATES_NONE" />
+				<Image		ID="BonusIconSuzerain"		Anchor="L,T"	Offset="2,0"		Size="26,26"					Texture="EnvoyBonuses26"						TextureOffset="156,0"	/>
+				<Label    ID="SecondHighestLabel"   Anchor="L,B"  Offset="3,0"                          Style="FontNormal12" />
+				<Label		ID="SuzerainLabel"				Anchor="L,T"	Offset="32,14"												Style="FontNormal12"								String="LOC_CITY_STATES_SUZERAIN" />
+				<Label		ID="Suzerain"							Anchor="L,T"	Offset="32,2"													Style="FontNormal12"								String="LOC_CITY_STATES_NONE" />
+				<Label    ID="SecondHighestName"    Anchor="L,B"  Offset="32,0"                         Style="FontNormal12" />
+				<Label    ID="SecondHighestEnvoys"  Anchor="R,B"  Offset="4,0"                          Style="FontNormal12" />
 			</Container>
 
-			<Button			ID="LookAtButton"					Anchor="R,C"	Offset="10,-7"		Size="23,31"					Texture="Controls_ShowMe"					StateOffsetIncrement="0,0"	ToolTip="LOC_CITY_STATES_LOOK_AT" />
+			<Button			ID="LookAtButton"					Anchor="R,C"	Offset="3,-7"		Size="23,31"					Texture="Controls_ShowMe"					StateOffsetIncrement="0,0"	ToolTip="LOC_CITY_STATES_LOOK_AT" />
 
 			<Label			ID="TypeLabel"						Anchor="L,C"	Offset="125,0"												Style="FontNormal16"	Hidden="1"	String="[ICON_Faith]Religious" Note="DEPRECATED" />
 			<Label			ID="QuestsLabel"					Anchor="L,C"	Offset="250,0"												Style="FontNormal16"	Hidden="1"	String="[COLOR_GREEN]![ENDCOLOR]"/>

--- a/qui.modinfo
+++ b/qui.modinfo
@@ -4,7 +4,7 @@
     <Name>Chao Quick UI</Name>
     <Description>Reduce clicks and make empire management easy</Description>
     <Teaser>Reduce clicks and make empire management easy</Teaser>
-    <Authors>vans163, chaorace, zgavin, olegbl, jacks0n, OfekA, Proustldee, RatchetJ, kblease, benjaminjackman, LordYanaek, zeyangl, velit, the-m4a</Authors>
+    <Authors>vans163, chaorace, zgavin, olegbl, jacks0n, OfekA, Proustldee, RatchetJ, kblease, benjaminjackman, LordYanaek, zeyangl, velit, the-m4a, Remolten</Authors>
     <SpecialThanks>vans163 for his original qui mod. astog for his Better Trade Screen mod + More Lenses mod. Ace for his Next City Plot mod. Divine Yuri for his Custom City Panel mod. Greg Miller for his Unit Report Screen mod. Lozenged/kblease for his Production Queue mod. ZhouYzzz for providing the Chinese translation of CQUI</SpecialThanks>
   </Properties>
   <Components>
@@ -33,6 +33,8 @@
         <File>UI/Panels/StatusMessagePanel.lua</File>
         <File>UI/Panels/StatusMessagePanel.xml</File>
         <File>UI/Panels/UnitPanel.lua</File>
+        <File>UI/PartialScreens/CityStates.lua></File>
+        <File>UI/PartialScreens/CityStates.xml></File>
         <File>UI/Popups/GreatPeoplePopup.lua</File>
         <File>UI/Popups/GreatPeoplePopup.xml</File>
         <File>UI/Popups/MapPinListPanel.lua</File>
@@ -129,7 +131,7 @@
     <File>UI/MinimapPanel.xml</File>
     <File>UI/ProductionPanel.xml</File>
     <File>UI/TopPanel.lua</File>
-    <File>UI/UnitPanel.xml</File> 
+    <File>UI/UnitPanel.xml</File>
     <File>UI/WorldInput.lua</File>
     <File>UI/WorldViewIconsManager.lua</File>
     <File>UI/Civilopedia/CivilopediaSupport.lua</File>
@@ -142,6 +144,8 @@
     <File>UI/Panels/StatusMessagePanel.lua</File>
     <File>UI/Panels/StatusMessagePanel.xml</File>
     <File>UI/Panels/UnitPanel.lua</File>
+    <File>UI/PartialScreens/CityStates.lua></File>
+    <File>UI/PartialScreens/CityStates.xml></File>
     <File>UI/Popups/GreatPeoplePopup.lua</File>
     <File>UI/Popups/GreatPeoplePopup.xml</File>
     <File>UI/Popups/MapPinListPanel.lua</File>

--- a/qui.modinfo
+++ b/qui.modinfo
@@ -33,8 +33,8 @@
         <File>UI/Panels/StatusMessagePanel.lua</File>
         <File>UI/Panels/StatusMessagePanel.xml</File>
         <File>UI/Panels/UnitPanel.lua</File>
-        <File>UI/PartialScreens/CityStates.lua></File>
-        <File>UI/PartialScreens/CityStates.xml></File>
+        <File>UI/PartialScreens/CityStates.lua</File>
+        <File>UI/PartialScreens/CityStates.xml</File>
         <File>UI/Popups/GreatPeoplePopup.lua</File>
         <File>UI/Popups/GreatPeoplePopup.xml</File>
         <File>UI/Popups/MapPinListPanel.lua</File>
@@ -144,8 +144,8 @@
     <File>UI/Panels/StatusMessagePanel.lua</File>
     <File>UI/Panels/StatusMessagePanel.xml</File>
     <File>UI/Panels/UnitPanel.lua</File>
-    <File>UI/PartialScreens/CityStates.lua></File>
-    <File>UI/PartialScreens/CityStates.xml></File>
+    <File>UI/PartialScreens/CityStates.lua</File>
+    <File>UI/PartialScreens/CityStates.xml</File>
     <File>UI/Popups/GreatPeoplePopup.lua</File>
     <File>UI/Popups/GreatPeoplePopup.xml</File>
     <File>UI/Popups/MapPinListPanel.lua</File>


### PR DESCRIPTION
I was annoyed by the lack of an easy way to see how many envoys each civilization has, so I decided to add this.

It modifies the UI of the City States Overview Panel, by adding a section at the end of each row that displays which civilization has the second-most envoys, and how many envoys they have.