### PR TITLE
Re-add tooltip to CQUI settings button in minimap panel

### DIFF
--- a/Integrations/ML/UI/minimappanel.xml
+++ b/Integrations/ML/UI/minimappanel.xml
@@ -54,7 +54,7 @@
             <CheckBox ID="MapOptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40"  ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_HUD_MAP_OPTIONS" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
               <Image Texture="Minimap_MapOptions" Size="22,22" Anchor="C,C"/>
             </CheckBox>
-            <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40"  ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
+            <CheckBox ID="CQUI_OptionsButton" UseSelectedTextures="1" Anchor="L,C" ButtonSize="40,40"  ButtonTexture="LaunchBar_Hook_ButtonSmall" Style="ButtonNormalText" ToolTip="LOC_CQUI_NAME" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0">
               <Image Texture="Stats30" Icon="ICON_RESOURCE_TOBACCO" Size="35,35" Anchor="C,C"/>
             </CheckBox>
             <Image                       Anchor="L,C" Size="7,7"    Texture="LaunchBar_TrackPip" Color="255,255,255,200" Offset="0,-2"/>


### PR DESCRIPTION
Resolves #347 

![civilizationvi_2017-02-27_18-58-56](https://cloud.githubusercontent.com/assets/803180/23371264/353a2b28-fd20-11e6-9169-0edb49ebbf69.png)

The tooltip uses the already existing localization key `LOC_CQUI_NAME`, which is just "CQUI" in all locales.
