### PR TITLE
Option to enable/disable individual smartbanner elements

### DIFF
--- a/Assets/CQUI_Settings.sql
+++ b/Assets/CQUI_Settings.sql
@@ -32,6 +32,8 @@ INSERT INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_Smartbanner", 1), -- Additional informations such as districts will show in the city banner
 	  ("CQUI_Smartbanner_UnlockedCitizen", 1), -- Shows if city have Unmanaged citizens in the banner
 	  ("CQUI_Smartbanner_Districts", 1), -- Shows city districts in the banner
+	  ("CQUI_Smartbanner_Population", 1), -- Shows turns to city population growth in the banner
+	  ("CQUI_Smartbanner_Cultural", 1), -- Shows turns to city cultural growth in the banner
       ("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_TechPopupAudio", 1), -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_ToggleYieldsOnLoad", 1); -- Toggles yields immediately on load

--- a/Assets/CQUI_Settings.sql
+++ b/Assets/CQUI_Settings.sql
@@ -30,10 +30,10 @@ INSERT INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_ShowUnitPaths", 1), -- Shows unit paths on hover and selection
       ("CQUI_ShowYieldsOnCityHover", 1), -- Shows city management info like citizens, tile yields, and tile growth on hover
       ("CQUI_Smartbanner", 1), -- Additional informations such as districts will show in the city banner
-	  ("CQUI_Smartbanner_UnlockedCitizen", 1), -- Shows if city have Unmanaged citizens in the banner
-	  ("CQUI_Smartbanner_Districts", 1), -- Shows city districts in the banner
-	  ("CQUI_Smartbanner_Population", 1), -- Shows turns to city population growth in the banner
-	  ("CQUI_Smartbanner_Cultural", 1), -- Shows turns to city cultural growth in the banner
+      ("CQUI_Smartbanner_UnlockedCitizen", 1), -- Shows if city have Unmanaged citizens in the banner
+      ("CQUI_Smartbanner_Districts", 1), -- Shows city districts in the banner
+      ("CQUI_Smartbanner_Population", 1), -- Shows turns to city population growth in the banner
+      ("CQUI_Smartbanner_Cultural", 1), -- Shows turns to city cultural growth in the banner
       ("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_TechPopupAudio", 1), -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_ToggleYieldsOnLoad", 1); -- Toggles yields immediately on load

--- a/Assets/CQUI_Settings.sql
+++ b/Assets/CQUI_Settings.sql
@@ -15,7 +15,7 @@
     │                                    Checkbox settings                                       │
     ├────────────────────────────────────────────────────────────────────────────────────────────┤
     │These settings control the default state of the CQUI configuration checkboxes.              │
-    │Valid values are 0 (disabled) or 1 (unabled). Don't change the names or the first line!     │
+    │Valid values are 0 (disabled) or 1 (enabled). Don't change the names or the first line!     │
     └────────────────────────────────────────────────────────────────────────────────────────────┘
 */
 
@@ -30,6 +30,8 @@ INSERT INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_ShowUnitPaths", 1), -- Shows unit paths on hover and selection
       ("CQUI_ShowYieldsOnCityHover", 1), -- Shows city management info like citizens, tile yields, and tile growth on hover
       ("CQUI_Smartbanner", 1), -- Additional informations such as districts will show in the city banner
+	  ("CQUI_Smartbanner_UnlockedCitizen", 1), -- Shows if city have Unmanaged citizens in the banner
+	  ("CQUI_Smartbanner_Districts", 1), -- Shows city districts in the banner
       ("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_TechPopupAudio", 1), -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_ToggleYieldsOnLoad", 1); -- Toggles yields immediately on load

--- a/Assets/CQUI_SettingsElement.lua
+++ b/Assets/CQUI_SettingsElement.lua
@@ -241,6 +241,8 @@ function Initialize()
   PopulateCheckBox(Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH_TOOLTIP"));
   RegisterControl(Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", UpdateCheckbox);
   PopulateCheckBox(Controls.SmartbannerCheckbox, "CQUI_Smartbanner", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP"));
+  PopulateCheckBox(Controls.SmartbannerUnlockedCitizenCheckbox, "CQUI_Smartbanner_UnlockedCitizen", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP"));
+  PopulateCheckBox(Controls.SmartbannerDistrictsCheckbox, "CQUI_Smartbanner_Districts", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS_TOOLTIP"));
   PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
   PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
   PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
@@ -262,8 +264,14 @@ function Initialize()
 
   --Bind CQUI events
   LuaEvents.CQUI_ToggleSettings.Add(function() ContextPtr:SetHide(not ContextPtr:IsHidden()); end);
+  LuaEvents.CQUI_SettingsUpdate.Add(ToggleSmartbannerCheckboxes);
 
   LuaEvents.CQUI_SettingsInitialized(); --Tell other elements that the settings have been initialized and it's safe to try accessing settings now
+end
+
+function ToggleSmartbannerCheckboxes()
+    local selected = Controls.SmartbannerCheckbox:IsSelected();
+    Controls.SmartbannerCheckboxes:SetHide(not selected);
 end
 
 Initialize();

--- a/Assets/CQUI_SettingsElement.lua
+++ b/Assets/CQUI_SettingsElement.lua
@@ -243,6 +243,8 @@ function Initialize()
   PopulateCheckBox(Controls.SmartbannerCheckbox, "CQUI_Smartbanner", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP"));
   PopulateCheckBox(Controls.SmartbannerUnlockedCitizenCheckbox, "CQUI_Smartbanner_UnlockedCitizen", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP"));
   PopulateCheckBox(Controls.SmartbannerDistrictsCheckbox, "CQUI_Smartbanner_Districts", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS_TOOLTIP"));
+  PopulateCheckBox(Controls.SmartbannerPopulationCheckbox, "CQUI_Smartbanner_Population", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION_TOOLTIP"));
+  PopulateCheckBox(Controls.SmartbannerCulturalCheckbox, "CQUI_Smartbanner_Cultural", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL_TOOLTIP"));
   PopulateCheckBox(Controls.ToggleYieldsOnLoadCheckbox, "CQUI_ToggleYieldsOnLoad");
   PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
   PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));

--- a/Assets/CQUI_SettingsElement.xml
+++ b/Assets/CQUI_SettingsElement.xml
@@ -82,6 +82,12 @@
             <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
               <GridButton ID="SmartbannerDistrictsCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS" />
             </Stack>
+            <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+              <GridButton ID="SmartbannerPopulationCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION" />
+            </Stack>
+            <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+              <GridButton ID="SmartbannerCulturalCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL" />
+            </Stack>
           </Stack>
         </Stack>
       </Container>

--- a/Assets/CQUI_SettingsElement.xml
+++ b/Assets/CQUI_SettingsElement.xml
@@ -77,16 +77,16 @@
           <Stack ID="SmartbannerCheckboxes" Anchor="R,T" StackGrowth="Down">
             <Line Start="0,0" End="300,0" Width="2" Color="84,77,66,255" />
             <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-              <GridButton ID="SmartbannerUnlockedCitizenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN" />
+              <GridButton ID="SmartbannerUnlockedCitizenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_HUD_CITY_UNASSIGNED_CITIZENS" />
             </Stack>
             <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-              <GridButton ID="SmartbannerDistrictsCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS" />
+              <GridButton ID="SmartbannerDistrictsCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_PEDIA_DISTRICTS_TITLE" />
             </Stack>
             <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-              <GridButton ID="SmartbannerPopulationCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION" />
+              <GridButton ID="SmartbannerPopulationCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CIVINFO_POPULATION" />
             </Stack>
             <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
-              <GridButton ID="SmartbannerCulturalCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL" />
+              <GridButton ID="SmartbannerCulturalCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_PEDIA_CITYSTATES_PAGEGROUP_CULTURAL_NAME" />
             </Stack>
           </Stack>
         </Stack>

--- a/Assets/CQUI_SettingsElement.xml
+++ b/Assets/CQUI_SettingsElement.xml
@@ -55,12 +55,12 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ProductionQueueCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_PRODUCTIONQUEUE" />
           </Stack>
-          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
-            <Container Anchor="R,C" Size="300,32" Padding="5">
-              <Slider Style="SliderControl" Anchor="R,C" Size="220,13" Offset="5,0" SpaceForScroll="0" ID="ProductionItemHeightSlider" Steps="104" />
-              <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="ProductionItemHeightText" Offset="3,0" />
-            </Container>
+          <Stack Anchor="C,T" StackGrowth="Left" Padding="5">
+            <Label String="0" Style="ShellOptionText" Anchor="L,C" ID="ProductionItemHeightText" Offset="3,0" />
             <Label Anchor="L,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_ITEMHEIGHT"/>
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <Slider Style="SliderControl" Anchor="R,C" Size="300,13" Offset="5,0" SpaceForScroll="0" ID="ProductionItemHeightSlider" Steps="104" />
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ShowCultureGrowthCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH" />
@@ -68,8 +68,20 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ShowYieldsOnCityHoverCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER" />
           </Stack>
+          <Stack Anchor="C,C" StackGrowth="Left">
+            <Label Anchor="C,C" Style="ShellOptionText" String="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Offset="0,10"/>
+          </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="SmartbannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER" />
+          </Stack>
+          <Stack ID="SmartbannerCheckboxes" Anchor="R,T" StackGrowth="Down">
+            <Line Start="0,0" End="300,0" Width="2" Color="84,77,66,255" />
+            <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+              <GridButton ID="SmartbannerUnlockedCitizenCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN" />
+            </Stack>
+            <Stack Anchor="R,T" StackGrowth="Left" Offset="0,5">
+              <GridButton ID="SmartbannerDistrictsCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS" />
+            </Stack>
           </Stack>
         </Stack>
       </Container>

--- a/Assets/Text/CQUI_Text_Settings.xml
+++ b/Assets/Text/CQUI_Text_Settings.xml
@@ -40,11 +40,26 @@
     <Row Tag="LOC_CQUI_CITYVIEW_SHOWYIELDSONCITYHOVER_TOOLTIP" Language="en_US">
       <Text>Shows citizen managament icons, tile yields, and border growth on hover</Text>
     </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER" Language="en_US">
+      <Text>Smartbanners</Text>
+    </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER" Language="en_US">
       <Text>Enable Smartbanners</Text>
     </Row>
     <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP" Language="en_US">
-      <Text>Displays new icons in the city banner. A [ICON_EXCLAMATION] is displayed whenever there are unlocked citizens being automatically assigned by the AI city governor. District icons indicate built districts</Text>
+      <Text>Displays new icons and information in the city banner.</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP" Language="en_US">
+      <Text>A [ICON_EXCLAMATION] is displayed whenever there are unlocked citizens being automatically assigned by the AI city governor.</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS_TOOLTIP" Language="en_US">
+      <Text>District icons indicate built districts</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION_TOOLTIP" Language="en_US">
+      <Text>Show the number of turns left to population growth[NEWLINE]and the [current population/max housing].</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL_TOOLTIP" Language="en_US">
+      <Text>Show the number of turns left to cultural growth.</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL" Language="en_US">
       <Text>General</Text>

--- a/Assets/UI/WorldView/CityBannerManager.lua
+++ b/Assets/UI/WorldView/CityBannerManager.lua
@@ -981,26 +981,33 @@ function CityBanner.UpdateStats( self : CityBanner)
         turnsUntilGrowth = -pCityGrowth:GetTurnsUntilStarvation();  -- Make negative
       end 
       --- POPULATION AND GROWTH INFO ---
-      local popTooltip :string = Locale.Lookup("LOC_CITY_BANNER_POPULATION") .. ": " .. currentPopulation;
-      if turnsUntilGrowth > 0 then
-        popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_GROWTH", turnsUntilGrowth);
-        popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_FOOD_SURPLUS", round(foodSurplus,1));        
-        self.m_Instance.CityPopTurnsLeft:SetColorByName("StatGoodCS");
-      elseif turnsUntilGrowth < 0 then
-        popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_STARVATION", -turnsUntilGrowth);
-        self.m_Instance.CityPopTurnsLeft:SetColorByName("StatBadCS");
-      else
-        self.m_Instance.CityPopTurnsLeft:SetColorByName("StatNormalCS");
-      end
-      self.m_Instance.CityPopulation:SetText(currentPopulation);
+      if g_smartbanner then
+        self.m_Instance.CityPopTurnsLeft:SetHide(false);
+        self.m_Instance.CityCultureTurnsLeft:SetHide(false);
+        local popTooltip :string = Locale.Lookup("LOC_CITY_BANNER_POPULATION") .. ": " .. currentPopulation;
+        if turnsUntilGrowth > 0 then
+          popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_GROWTH", turnsUntilGrowth);
+          popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_FOOD_SURPLUS", round(foodSurplus,1));        
+          self.m_Instance.CityPopTurnsLeft:SetColorByName("StatGoodCS");
+        elseif turnsUntilGrowth < 0 then
+          popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_STARVATION", -turnsUntilGrowth);
+          self.m_Instance.CityPopTurnsLeft:SetColorByName("StatBadCS");
+        else
+          self.m_Instance.CityPopTurnsLeft:SetColorByName("StatNormalCS");
+        end
+        self.m_Instance.CityPopulation:SetText(currentPopulation);
 
-      if (self.m_Player == Players[localPlayerID]) then     --Only show growth data if the player is you
-        self.m_Instance.CityPopulation:SetToolTipString(popTooltip);
-        local turnsUntilBorderGrowth = pCityCulture:GetTurnsUntilExpansion();
-        local housing = pCityGrowth:GetHousing();
-        local CTLS = turnsUntilGrowth.."  ["..currentPopulation.."/"..housing..
-          "]  "..turnsUntilBorderGrowth;
-        self.m_Instance.CityPopTurnsLeft:SetText(CTLS);
+        if (self.m_Player == Players[localPlayerID]) then     --Only show growth data if the player is you
+          self.m_Instance.CityPopulation:SetToolTipString(popTooltip);
+          local turnsUntilBorderGrowth = pCityCulture:GetTurnsUntilExpansion();
+          local housing = pCityGrowth:GetHousing();
+          local CTLS = turnsUntilGrowth.."  ["..currentPopulation.."/"..housing.."]  ";
+          self.m_Instance.CityCultureTurnsLeft:SetText(turnsUntilBorderGrowth);
+          self.m_Instance.CityPopTurnsLeft:SetText(CTLS);
+        end
+      else
+        self.m_Instance.CityPopTurnsLeft:SetHide(true);
+        self.m_Instance.CityCultureTurnsLeft:SetHide(true);
       end
 
       local food             :number = pCityGrowth:GetFood();

--- a/Assets/UI/WorldView/CityBannerManager.lua
+++ b/Assets/UI/WorldView/CityBannerManager.lua
@@ -165,6 +165,8 @@ local g_smartbanner = true;
 function CQUI_OnSettingsUpdate()
   CQUI_ShowYieldsOnCityHover = GameConfiguration.GetValue("CQUI_ShowYieldsOnCityHover");
   g_smartbanner = GameConfiguration.GetValue("CQUI_Smartbanner")
+  g_smartbanner_unmanaged_citizen = GameConfiguration.GetValue("CQUI_Smartbanner_UnlockedCitizen")
+  g_smartbanner_districts = GameConfiguration.GetValue("CQUI_Smartbanner_Districts")
   Reload();
 end
 LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
@@ -1420,51 +1422,54 @@ function CityBanner.UpdateName( self : CityBanner )
       local pCityDistricts:table  = pCity:GetDistricts();
       if g_smartbanner and self.m_Instance.CityBuiltDistrictAquaduct ~= nil then
         --Unlocked citizen check
-        local tParameters :table = {};
-        tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
+        if g_smartbanner_unmanaged_citizen then
+          local tParameters :table = {};
+          tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
 
-        local tResults  :table = CityManager.GetCommandTargets( pCity, CityCommandTypes.MANAGE, tParameters );
-        if tResults ~= nil then
-          local tPlots    :table = tResults[CityCommandResults.PLOTS];
-          local tUnits    :table = tResults[CityCommandResults.CITIZENS];
-          local tMaxUnits   :table = tResults[CityCommandResults.MAX_CITIZENS];
-          local tLockedUnits  :table = tResults[CityCommandResults.LOCKED_CITIZENS];
-          if tPlots ~= nil and (table.count(tPlots) > 0) then
-            for i,plotId in pairs(tPlots) do      
-              local kPlot :table = Map.GetPlotByIndex(plotId);
-              if(tMaxUnits[i] >= 1 and tUnits[i] >= 1 and tLockedUnits[i] <= 0) then
-                self.m_Instance.CityUnlockedCitizen:SetHide(false);
-              end
-            end    
+          local tResults  :table = CityManager.GetCommandTargets( pCity, CityCommandTypes.MANAGE, tParameters );
+          if tResults ~= nil then
+            local tPlots    :table = tResults[CityCommandResults.PLOTS];
+            local tUnits    :table = tResults[CityCommandResults.CITIZENS];
+            local tMaxUnits   :table = tResults[CityCommandResults.MAX_CITIZENS];
+            local tLockedUnits  :table = tResults[CityCommandResults.LOCKED_CITIZENS];
+            if tPlots ~= nil and (table.count(tPlots) > 0) then
+              for i,plotId in pairs(tPlots) do      
+                local kPlot :table = Map.GetPlotByIndex(plotId);
+                if(tMaxUnits[i] >= 1 and tUnits[i] >= 1 and tLockedUnits[i] <= 0) then
+                  self.m_Instance.CityUnlockedCitizen:SetHide(false);
+                end
+              end    
+            end
           end
         end
         -- End Unlocked Citizen Check
         
-        for i, district in pCityDistricts:Members() do
-          local districtType = district:GetType();
-          local districtInfo:table = GameInfo.Districts[districtType];
-          local isBuilt = pCityDistricts:HasDistrict(districtInfo.Index, true);
-          if isBuilt then
-            if (districtType == iAquaduct) then self.m_Instance.CityBuiltDistrictAquaduct:SetHide(false); end
-            if (districtType == iBath) then self.m_Instance.CityBuiltDistrictBath:SetHide(false); end
-            if (districtType == iNeighborhood) then self.m_Instance.CityBuiltDistrictNeighborhood:SetHide(false); end
-            if (districtType == iMbanza) then self.m_Instance.CityBuiltDistrictMbanza:SetHide(false); end
-            if (districtType == iCampus) then self.m_Instance.CityBuiltDistrictCampus:SetHide(false); end
-            if (districtType == iCommerce) then self.m_Instance.CityBuiltDistrictCommercial:SetHide(false); end
-            if (districtType == iEncampment) then self.m_Instance.CityBuiltDistrictEncampment:SetHide(false); end
-            if (districtType == iTheater) then self.m_Instance.CityBuiltDistrictTheatre:SetHide(false); end
-            if (districtType == iAcropolis) then self.m_Instance.CityBuiltDistrictAcropolis:SetHide(false); end
-            if (districtType == iIndustrial) then self.m_Instance.CityBuiltDistrictIndustrial:SetHide(false); end
-            if (districtType == iHansa) then self.m_Instance.CityBuiltDistrictHansa:SetHide(false); end
-            if (districtType == iHarbor) then self.m_Instance.CityBuiltDistrictHarbor:SetHide(false); end
-            if (districtType == iRoyalNavy) then self.m_Instance.CityBuiltDistrictRoyalNavy:SetHide(false); end
-            if (districtType == iSpaceport) then self.m_Instance.CityBuiltDistrictSpaceport:SetHide(false); end
-            if (districtType == iEntertainmentComplex) then self.m_Instance.CityBuiltDistrictEntertainment:SetHide(false); end
-            if (districtType == iHolySite) then self.m_Instance.CityBuiltDistrictHoly:SetHide(false); end
-            if (districtType == iAerodrome) then self.m_Instance.CityBuiltDistrictAerodrome:SetHide(false); end
-            if (districtType == iStreetCarnival) then self.m_Instance.CityBuiltDistrictStreetCarnival:SetHide(false); end
-            if (districtType == iLavra) then self.m_Instance.CityBuiltDistrictLavra:SetHide(false); end
-            
+        if g_smartbanner_districts then
+          for i, district in pCityDistricts:Members() do
+            local districtType = district:GetType();
+            local districtInfo:table = GameInfo.Districts[districtType];
+            local isBuilt = pCityDistricts:HasDistrict(districtInfo.Index, true);
+            if isBuilt then
+              if (districtType == iAquaduct) then self.m_Instance.CityBuiltDistrictAquaduct:SetHide(false); end
+              if (districtType == iBath) then self.m_Instance.CityBuiltDistrictBath:SetHide(false); end
+              if (districtType == iNeighborhood) then self.m_Instance.CityBuiltDistrictNeighborhood:SetHide(false); end
+              if (districtType == iMbanza) then self.m_Instance.CityBuiltDistrictMbanza:SetHide(false); end
+              if (districtType == iCampus) then self.m_Instance.CityBuiltDistrictCampus:SetHide(false); end
+              if (districtType == iCommerce) then self.m_Instance.CityBuiltDistrictCommercial:SetHide(false); end
+              if (districtType == iEncampment) then self.m_Instance.CityBuiltDistrictEncampment:SetHide(false); end
+              if (districtType == iTheater) then self.m_Instance.CityBuiltDistrictTheatre:SetHide(false); end
+              if (districtType == iAcropolis) then self.m_Instance.CityBuiltDistrictAcropolis:SetHide(false); end
+              if (districtType == iIndustrial) then self.m_Instance.CityBuiltDistrictIndustrial:SetHide(false); end
+              if (districtType == iHansa) then self.m_Instance.CityBuiltDistrictHansa:SetHide(false); end
+              if (districtType == iHarbor) then self.m_Instance.CityBuiltDistrictHarbor:SetHide(false); end
+              if (districtType == iRoyalNavy) then self.m_Instance.CityBuiltDistrictRoyalNavy:SetHide(false); end
+              if (districtType == iSpaceport) then self.m_Instance.CityBuiltDistrictSpaceport:SetHide(false); end
+              if (districtType == iEntertainmentComplex) then self.m_Instance.CityBuiltDistrictEntertainment:SetHide(false); end
+              if (districtType == iHolySite) then self.m_Instance.CityBuiltDistrictHoly:SetHide(false); end
+              if (districtType == iAerodrome) then self.m_Instance.CityBuiltDistrictAerodrome:SetHide(false); end
+              if (districtType == iStreetCarnival) then self.m_Instance.CityBuiltDistrictStreetCarnival:SetHide(false); end
+              if (districtType == iLavra) then self.m_Instance.CityBuiltDistrictLavra:SetHide(false); end
+            end
           end
         end
       end

--- a/Assets/UI/WorldView/CityBannerManager.lua
+++ b/Assets/UI/WorldView/CityBannerManager.lua
@@ -167,6 +167,8 @@ function CQUI_OnSettingsUpdate()
   g_smartbanner = GameConfiguration.GetValue("CQUI_Smartbanner")
   g_smartbanner_unmanaged_citizen = GameConfiguration.GetValue("CQUI_Smartbanner_UnlockedCitizen")
   g_smartbanner_districts = GameConfiguration.GetValue("CQUI_Smartbanner_Districts")
+  g_smartbanner_population = GameConfiguration.GetValue("CQUI_Smartbanner_Population")
+  g_smartbanner_cultural = GameConfiguration.GetValue("CQUI_Smartbanner_Cultural")
   Reload();
 end
 LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
@@ -981,9 +983,8 @@ function CityBanner.UpdateStats( self : CityBanner)
         turnsUntilGrowth = -pCityGrowth:GetTurnsUntilStarvation();  -- Make negative
       end 
       --- POPULATION AND GROWTH INFO ---
-      if g_smartbanner then
-        self.m_Instance.CityPopTurnsLeft:SetHide(false);
-        self.m_Instance.CityCultureTurnsLeft:SetHide(false);
+      self.m_Instance.CityPopulation:SetText(currentPopulation);
+      if (self.m_Player == Players[localPlayerID]) then --Only show growth data if the player is you
         local popTooltip :string = Locale.Lookup("LOC_CITY_BANNER_POPULATION") .. ": " .. currentPopulation;
         if turnsUntilGrowth > 0 then
           popTooltip = popTooltip .. "[NEWLINE]  " .. Locale.Lookup("LOC_CITY_BANNER_TURNS_GROWTH", turnsUntilGrowth);
@@ -995,19 +996,29 @@ function CityBanner.UpdateStats( self : CityBanner)
         else
           self.m_Instance.CityPopTurnsLeft:SetColorByName("StatNormalCS");
         end
-        self.m_Instance.CityPopulation:SetText(currentPopulation);
 
-        if (self.m_Player == Players[localPlayerID]) then     --Only show growth data if the player is you
-          self.m_Instance.CityPopulation:SetToolTipString(popTooltip);
-          local turnsUntilBorderGrowth = pCityCulture:GetTurnsUntilExpansion();
-          local housing = pCityGrowth:GetHousing();
-          local CTLS = turnsUntilGrowth.."  ["..currentPopulation.."/"..housing.."]  ";
-          self.m_Instance.CityCultureTurnsLeft:SetText(turnsUntilBorderGrowth);
-          self.m_Instance.CityPopTurnsLeft:SetText(CTLS);
+        if g_smartbanner then
+          if g_smartbanner_cultural then
+            local turnsUntilBorderGrowth = pCityCulture:GetTurnsUntilExpansion();
+            self.m_Instance.CityCultureTurnsLeft:SetText(turnsUntilBorderGrowth);
+            self.m_Instance.CityCultureTurnsLeft:SetHide(false);
+          else
+            self.m_Instance.CityCultureTurnsLeft:SetHide(true);
+          end
+
+          if g_smartbanner_population then
+            self.m_Instance.CityPopulation:SetToolTipString(popTooltip);
+            local housing = pCityGrowth:GetHousing();
+            local CTLS = turnsUntilGrowth.."  ["..currentPopulation.."/"..housing.."]  ";
+            self.m_Instance.CityPopTurnsLeft:SetText(CTLS);
+            self.m_Instance.CityPopTurnsLeft:SetHide(false);
+          else
+            self.m_Instance.CityPopTurnsLeft:SetHide(true);
+          end
+        else
+          self.m_Instance.CityPopTurnsLeft:SetHide(true);
+          self.m_Instance.CityCultureTurnsLeft:SetHide(true);
         end
-      else
-        self.m_Instance.CityPopTurnsLeft:SetHide(true);
-        self.m_Instance.CityCultureTurnsLeft:SetHide(true);
       end
 
       local food             :number = pCityGrowth:GetFood();

--- a/Assets/UI/WorldView/CityBannerManager.xml
+++ b/Assets/UI/WorldView/CityBannerManager.xml
@@ -198,6 +198,7 @@
           <Container                                    Anchor="L,C" Size="34,34">
             <Label          ID="CityPopulation"         Anchor="C,C" String="999" Style="FontFlair28" FontStyle="glow" />
             <Label          ID="CityPopTurnsLeft"       AnchorSide="O,I" Offset="3,-2" Style="StrongSmall2" KerningAdjustment="-1" Hidden="1"/>
+            <Label          ID="CityCultureTurnsLeft"       AnchorSide="O,I" Offset="3,-2" Style="StrongSmall2" KerningAdjustment="-1" Hidden="1"/>
           </Container>
             
           <Container        ID="CityNameContainer"            Anchor ="L,C" Size="50,34">

--- a/Assets/UI/WorldView/CityBannerManager.xml
+++ b/Assets/UI/WorldView/CityBannerManager.xml
@@ -59,7 +59,10 @@
         <Stack              ID="ContentStack"               Anchor="C,T" StackGrowth="Right" Padding="5" >
           <Container                                        Anchor="L,C" Size="34,34">
             <Label          ID="CityPopulation"             Anchor="C,C" String="999"   Style="FontFlair28" FontStyle="glow" KerningAdjustment="-3" />
-            <Label          ID="CityPopTurnsLeft"           Anchor="L,T" Offset="3,-6"  Style="StrongSmall2"/>
+            <Stack StackGrowth="Right">
+              <Label ID="CityPopTurnsLeft" Anchor="L,T" Offset="3,-6" Style="StrongSmall2" />
+              <Label ID="CityCultureTurnsLeft" Anchor="L,T" Offset="3,-6" Style="StrongSmall2" Color="204,109,197,255" />
+            </Stack>
           </Container>
 
           <Container        ID="CityNameContainer"          Anchor="L,C"  Size="50,34">


### PR DESCRIPTION
Added individual settings for the information in the smartbanner. See #134 

Options added for:
* Unmanaged citizen icon
* District icons
* Turns to population growth
* Turns to cultural growth

Did some small layout changes to the CityView settings page.
Changed the color for the culture growth number.

Not sure how you usually handle LOCs but did my best to keep new ones to a minimum.
New LOCs:
* LOC_CQUI_CITYVIEW_SMARTBANNER_HEADER
* LOC_CQUI_CITYVIEW_SMARTBANNER_UNLOCKEDCITIZEN_TOOLTIP
* LOC_CQUI_CITYVIEW_SMARTBANNER_DISTRICTS_TOOLTIP
* LOC_CQUI_CITYVIEW_SMARTBANNER_POPULATION_TOOLTIP
* LOC_CQUI_CITYVIEW_SMARTBANNER_CULTURAL_TOOLTIP