### PR TITLE
Add worldtracker.lua to modinfo file

### DIFF
--- a/cqui.modinfo
+++ b/cqui.modinfo
@@ -121,6 +121,7 @@
     <File>Assets/UI/unitflagmanager.xml</File>
     <File>Assets/UI/worldinput.lua</File>
     <File>Assets/UI/worldviewiconsmanager.lua</File>
+	<File>Assets/UI/worldtracker.lua</File>
     <File>Assets/UI/Choosers/civicschooser.lua</File>
     <File>Assets/UI/Choosers/researchchooser.lua</File>
     <File>Assets/UI/Civilopedia/civilopediasupport.lua</File>
@@ -198,6 +199,7 @@
         <File>Assets/UI/unitflagmanager.xml</File>
         <File>Assets/UI/worldinput.lua</File>
         <File>Assets/UI/worldviewiconsmanager.lua</File>
+		<File>Assets/UI/worldtracker.lua</File>
         <File>Assets/UI/Choosers/civicschooser.lua</File>
         <File>Assets/UI/Choosers/researchchooser.lua</File>
         <File>Assets/UI/Civilopedia/civilopediasupport.lua</File>

--- a/cqui.modinfo
+++ b/cqui.modinfo
@@ -121,7 +121,7 @@
     <File>Assets/UI/unitflagmanager.xml</File>
     <File>Assets/UI/worldinput.lua</File>
     <File>Assets/UI/worldviewiconsmanager.lua</File>
-	<File>Assets/UI/worldtracker.lua</File>
+	  <File>Assets/UI/worldtracker.lua</File>
     <File>Assets/UI/Choosers/civicschooser.lua</File>
     <File>Assets/UI/Choosers/researchchooser.lua</File>
     <File>Assets/UI/Civilopedia/civilopediasupport.lua</File>
@@ -199,7 +199,7 @@
         <File>Assets/UI/unitflagmanager.xml</File>
         <File>Assets/UI/worldinput.lua</File>
         <File>Assets/UI/worldviewiconsmanager.lua</File>
-		<File>Assets/UI/worldtracker.lua</File>
+		    <File>Assets/UI/worldtracker.lua</File>
         <File>Assets/UI/Choosers/civicschooser.lua</File>
         <File>Assets/UI/Choosers/researchchooser.lua</File>
         <File>Assets/UI/Civilopedia/civilopediasupport.lua</File>


### PR DESCRIPTION
Missing file info in modinfo file for the new modified worldtracker.lua that fixed the checkbox bug.