### PR TITLE
Auto-updating governor assigned citizens on tile changes or city focus

### DIFF
--- a/Assets/UI/Panels/CityPanel.lua
+++ b/Assets/UI/Panels/CityPanel.lua
@@ -1237,7 +1237,9 @@ function Initialize()
   Controls.ScienceIgnore:RegisterCallback(  Mouse.eLClick,  function() OnResetYieldToNormal( YieldTypes.SCIENCE,  "Science"); end); 
   Controls.NextCityButton:RegisterCallback( Mouse.eLClick,  CQUI_OnNextCity); 
   Controls.PrevCityButton:RegisterCallback( Mouse.eLClick,  CQUI_OnPreviousCity); 
-  
+
+  -- CQUI recenter on the city when clicking the round icon in the panel
+  Controls.CircleBacking:RegisterCallback( Mouse.eLClick,  RecenterCameraOnCity); 
 
   Controls.PurchaseTileCheck:RegisterCheckHandler(  OnTogglePurchaseTile );
   Controls.PurchaseTileCheck:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);

--- a/Assets/UI/WorldView/CityBannerManager.lua
+++ b/Assets/UI/WorldView/CityBannerManager.lua
@@ -1250,6 +1250,7 @@ function OnCityBannerClick( playerID:number, cityID:number )
     end
     
   end
+  OnClickCitizen();
 end
 
 -- ===========================================================================
@@ -3140,6 +3141,20 @@ function Initialize()
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);  
   LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
+end
+
+-- ===========================================================================
+function OnClickCitizen( plotId:number )
+
+	local pSelectedCity	:table = UI.GetHeadSelectedCity();
+	local kPlot			:table = Map.GetPlotByIndex(plotId);
+	local tParameters	:table = {};
+	tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
+	tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
+	tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
+
+	local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
+	return true;
 end
 Initialize();
 

--- a/Assets/UI/WorldView/CityBannerManager.lua
+++ b/Assets/UI/WorldView/CityBannerManager.lua
@@ -3080,6 +3080,21 @@ function OnInterfaceModeChanged( oldMode:number, newMode:number )
   end
 end
 
+-- ===========================================================================
+function OnClickCitizen( plotId:number )
+
+	local pSelectedCity	:table = UI.GetHeadSelectedCity();
+	local kPlot			:table = Map.GetPlotByIndex(plotId);
+	local tParameters	:table = {};
+	tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
+	tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
+	tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
+
+	local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
+	return true;
+end
+
+-- ===========================================================================
 function Initialize() 
 
   RegisterDirtyEvents();
@@ -3141,19 +3156,5 @@ function Initialize()
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);  
   LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
-end
-
--- ===========================================================================
-function OnClickCitizen( plotId:number )
-
-	local pSelectedCity	:table = UI.GetHeadSelectedCity();
-	local kPlot			:table = Map.GetPlotByIndex(plotId);
-	local tParameters	:table = {};
-	tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-	tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
-	tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
-
-	local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
-	return true;
 end
 Initialize();

--- a/Assets/UI/WorldView/CityBannerManager.lua
+++ b/Assets/UI/WorldView/CityBannerManager.lua
@@ -3157,4 +3157,3 @@ function OnClickCitizen( plotId:number )
 	return true;
 end
 Initialize();
-

--- a/Assets/UI/WorldView/PlotInfo.lua
+++ b/Assets/UI/WorldView/PlotInfo.lua
@@ -63,6 +63,7 @@ function OnClickSwapTile( plotId:number )
   tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
+  OnClickCitizen();
   return true;
 end
 
@@ -95,6 +96,7 @@ function OnClickPurchasePlot( plotId:number )
   --     you must wait for the event raised from the gamecore before figuring
   --     out which plots need a display.
 
+  OnClickCitizen();
   return true;
 end
 


### PR DESCRIPTION
#247
Autoupdate values after left-clicking swap/purchase tile buttons.
Maybe it can be done in another way so it's just an example of what I mean I would like to see.