### PR TITLE
Reduce tab-button size, Fix #366

### DIFF
--- a/Integrations/URS/reportscreen.lua
+++ b/Integrations/URS/reportscreen.lua
@@ -2074,7 +2074,7 @@ function Initialize()
 	AddTabSection( "LOC_HUD_REPORTS_TAB_CURRENT_DEALS", ViewDealsPage );
 	AddTabSection( "LOC_UNIT_NAME",						ViewUnitsPage );
 
-	m_tabs.SameSizedTabs(50);
+	m_tabs.SameSizedTabs(0);
 	m_tabs.CenterAlignTabs(-10);
 
 	-- UI Callbacks


### PR DESCRIPTION
For some resolutions the buttons doesn't fit in the report-screen.
See Issue #366.

Reduce button size...
>2077: m_tabs.SameSizedTabs(0);

Padding here is duplicate to line 
> 2005: kTab.Button:SetSizeToText( 40, 20 );