### PR TITLE
Auto-updating governor assigned citizens on tile changes or city focus

### DIFF
--- a/Assets/UI/Panels/CityPanel.lua
+++ b/Assets/UI/Panels/CityPanel.lua
@@ -186,12 +186,14 @@ function CQUI_OnNextCity()
   local kCity:table = UI.GetHeadSelectedCity();
   UI.SelectNextCity(kCity);
   UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
+  CQUI_UpdateSelectedCityCitizens();
 end
 
 function CQUI_OnPreviousCity()
   local kCity:table = UI.GetHeadSelectedCity();
   UI.SelectPrevCity(kCity);
   UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
+  CQUI_UpdateSelectedCityCitizens();
 end
 
 function CQUI_OnLoadScreenClose()
@@ -1203,6 +1205,19 @@ function OnTutorial_ContextDisableItems( contextName:string, kIdsToDisable:table
   end
 end
 
+-- ===========================================================================
+function CQUI_UpdateSelectedCityCitizens( plotId:number )
+
+	local pSelectedCity	:table = UI.GetHeadSelectedCity();
+	local kPlot			:table = Map.GetPlotByIndex(plotId);
+	local tParameters	:table = {};
+	tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
+	tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
+	tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
+
+	local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
+	return true;
+end
 
 -- ===========================================================================
 --  CTOR

--- a/Assets/UI/WorldInput.lua
+++ b/Assets/UI/WorldInput.lua
@@ -3350,16 +3350,32 @@ function OnInputActionTriggered( actionId )
     elseif actionId == m_actionHotkeyPrevCity then
         LuaEvents.CQUI_GoPrevCity();
         UI.PlaySound("Play_UI_Click");
+        CQUI_UpdateSelectedCityCitizens();
 
     elseif actionId == m_actionHotkeyNextCity then
         LuaEvents.CQUI_GoNextCity();
         UI.PlaySound("Play_UI_Click");
+        CQUI_UpdateSelectedCityCitizens();
 
     elseif actionId == m_actionHotkeyOnlinePause then
         if GameConfiguration.IsNetworkMultiplayer() then
             TogglePause();
         end
     end
+end
+
+-- ===========================================================================
+function CQUI_UpdateSelectedCityCitizens( plotId:number )
+
+	local pSelectedCity	:table = UI.GetHeadSelectedCity();
+	local kPlot			:table = Map.GetPlotByIndex(plotId);
+	local tParameters	:table = {};
+	tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
+	tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
+	tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
+
+	local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
+	return true;
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/CityBannerManager.lua
+++ b/Assets/UI/WorldView/CityBannerManager.lua
@@ -1250,6 +1250,7 @@ function OnCityBannerClick( playerID:number, cityID:number )
     end
     
   end
+  CQUI_UpdateSelectedCityCitizens();
 end
 
 -- ===========================================================================
@@ -3079,6 +3080,21 @@ function OnInterfaceModeChanged( oldMode:number, newMode:number )
   end
 end
 
+-- ===========================================================================
+function CQUI_UpdateSelectedCityCitizens( plotId:number )
+
+	local pSelectedCity	:table = UI.GetHeadSelectedCity();
+	local kPlot			:table = Map.GetPlotByIndex(plotId);
+	local tParameters	:table = {};
+	tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
+	tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
+	tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
+
+	local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
+	return true;
+end
+
+-- ===========================================================================
 function Initialize() 
 
   RegisterDirtyEvents();

--- a/Assets/UI/WorldView/PlotInfo.lua
+++ b/Assets/UI/WorldView/PlotInfo.lua
@@ -63,6 +63,8 @@ function OnClickSwapTile( plotId:number )
   tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
+  -- CQUI_UpdateSelectedCityCitizens
+  OnClickCitizen();
   return true;
 end
 
@@ -94,7 +96,8 @@ function OnClickPurchasePlot( plotId:number )
   --     after a plot puchase (e.g., buying plot for district placement)
   --     you must wait for the event raised from the gamecore before figuring
   --     out which plots need a display.
-
+  -- CQUI_UpdateSelectedCityCitizens
+  OnClickCitizen();
   return true;
 end
 


### PR DESCRIPTION
#247 temporary solved.
I've opened onother PR as soon as I can't complete #252 myself.
Now we can always see updated values on Cityview panels.

But there are still some things that would be good to be changed:
Values don't update still at the same turn on Report Screen and Citybanner when a player makes a tile improvement or pillages it and for the second city after swap tiles.